### PR TITLE
Fix skill name mismatches in metadata

### DIFF
--- a/skills/firebase-ai-logic-basics/SKILL.md
+++ b/skills/firebase-ai-logic-basics/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: firebase-ai-logic
+name: firebase-ai-logic-basics
 description: Official skill for integrating Firebase AI Logic (Gemini API) into web applications. Covers setup, multimodal inference, structured output, and security.
 version: 1.0.0
 ---

--- a/skills/firebase-security-rules-auditor/SKILL.md
+++ b/skills/firebase-security-rules-auditor/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: firestore-security-rules-auditor
+name: firebase-security-rules-auditor
 description: A skill to evaluate how secure Firestore security rules are. Use this when Firestore security rules are updated to ensure that the generated rules are extremely secure and robust.
 ---
 


### PR DESCRIPTION
This PR fixes the skill name mismatches in metadata for `firebase-security-rules-auditor` and `firebase-ai-logic-basics` to match their folder names.

I went with firebase-security-rules-auditor over firestore-security-rules-auditor so that we can extend this skill in the future if we want without a full rename

TAG=agy
CONV=e2895221-778b-4959-b3b9-a264dd7a9405