### PR TITLE
WIP: Update the xcode_spm_setup tool to add the Crashlytics run script

### DIFF
--- a/skills/firebase-crashlytics/references/ios_setup.md
+++ b/skills/firebase-crashlytics/references/ios_setup.md
@@ -36,7 +36,7 @@ Add a Run Script phase to the main app target in Xcode. This step is required to
     ${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run
     ```
 
-When using the `xcode-project-setup` skills, the above two steps will be done as part of adding the `FirebaseCrashlytics` package. Once the skill has been invoked and succeeded, verify that the app's project.pbxproj file contains a Run Script Build phase where the shell script attribute value contains 'Crashlytics'. Specifically, there should be a `PBXShellScriptBuildPhase` section with the attribute `shellScript` that is set to a value that contains `Crashlytics/run` and an attribute `inputPaths` that where one of the values contains `GoogleService-Info.plist`. If verification is not successful, present the above two options to be done manually.
+When using the `xcode-project-setup` skills, the above two steps will be done as part of adding the `FirebaseCrashlytics` package. Once the skill has been invoked and succeeded, verify that the app's project.pbxproj file contains a Run Script Build phase where the shell script attribute value contains 'Crashlytics'. Specifically, there should be a `PBXShellScriptBuildPhase` section with the attribute `shellScript` that is set to a value that contains `Crashlytics/run` and an attribute `inputPaths` where one of the values contains `GoogleService-Info.plist`. If verification is not successful, present the above two options to be done manually.
 
 ## Follow up Steps
 

--- a/skills/firebase-crashlytics/references/ios_setup.md
+++ b/skills/firebase-crashlytics/references/ios_setup.md
@@ -36,6 +36,8 @@ Add a Run Script phase to the main app target in Xcode. This step is required to
     ${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run
     ```
 
+When using the `xcode-project-setup` skills, the above two steps will be done as part of adding the `FirebaseCrashlytics` package. Once the skill has been invoked and succeeded, verify that the app's project.pbxproj file contains a Run Script Build phase where the shell script attribute value contains 'Crashlytics'. Specifically, there should be a `PBXShellScriptBuildPhase` section with the attribute `shellScript` that is set to a value that contains `Crashlytics/run` and an attribute `inputPaths` that where one of the values contains `GoogleService-Info.plist`. If verification is not successful, present the above two options to be done manually.
+
 ## Follow up Steps
 
 The following optional steps are recommended, but don't necessarily apply to all projects.

--- a/skills/xcode-project-setup/scripts/xcode_spm_setup/Sources/main.swift
+++ b/skills/xcode-project-setup/scripts/xcode_spm_setup/Sources/main.swift
@@ -9,14 +9,13 @@ func isUserScriptSandboxingEnabled(project: PBXProj) -> Bool {
     }
 
     for configuration in target.buildConfigurationList?.buildConfigurations ?? [] {
-        if let userSandbox = configuration.buildSettings["ENABLE_USER_SCRIPT_SANDBOXING"] {
-            if let userSandboxValue = userSandbox as? String {
-                return userSandboxValue.uppercased() == "YES"
-            }
+        if let userSandbox = configuration.buildSettings["ENABLE_USER_SCRIPT_SANDBOXING"] as? String {
+            return userSandbox.uppercased() == "YES"
         }
     }
 
-    return false;
+    // If the value is absent, assume it is the default "YES"
+    return true
 }
 
 func hasCrashlyticsRunScriptBuildPhase(project: PBXProj) -> Bool {
@@ -37,7 +36,7 @@ func hasCrashlyticsRunScriptBuildPhase(project: PBXProj) -> Bool {
 
 func addCrashlyticsRunScriptBuildPhase(project: PBXProj) {
     guard let nativeTarget = project.nativeTargets.first else {
-        print("Error: couldn't add the Crashlytics Run Script Build phase automatically, plase add it manually")
+        print("Error: couldn't add the Crashlytics Run Script Build phase automatically, please add it manually")
         return
     }
 
@@ -73,9 +72,8 @@ func setDwarfWithDsymDebugInformationFormat(project: PBXProj) {
     }
 
     for configuration in target.buildConfigurationList?.buildConfigurations ?? [] {
-        if (configuration.name == "Debug") {
-            configuration.buildSettings["DEBUG_INFORMATION_FORMAT"] = "dwarf-with-dsym"
-        }
+        // Set debug format for all configs
+        configuration.buildSettings["DEBUG_INFORMATION_FORMAT"] = "dwarf-with-dsym"
     }
 }
 

--- a/skills/xcode-project-setup/scripts/xcode_spm_setup/Sources/main.swift
+++ b/skills/xcode-project-setup/scripts/xcode_spm_setup/Sources/main.swift
@@ -58,7 +58,7 @@ func addCrashlyticsRunScriptBuildPhase(project: PBXProj) {
         outputPaths: [],
         shellPath: "/bin/sh",
         shellScript: "\"${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\"\n",
-        runOnlyForDeploymentPostprocessing: false,
+        runOnlyForDeploymentPostprocessing: false
     )
 
     project.add(object: phase)

--- a/skills/xcode-project-setup/scripts/xcode_spm_setup/Sources/main.swift
+++ b/skills/xcode-project-setup/scripts/xcode_spm_setup/Sources/main.swift
@@ -2,6 +2,83 @@ import Foundation
 import XcodeProj
 import PathKit
 
+func isUserScriptSandboxingEnabled(project: PBXProj) -> Bool {
+    guard let target = project.projects.first else {
+        print("Error: No project targets found")
+        return false
+    }
+
+    for configuration in target.buildConfigurationList?.buildConfigurations ?? [] {
+        if let userSandbox = configuration.buildSettings["ENABLE_USER_SCRIPT_SANDBOXING"] {
+            if let userSandboxValue = userSandbox as? String {
+                return userSandboxValue.uppercased() == "YES"
+            }
+        }
+    }
+
+    return false;
+}
+
+func hasCrashlyticsRunScriptBuildPhase(project: PBXProj) -> Bool {
+    guard let nativeTargets = project.nativeTargets.first else {
+        return false
+    }
+
+    for phase in nativeTargets.buildPhases {
+        if phase.buildPhase == BuildPhase.runScript, let scriptPhase = phase as? PBXShellScriptBuildPhase {
+            if let script = scriptPhase.shellScript, script.contains("Crashlytics") {
+                return true
+            }
+        }
+    }
+
+    return false
+}
+
+func addCrashlyticsRunScriptBuildPhase(project: PBXProj) {
+    guard let nativeTarget = project.nativeTargets.first else {
+        print("Error: couldn't add the Crashlytics Run Script Build phase automatically, plase add it manually")
+        return
+    }
+
+    var inputPaths = [
+        "${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}",
+        "${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${PRODUCT_NAME}",
+        "${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Info.plist",
+        "$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/GoogleService-Info.plist",
+        "$(TARGET_BUILD_DIR)/$(EXECUTABLE_PATH)"
+    ]
+
+    if isUserScriptSandboxingEnabled(project: project) {
+        inputPaths.append("${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${PRODUCT_NAME}.debug.dylib")
+    }
+
+    let phase = PBXShellScriptBuildPhase(
+        files: [],
+        inputPaths: inputPaths,
+        outputPaths: [],
+        shellPath: "/bin/sh",
+        shellScript: "\"${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\"\n",
+        runOnlyForDeploymentPostprocessing: false,
+    )
+
+    project.add(object: phase)
+    nativeTarget.buildPhases.append(phase)
+}
+
+func setDwarfWithDsymDebugInformationFormat(project: PBXProj) {
+    guard let target = project.projects.first else {
+        print("Error: No project targets found")
+        return
+    }
+
+    for configuration in target.buildConfigurationList?.buildConfigurations ?? [] {
+        if (configuration.name == "Debug") {
+            configuration.buildSettings["DEBUG_INFORMATION_FORMAT"] = "dwarf-with-dsym"
+        }
+    }
+}
+
 func main() {
     let args = CommandLine.arguments
     guard args.count >= 5 else {
@@ -21,7 +98,7 @@ func main() {
         arguments.remove(at: plistIndex + 1)
         arguments.remove(at: plistIndex)
     }
-    
+
     let products = arguments
 
     guard !products.isEmpty else {
@@ -129,6 +206,18 @@ func main() {
                     configuration.buildSettings["OTHER_LDFLAGS"] = otherLdFlags
                     print("Updated OTHER_LDFLAGS for configuration: \(configuration.name)")
                 }
+            }
+        }
+
+        if products.contains(where: { $0.contains("FirebaseCrashlytics")}) {
+            print("Setting the debug format to DWARF with dSYMs")
+            setDwarfWithDsymDebugInformationFormat(project: pbxproj)
+
+            print("Adding the Crashlytics Run Script Build phase")
+            if !hasCrashlyticsRunScriptBuildPhase(project: pbxproj) {
+                addCrashlyticsRunScriptBuildPhase(project: pbxproj)
+            } else {
+                print("Crashlytics Run Script Build phase already exists")
             }
         }
         


### PR DESCRIPTION
When adding FirebaseCrashlytics as a product, automatically add the run script build phase and modify the necessary build settings. This automates Crashlytics onboarding fully.