### PR TITLE
docs: prioritize programmatic config retrieval in skills

### DIFF
--- a/skills/firebase-basics/SKILL.md
+++ b/skills/firebase-basics/SKILL.md
@@ -57,8 +57,8 @@ Adhere to these principles:
    - **Cursor**: Follow [references/refresh/other-agents.md](references/refresh/other-agents.md)
    - **Others**: Follow [references/refresh/other-agents.md](references/refresh/other-agents.md)
 6. **Automate Config File Retrieval:** When setting up iOS or Android apps, do NOT direct users to the Firebase Console to download `google-services.json` or `GoogleService-Info.plist`. Instead, use the Firebase CLI to fetch the config programmatically:
-   - For Android: `npx -y firebase-tools@latest apps:sdkconfig ANDROID <App-ID>`
-   - For iOS: `npx -y firebase-tools@latest apps:sdkconfig IOS <App-ID>`
+   - For Android: `npx -y firebase-tools@latest apps:sdkconfig ANDROID <APP_ID> --project <PROJECT_ID>`
+   - For iOS: `npx -y firebase-tools@latest apps:sdkconfig IOS <APP_ID> --project <PROJECT_ID>`
    Save the output to the appropriate location (e.g., `app/google-services.json` for Android, or a path to be linked by `xcode-project-setup` for iOS).
 
 # References

--- a/skills/firebase-basics/SKILL.md
+++ b/skills/firebase-basics/SKILL.md
@@ -4,8 +4,8 @@ description: >-
   Provides foundational setup, authentication, and project management workflows
   for Firebase using the Firebase CLI. Use when checking Firebase CLI version
   (must use 'npx -y firebase-tools@latest --version'), initializing a Firebase
-  environment, authenticating, setting active projects, or executing core
-  Firebase CLI commands.
+  environment, authenticating, setting active projects, or setting up google-services.json
+  or GoogleService-Info.plist files.
 ---
 # Prerequisites
 
@@ -56,6 +56,10 @@ Adhere to these principles:
    - **Claude Code**: Follow [references/refresh/claude.md](references/refresh/claude.md)
    - **Cursor**: Follow [references/refresh/other-agents.md](references/refresh/other-agents.md)
    - **Others**: Follow [references/refresh/other-agents.md](references/refresh/other-agents.md)
+6. **Automate Config File Retrieval:** When setting up iOS or Android apps, do NOT direct users to the Firebase Console to download `google-services.json` or `GoogleService-Info.plist`. Instead, use the Firebase CLI to fetch the config programmatically:
+   - For Android: `npx -y firebase-tools@latest apps:sdkconfig ANDROID <App-ID>`
+   - For iOS: `npx -y firebase-tools@latest apps:sdkconfig IOS <App-ID>`
+   Save the output to the appropriate location (e.g., `app/google-services.json` for Android, or a path to be linked by `xcode-project-setup` for iOS).
 
 # References
 
@@ -64,6 +68,7 @@ Adhere to these principles:
 - **SDK Setup:** For detailed guides on adding Firebase to your app:
   - **Web**: See [references/web_setup.md](references/web_setup.md)
   - **Android**: See [references/android_setup.md](references/android_setup.md)
+  - **iOS**: See [references/ios_setup.md](references/ios_setup.md)
 
 # Common Issues
 

--- a/skills/firebase-basics/SKILL.md
+++ b/skills/firebase-basics/SKILL.md
@@ -4,8 +4,8 @@ description: >-
   Provides foundational setup, authentication, and project management workflows
   for Firebase using the Firebase CLI. Use when checking Firebase CLI version
   (must use 'npx -y firebase-tools@latest --version'), initializing a Firebase
-  environment, authenticating, setting active projects, or setting up google-services.json
-  or GoogleService-Info.plist files.
+  environment, authenticating, setting active projects, or setting up `google-services.json`
+  or `GoogleService-Info.plist` files.
 ---
 # Prerequisites
 

--- a/skills/firebase-basics/references/android_setup.md
+++ b/skills/firebase-basics/references/android_setup.md
@@ -3,7 +3,7 @@
 ---
 ## 📋 Prerequisites
 Before running these commands, ensure you are authenticated:
-` firebase login` (or `firebase login --no-localhost` on remote servers)
+`npx -y firebase-tools@latest login` (or `npx -y firebase-tools@latest login --no-localhost` on remote servers)
 ---
 
 ## 0. Create an Android application
@@ -11,24 +11,24 @@ if you haven't already created an android application, create one.
 
 ## 1. Create a Firebase Project
 If you haven't already created a project, create a new cloud project with a unique ID:
-` firebase projects:create <UNIQUE_PROJECT_ID> --display-name '<DISPLAY_NAME>'`
+`npx -y firebase-tools@latest projects:create <UNIQUE_PROJECT_ID> --display-name '<DISPLAY_NAME>'`
 *Example:*
-` firebase projects:create my-cool-app-20260330 --display-name 'MyCoolApp'`
+`npx -y firebase-tools@latest projects:create my-cool-app-20260330 --display-name 'MyCoolApp'`
 ### 2. Register Your Android App
 Link your Android app module (package name) to your project. Notice that the display name is passed as a positional argument at the end:
-` firebase apps:create ANDROID '<APP_DISPLAY_NAME>' --package-name '<PACKAGE_NAME>' --project <PROJECT_ID>`
+`npx -y firebase-tools@latest apps:create ANDROID '<APP_DISPLAY_NAME>' --package-name '<PACKAGE_NAME>' --project <PROJECT_ID>`
 *Example:*
-` firebase apps:create ANDROID 'MyApplication' --package-name 'com.example.myapplication' --project my-cool-app-20260330`
+`npx -y firebase-tools@latest apps:create ANDROID 'MyApplication' --package-name 'com.example.myapplication' --project my-cool-app-20260330`
 ### 3. Download `google-services.json`
 Fetch the configuration file using the App ID (which is printed in the output of the previous command):
-` firebase apps:sdkconfig ANDROID <APP_ID> --project <PROJECT_ID>`
+`npx -y firebase-tools@latest apps:sdkconfig ANDROID <APP_ID> --project <PROJECT_ID>`
 *Example output extraction to file:*
 ` # (Output must be saved as app/google-services.json)`
 ---
 ## ✅ Verification Plan
 ### Manual Verification
 Validate that the project was created and registered successfully:
-` firebase projects:list`
-` firebase apps:list --project <PROJECT_ID>`
+`npx -y firebase-tools@latest projects:list`
+`npx -y firebase-tools@latest apps:list --project <PROJECT_ID>`
 
 ---


### PR DESCRIPTION
This PR updates the skills to ensure agents use the Firebase CLI to fetch configuration files programmatically instead of directing users to the console.