### PR TITLE
Removing hard-coded version numbers

### DIFF
--- a/skills/firebase-crashlytics/SKILL.md
+++ b/skills/firebase-crashlytics/SKILL.md
@@ -30,5 +30,5 @@ The SDK provides a number of features to make crash reports more actionable.
 
 To learn how to customize crash reports and add additional debugging data, consult the documentation for your platform.
 
-*   **Android**: [Customize Crash Reports for Android](https://firebase.google.com/docs/crashlytics/android/customize-crash-reports)
-*   **iOS**: [Customize Crash Reports for Apple Platforms](https://firebase.google.com/docs/crashlytics/ios/customize-crash-reports)
+*   **Android**: [Customize Crash Reports for Android](https://firebase.google.com/docs/crashlytics/android/customize-crash-reports.md)
+*   **iOS**: [Customize Crash Reports for Apple Platforms](https://firebase.google.com/docs/crashlytics/ios/customize-crash-reports.md)

--- a/skills/firebase-crashlytics/references/android_setup.md
+++ b/skills/firebase-crashlytics/references/android_setup.md
@@ -20,7 +20,7 @@ These changes are made to your Android project's Gradle files.
 
 ### Project-level `build.gradle.kts` (`<project>/build.gradle.kts`)
 
-Add the latest version of the Crashlytics Gradle plugin to the `plugins` block. Fetch the latest version from https://firebase.google.com/docs/crashlytics/android/get-started#add-plugin before adding this. 
+Add the latest version of the Crashlytics Gradle plugin to the `plugins` block. Fetch the [latest version from the Google Maven repository](https://maven.google.com/web/index.html?q=firebase-crashlytics-gradle#com.google.firebase:firebase-crashlytics-gradle) before adding this. 
 
 ```kotlin
 plugins {
@@ -40,7 +40,7 @@ plugins {
     }
     ```
 
-2.  Add the Firebase Crashlytics dependency to the `dependencies` block. It is recommended to use the Firebase Bill of Materials (BoM) to manage SDK versions. Fetch the latest available BoM version from https://firebase.google.com/support/release-notes/android before adding this.
+2.  Add the Firebase Crashlytics dependency to the `dependencies` block. It is recommended to use the Firebase Bill of Materials (BoM) to manage SDK versions. Fetch the [latest version from the Google Maven repository](https://maven.google.com/web/index.html?q=firebase-bom#com.google.firebase:firebase-bom) before adding this.
 
     ```kotlin
     dependencies {
@@ -118,5 +118,5 @@ To verify that Crashlytics is correctly installed, you need to force a test cras
 
 ### Optional: Add custom debugging information
 
-Customize reports to help you better understand what's happening in your app and the circumstances around events reported to Crashlytics. See [Customize Crash Reports for Android](https://firebase.google.com/docs/crashlytics/android/customize-crash-reports).
+Customize reports to help you better understand what's happening in your app and the circumstances around events reported to Crashlytics. See [Customize Crash Reports for Android](https://firebase.google.com/docs/crashlytics/android/customize-crash-reports.md).
 

--- a/skills/firebase-crashlytics/references/android_setup.md
+++ b/skills/firebase-crashlytics/references/android_setup.md
@@ -20,12 +20,12 @@ These changes are made to your Android project's Gradle files.
 
 ### Project-level `build.gradle.kts` (`<project>/build.gradle.kts`)
 
-Add the Crashlytics plugin to the `plugins` block:
+Add the latest version of the Crashlytics Gradle plugin to the `plugins` block. Fetch the latest version from https://firebase.google.com/docs/crashlytics/android/get-started#add-plugin before adding this. 
 
 ```kotlin
 plugins {
     // ... other plugins
-    id("com.google.firebase.crashlytics") version "2.9.9" apply false
+    id("com.google.firebase.crashlytics") version "<latest_plugin_version>" apply false
 }
 ```
 
@@ -40,14 +40,14 @@ plugins {
     }
     ```
 
-2.  Add the Firebase Crashlytics dependency to the `dependencies` block. It is recommended to use the Firebase Bill of Materials (BoM) to manage SDK versions.
+2.  Add the Firebase Crashlytics dependency to the `dependencies` block. It is recommended to use the Firebase Bill of Materials (BoM) to manage SDK versions. Fetch the latest available BoM version from https://firebase.google.com/support/release-notes/android before adding this.
 
     ```kotlin
     dependencies {
         // ... other dependencies
 
         // Import the Firebase BoM
-        implementation(platform("com.google.firebase:firebase-bom:32.7.0"))
+        implementation(platform("com.google.firebase:firebase-bom:<latest_bom_version>"))
 
         // Add the dependencies for the Crashlytics and Analytics
         implementation("com.google.firebase:firebase-crashlytics-ktx")

--- a/skills/firebase-crashlytics/references/ios_setup.md
+++ b/skills/firebase-crashlytics/references/ios_setup.md
@@ -78,4 +78,4 @@ When using the `xcode-project-setup` skills, the above two steps will be done as
 
 ### Optional: Add custom debugging information
 
-Customize reports to help you better understand what's happening in your app and the circumstances around events reported to Crashlytics. See [Customize Crash Reports for Apple Platforms](https://firebase.google.com/docs/crashlytics/ios/customize-crash-reports).
+Customize reports to help you better understand what's happening in your app and the circumstances around events reported to Crashlytics. See [Customize Crash Reports for Apple Platforms](https://firebase.google.com/docs/crashlytics/ios/customize-crash-reports.md).


### PR DESCRIPTION
Updating android skills to check devsite for the latest versions before installing Crashlytics SDK and Gradle plugin