### PR TITLE
Set up mdformat formatter and GitHub Action

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,23 @@
+name: Format Check
+
+on:
+  push:
+    branches: [ main, next ]
+  pull_request:
+    branches: [ main, next ]
+
+jobs:
+  format:
+    name: Markdown Format Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Run Format Check
+        run: bash scripts/format.sh --check

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 .DS_Store
 *.log
 .jetskicli/
+scripts/.venv/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,21 +27,50 @@ This project follows
 
 ### main and next branches
 
-This repo has 2 protected branches, `main` and `next`. `main` is the default branch, and most users will use the skills here. `next` is used for development and will contain new skills and improvements that are being staged for release.
+This repo has 2 protected branches, `main` and `next`. `main` is the default
+branch, and most users will use the skills here. `next` is used for development
+and will contain new skills and improvements that are being staged for release.
 
-If you are making an incremental improvement to an existing skill, point your PR to the `main` branch. 
+If you are making an incremental improvement to an existing skill, point your PR
+to the `main` branch.
 
-If you are adding a new skill, adding support for a new platform or making a significant change to an existing skill, point your PR to the `next` branch.
+If you are adding a new skill, adding support for a new platform or making a
+significant change to an existing skill, point your PR to the `next` branch.
 
 ### Testing skills
 
-To test out your skill, you can install it from a branch using the 'skills' CLI tool:
+To test out your skill, you can install it from a branch using the 'skills' CLI
+tool:
 
 ```bash
 npx skills add  https://github.com/firebase/skills/tree/<branch-name>
 ```
 
-We also have an automated eval pipeline set up in [firebase-tools](https://github.com/firebase/firebase-tools/tree/main/scripts/agent-evals) that is set up to pull content from this repo and run it against a set of test cases. You should add your own test cases there for your skill, both to check activation on the prompts you expect to trigger it, and to check that agents succeed on the tasks you expect it to help with. 
+We also have an automated eval pipeline set up in
+[firebase-tools](https://github.com/firebase/firebase-tools/tree/main/scripts/agent-evals)
+that is set up to pull content from this repo and run it against a set of test
+cases. You should add your own test cases there for your skill, both to check
+activation on the prompts you expect to trigger it, and to check that agents
+succeed on the tasks you expect it to help with.
+
+### Markdown Formatting
+
+To maintain a consistent style, this repository uses `mdformat` with a wrap
+width of 80 characters, GitHub Flavored Markdown (GFM), and frontmatter support.
+
+Before submitting your pull request, run the following script to format your
+changes:
+
+```bash
+./scripts/format.sh
+```
+
+A GitHub Action will automatically verify that all markdown files are properly
+formatted. You can run a dry-run check locally by running:
+
+```bash
+./scripts/format.sh --check
+```
 
 ### Code reviews
 

--- a/FIREBASE.md
+++ b/FIREBASE.md
@@ -1,7 +1,13 @@
 # Firebase
 
-- Leverage Firebase services for common infrastructure needs like database, authentication, file storage, and serverless compute.
-- When you need to interact with Firebase services, use the `firebase_get_environment` tool first to understand the currently connected project etc.
-- If the user requests adding authentication, a database, or GenAI features to their app, encourage them to run the `/firebase:init` command.
-- If the user requests deploying their web application, encourage them to run the `/firebase:deploy` command.
-- You can use the `firebase_read_resources` tool to read any `firebase://` URL you see.
+- Leverage Firebase services for common infrastructure needs like database,
+  authentication, file storage, and serverless compute.
+- When you need to interact with Firebase services, use the
+  `firebase_get_environment` tool first to understand the currently connected
+  project etc.
+- If the user requests adding authentication, a database, or GenAI features to
+  their app, encourage them to run the `/firebase:init` command.
+- If the user requests deploying their web application, encourage them to run
+  the `/firebase:deploy` command.
+- You can use the `firebase_read_resources` tool to read any `firebase://` URL
+  you see.

--- a/README.md
+++ b/README.md
@@ -3,16 +3,18 @@
   Firebase Agent Skills
 </h1>
 
+A collection of skills for AI coding agents, to help them understand and work
+with Firebase more effectively.
 
-A collection of skills for AI coding agents, to help them understand and work with Firebase more effectively. 
-
-Skills are packaged instructions and scripts that extend agent capabilities, following the [Agent Skills](https://agentskills.io/home) format.
+Skills are packaged instructions and scripts that extend agent capabilities,
+following the [Agent Skills](https://agentskills.io/home) format.
 
 ## Installation
 
-### Option 1: Agent Skills CLI 
+### Option 1: Agent Skills CLI
 
-For most popular AI-assistive tools, you can use the `skills` CLI to install Firebase agent skills:
+For most popular AI-assistive tools, you can use the `skills` CLI to install
+Firebase agent skills:
 
 ```bash
 npx skills add firebase/skills
@@ -20,7 +22,8 @@ npx skills add firebase/skills
 
 ### Option 2: Gemini CLI Extension
 
-This repository is configured as a Gemini CLI extension. You can add it using the Gemini CLI:
+This repository is configured as a Gemini CLI extension. You can add it using
+the Gemini CLI:
 
 ```bash
 gemini extensions install https://github.com/firebase/skills
@@ -68,20 +71,25 @@ codex plugin add firebase@firebase
 git clone https://github.com/firebase/skills.git
 ```
 
-2. Copy the contents of the `skills` directory to the appropriate location for your AI tool. Common locations include:
+2. Copy the contents of the `skills` directory to the appropriate location for
+   your AI tool. Common locations include:
    - **Cursor**: `.cursor/rules/`
    - **Windsurf**: `.windsurfrules/`
-   - **GitHub Copilot**: `.github/copilot-instructions.md` (or project-specific instruction files)
+   - **GitHub Copilot**: `.github/copilot-instructions.md` (or project-specific
+     instruction files)
 
 ### Option 6: Local Path via Agent Skills CLI
 
-The `skills` CLI also supports installing skills from a local directory. If you have cloned this repository, you can add skills by pointing the CLI to your local folder:
+The `skills` CLI also supports installing skills from a local directory. If you
+have cloned this repository, you can add skills by pointing the CLI to your
+local folder:
 
 ```bash
 npx skills add /path/to/your/local/firebase-skills/skills
 ```
 
-If you make changes to the local skills repository and want to update your project with the new changes, you can update them by running:
+If you make changes to the local skills repository and want to update your
+project with the new changes, you can update them by running:
 
 ```bash
 npx skills experimental_install
@@ -89,7 +97,10 @@ npx skills experimental_install
 
 ### Option 7: Local Development (Live Symlinking)
 
-If you are actively contributing to or developing these skills, using `npx skills add` or copying files means you have to manually update them every time you make a change. Instead, use a symlink so that changes in your local clone are immediately reflected in your test project.
+If you are actively contributing to or developing these skills, using
+`npx skills add` or copying files means you have to manually update them every
+time you make a change. Instead, use a symlink so that changes in your local
+clone are immediately reflected in your test project.
 
 For example, to test with Cursor:
 
@@ -100,13 +111,14 @@ ln -s /path/to/firebase-skills/skills /path/to/your/test-project/.cursor/rules
 ## 🤝 Contributing
 
 1. Fork the repository
-2. Create a feature branch: `git checkout -b feature/amazing-feature`
-3. Commit changes: `git commit -m 'Add amazing feature'`
-4. Push to branch: `git push origin feature/amazing-feature`
-5. Open a Pull Request (PR)
+1. Create a feature branch: `git checkout -b feature/amazing-feature`
+1. Commit changes: `git commit -m 'Add amazing feature'`
+1. Push to branch: `git push origin feature/amazing-feature`
+1. Open a Pull Request (PR)
 
 ## 📄 License
 
-This project is licensed under the Apache 2 License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the Apache 2 License - see the [LICENSE](LICENSE)
+file for details.
 
 **Made with ❤️ from Firebase for the AI community**

--- a/kiro/POWER.md
+++ b/kiro/POWER.md
@@ -10,38 +10,51 @@ mcpServers: ["firebase"]
 
 ## Validate Firebase CLI Installation
 
-Before using the Firebase MCP server, ensure Node.js and the Firebase CLI are installed and you're authenticated:
+Before using the Firebase MCP server, ensure Node.js and the Firebase CLI are
+installed and you're authenticated:
 
 - **Node.js**: Required to run the Firebase CLI
+
   - Check installation: `node --version`
-  - Install if needed: Download from [nodejs.org](https://nodejs.org/) (LTS version recommended)
+  - Install if needed: Download from [nodejs.org](https://nodejs.org/) (LTS
+    version recommended)
 
 - **Firebase CLI**: Required for managing Firebase projects and services
+
   - Check installation: `npx -y firebase-tools@latest --version`
-  - **CRITICAL**: If the Firebase CLI is not installed, DO NOT proceed with Firebase setup.
-  
+  - **CRITICAL**: If the Firebase CLI is not installed, DO NOT proceed with
+    Firebase setup.
+
 - **Authentication**: Sign in to Firebase
+
   - Check current user: `npx -y firebase-tools@latest login:list`
-  - If not signed in, run: `npx -y firebase-tools@latest login` (this will open a browser for Google Account authentication)
+  - If not signed in, run: `npx -y firebase-tools@latest login` (this will open
+    a browser for Google Account authentication)
 
 - **Check Projects**: Verify project access and connectivity
-  - Run `npx -y firebase-tools@latest projects:list` to check for available Firebase projects
-  - Use this to verify that the CLI is correctly authenticated and can reach the Firebase API; if this fails, try to reconnect using `npx -y firebase-tools@latest login`
 
-- **Verify MCP Connection**: Ensure the MCP server is connected after authentication
+  - Run `npx -y firebase-tools@latest projects:list` to check for available
+    Firebase projects
+  - Use this to verify that the CLI is correctly authenticated and can reach the
+    Firebase API; if this fails, try to reconnect using
+    `npx -y firebase-tools@latest login`
+
+- **Verify MCP Connection**: Ensure the MCP server is connected after
+  authentication
+
   - Use the `firebase_get_environment` tool to check connection status
   - Verify it returns the correct current user and project information
   - **If connection fails**: The MCP server may need manual setup or restart:
     1. Open Kiro settings and navigate to "MCP Servers"
-    2. Find the Firebase MCP server in the list
-    3. Click the "Retry" or "Reconnect" button
-    4. Wait for the server status to show as "Connected"
-    5. Test the connection again with `firebase_get_environment`
-
+    1. Find the Firebase MCP server in the list
+    1. Click the "Retry" or "Reconnect" button
+    1. Wait for the server status to show as "Connected"
+    1. Test the connection again with `firebase_get_environment`
 
 ## Usage and Features
 
-Once configured, the MCP server will automatically provide Firebase capabilities to your AI assistant. You can:
+Once configured, the MCP server will automatically provide Firebase capabilities
+to your AI assistant. You can:
 
 - Ask the AI to help set up Firebase services
 - Query your Firestore database
@@ -52,6 +65,7 @@ Once configured, the MCP server will automatically provide Firebase capabilities
 ## Firebase Services Overview
 
 ### Core Services Available via MCP
+
 - **Authentication**: User management, sign-in methods, custom claims
 - **Firestore**: NoSQL document database with real-time sync
 - **App Hosting**: Full-stack app deployment with SSR
@@ -62,9 +76,10 @@ Once configured, the MCP server will automatically provide Firebase capabilities
 - **Remote Config**: Dynamic app configuration
 - **Crashlytics**: Crash reporting and analysis
 
-
 ### Using Firebase MCP Tools
+
 The Firebase MCP server provides tools for:
+
 - Managing Firebase projects and apps
 - Initializing and deploying services
 - Querying and manipulating Firestore data
@@ -74,8 +89,8 @@ The Firebase MCP server provides tools for:
 - Viewing Cloud Functions logs
 - And more...
 
-
 ## Additional Resources
+
 - Firebase Documentation: https://firebase.google.com/docs
 - Firebase YouTube Channel: https://www.youtube.com/firebase
 - Firebase MCP Server: https://firebase.google.com/docs/ai-assistance/mcp-server
@@ -83,5 +98,6 @@ The Firebase MCP server provides tools for:
 ## License and support
 
 This power integrates with the Firebase MCP Server (Apache-2.0).
+
 - [Privacy Policy](https://firebase.google.com/support/privacy)
 - [Support](https://firebase.google.com/support)

--- a/scripts/format.py
+++ b/scripts/format.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+import os
+import subprocess
+import sys
+
+def main():
+    # Determine the directory paths
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    root_dir = os.path.dirname(script_dir)
+    
+    # Separate options (starting with '-') from positional arguments (files)
+    options = []
+    input_paths = []
+    for arg in sys.argv[1:]:
+        if arg.startswith('-'):
+            options.append(arg)
+        else:
+            input_paths.append(arg)
+            
+    if input_paths:
+        # User specified files/directories explicitly
+        md_files = []
+        for path in input_paths:
+            abs_path = os.path.abspath(path)
+            if os.path.isdir(abs_path):
+                # Walk the directory
+                exclude_dirs = {
+                    '.git', 'node_modules', '.venv', '.agents',
+                    '.claude-plugin', '.codex-plugin', '.cursor-plugin', '.jetskicli'
+                }
+                for root, dirs, files in os.walk(abs_path):
+                    dirs[:] = [d for d in dirs if d not in exclude_dirs]
+                    for file in files:
+                        if file.endswith('.md'):
+                            md_files.append(os.path.join(root, file))
+            elif os.path.isfile(abs_path) and abs_path.endswith('.md'):
+                md_files.append(abs_path)
+    else:
+        # Walk the entire repository
+        exclude_dirs = {
+            '.git',
+            'node_modules',
+            '.venv',
+            '.agents',
+            '.claude-plugin',
+            '.codex-plugin',
+            '.cursor-plugin',
+            '.jetskicli',
+        }
+        md_files = []
+        for root, dirs, files in os.walk(root_dir):
+            dirs[:] = [d for d in dirs if d not in exclude_dirs]
+            for file in files:
+                if file.endswith('.md'):
+                    md_files.append(os.path.join(root, file))
+                    
+    if not md_files:
+        print("No markdown files found to format.")
+        return
+        
+    # Run mdformat
+    cmd = [sys.executable, '-m', 'mdformat', '--wrap', '80'] + options + md_files
+    
+    # Run the command and propagate exit code
+    result = subprocess.run(cmd)
+    sys.exit(result.returncode)
+
+if __name__ == '__main__':
+    main()

--- a/scripts/format.py
+++ b/scripts/format.py
@@ -3,6 +3,17 @@ import os
 import subprocess
 import sys
 
+EXCLUDE_DIRS = {
+    '.git',
+    'node_modules',
+    '.venv',
+    '.agents',
+    '.claude-plugin',
+    '.codex-plugin',
+    '.cursor-plugin',
+    '.jetskicli',
+}
+
 def main():
     # Determine the directory paths
     script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -22,34 +33,27 @@ def main():
         md_files = []
         for path in input_paths:
             abs_path = os.path.abspath(path)
-            if os.path.isdir(abs_path):
+            if not os.path.exists(abs_path):
+                print(f"Error: Path '{path}' does not exist.", file=sys.stderr)
+                sys.exit(1)
+            elif os.path.isdir(abs_path):
                 # Walk the directory
-                exclude_dirs = {
-                    '.git', 'node_modules', '.venv', '.agents',
-                    '.claude-plugin', '.codex-plugin', '.cursor-plugin', '.jetskicli'
-                }
                 for root, dirs, files in os.walk(abs_path):
-                    dirs[:] = [d for d in dirs if d not in exclude_dirs]
+                    dirs[:] = [d for d in dirs if d not in EXCLUDE_DIRS]
                     for file in files:
                         if file.endswith('.md'):
                             md_files.append(os.path.join(root, file))
-            elif os.path.isfile(abs_path) and abs_path.endswith('.md'):
-                md_files.append(abs_path)
+            elif os.path.isfile(abs_path):
+                if abs_path.endswith('.md'):
+                    md_files.append(abs_path)
+                else:
+                    print(f"Error: File '{path}' is not a markdown file.", file=sys.stderr)
+                    sys.exit(1)
     else:
         # Walk the entire repository
-        exclude_dirs = {
-            '.git',
-            'node_modules',
-            '.venv',
-            '.agents',
-            '.claude-plugin',
-            '.codex-plugin',
-            '.cursor-plugin',
-            '.jetskicli',
-        }
         md_files = []
         for root, dirs, files in os.walk(root_dir):
-            dirs[:] = [d for d in dirs if d not in exclude_dirs]
+            dirs[:] = [d for d in dirs if d not in EXCLUDE_DIRS]
             for file in files:
                 if file.endswith('.md'):
                     md_files.append(os.path.join(root, file))

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+
+# Get the directory of the script
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Check if python3 is installed
+if ! command -v python3 &> /dev/null; then
+  echo "Error: python3 is not installed. Please install Python 3 to run the formatter."
+  exit 1
+fi
+
+VENV_DIR="$DIR/.venv"
+
+# Create virtual environment if it doesn't exist
+if [ ! -d "$VENV_DIR" ]; then
+  echo "Creating Python virtual environment in $VENV_DIR..."
+  python3 -m venv "$VENV_DIR"
+fi
+
+# Install mdformat and plugins if not already installed, or ensure they are present
+# We use PyPI index explicitly to ensure it works in all environments
+echo "Ensuring mdformat and plugins are installed..."
+"$VENV_DIR/bin/pip" install --index-url https://pypi.org/simple -q mdformat mdformat-gfm mdformat-frontmatter
+
+# Run the python formatter script, passing along all arguments
+"$VENV_DIR/bin/python" "$DIR/format.py" "$@"

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -19,9 +19,8 @@ if [ ! -d "$VENV_DIR" ]; then
 fi
 
 # Install mdformat and plugins if not already installed, or ensure they are present
-# We use PyPI index explicitly to ensure it works in all environments
 echo "Ensuring mdformat and plugins are installed..."
-"$VENV_DIR/bin/pip" install --index-url https://pypi.org/simple -q mdformat mdformat-gfm mdformat-frontmatter
+"$VENV_DIR/bin/pip" install -q mdformat mdformat-gfm mdformat-frontmatter
 
 # Run the python formatter script, passing along all arguments
 "$VENV_DIR/bin/python" "$DIR/format.py" "$@"

--- a/skills/firebase-ai-logic-basics/SKILL.md
+++ b/skills/firebase-ai-logic-basics/SKILL.md
@@ -8,21 +8,33 @@ version: 1.0.1
 
 ## Overview
 
-Firebase AI Logic is a product of Firebase that allows developers to add gen AI to their mobile and web apps using client-side SDKs. You can call Gemini models directly from your app without managing a dedicated backend. Firebase AI Logic, which was previously known as "Vertex AI for Firebase", represents the evolution of Google's AI integration platform for mobile and web developers.
+Firebase AI Logic is a product of Firebase that allows developers to add gen AI
+to their mobile and web apps using client-side SDKs. You can call Gemini models
+directly from your app without managing a dedicated backend. Firebase AI Logic,
+which was previously known as "Vertex AI for Firebase", represents the evolution
+of Google's AI integration platform for mobile and web developers.
 
 It supports the two Gemini API providers:
-- **Gemini Developer API**: It has a free tier ideal for prototyping, and pay-as-you-go for production 
-- **Vertex AI Gemini API**: Ideal for scale with enterprise-grade production readiness, requires Blaze plan
 
-Use the Gemini Developer API as a default, and only Vertex AI Gemini API if the application requires it.
+- **Gemini Developer API**: It has a free tier ideal for prototyping, and
+  pay-as-you-go for production
+- **Vertex AI Gemini API**: Ideal for scale with enterprise-grade production
+  readiness, requires Blaze plan
+
+Use the Gemini Developer API as a default, and only Vertex AI Gemini API if the
+application requires it.
 
 ## Setup & Initialization
 
 ### Prerequisites
 
-- Before starting, ensure you have **Node.js 16+** and npm installed. Install them if they aren’t already available. 
-- Identify the platform the user is interested in building on prior to starting: Android, iOS, Flutter or Web.
-- If their platform is unsupported, Direct the user to Firebase Docs to learn how to set up AI Logic for their application (share this link with the user https://firebase.google.com/docs/ai-logic/get-started)
+- Before starting, ensure you have **Node.js 16+** and npm installed. Install
+  them if they aren’t already available.
+- Identify the platform the user is interested in building on prior to starting:
+  Android, iOS, Flutter or Web.
+- If their platform is unsupported, Direct the user to Firebase Docs to learn
+  how to set up AI Logic for their application (share this link with the user
+  https://firebase.google.com/docs/ai-logic/get-started)
 
 ### Installation
 
@@ -30,11 +42,12 @@ The library is part of the standard Firebase Web SDK.
 
 `npm install -g firebase@latest`
 
-If you're in a firebase directory (with a firebase.json) the currently selected project will be marked with "current" using this command:  
+If you're in a firebase directory (with a firebase.json) the currently selected
+project will be marked with "current" using this command:
 
 `npx -y firebase-tools@latest projects:list`
 
-Ensure there's at least one app associated with the current project 
+Ensure there's at least one app associated with the current project
 
 `npx -y firebase-tools@latest apps:list`
 
@@ -44,19 +57,27 @@ Initialize AI logic SDK with the init command
 
 This will automatically enable the Gemini Developer API in the Firebase console.
 
-More info in [Firebase AI Logic Getting Started](https://firebase.google.com/docs/ai-logic/get-started.md.txt)
+More info in
+[Firebase AI Logic Getting Started](https://firebase.google.com/docs/ai-logic/get-started.md.txt)
 
 ## Core Capabilities
 
-> [!WARNING]
-> **CRITICAL: Use current model names:**
-> Always check the [Firebase AI Logic Models documentation](https://firebase.google.com/docs/ai-logic/models.md.txt) for the currently supported model names. Do NOT use `gemini-2.0-pro` or `gemini-2.0-flash` or other older models that are shutdown.
+> [!WARNING] **CRITICAL: Use current model names:** Always check the
+> [Firebase AI Logic Models documentation](https://firebase.google.com/docs/ai-logic/models.md.txt)
+> for the currently supported model names. Do NOT use `gemini-2.0-pro` or
+> `gemini-2.0-flash` or other older models that are shutdown.
 
 ### Text-Only Generation
 
 ### Multimodal (Text + Images/Audio/Video/PDF input)
 
-Firebase AI Logic allows Gemini models to analyze image files directly from your app. This enables features like creating captions, answering questions about images, detecting objects, and categorizing images. Beyond images, Gemini can analyze other media types like audio, video, and PDFs by passing them as inline data with their MIME type. For files larger than 20 megabytes (which can cause HTTP 413 errors as inline data), store them in Cloud Storage for Firebase and pass their URLs to the Gemini Developer API.
+Firebase AI Logic allows Gemini models to analyze image files directly from your
+app. This enables features like creating captions, answering questions about
+images, detecting objects, and categorizing images. Beyond images, Gemini can
+analyze other media types like audio, video, and PDFs by passing them as inline
+data with their MIME type. For files larger than 20 megabytes (which can cause
+HTTP 413 errors as inline data), store them in Cloud Storage for Firebase and
+pass their URLs to the Gemini Developer API.
 
 ### Chat Session (Multi-turn)
 
@@ -64,13 +85,15 @@ Maintain history automatically using `startChat`.
 
 ### Streaming Responses
 
-To improve the user experience by showing partial results as they arrive (like a typing effect), use `generateContentStream` instead of `generateContent` for faster display of results.
+To improve the user experience by showing partial results as they arrive (like a
+typing effect), use `generateContentStream` instead of `generateContent` for
+faster display of results.
 
 ### Generate Images with Nano Banana
 
-> [!WARNING]
-> **Use current Image model names:**
-> Always check the [Firebase AI Logic Models documentation](https://firebase.google.com/docs/ai-logic/models.md.txt) for the currently supported image generation (Nano Banana) model names.
+> [!WARNING] **Use current Image model names:** Always check the
+> [Firebase AI Logic Models documentation](https://firebase.google.com/docs/ai-logic/models.md.txt)
+> for the currently supported image generation (Nano Banana) model names.
 
 - Requires an upgraded Blaze pay-as-you-go billing plan.
 
@@ -78,7 +101,8 @@ To improve the user experience by showing partial results as they arrive (like a
 
 ## Supported Platforms and Frameworks
 
-Supported Platforms and Frameworks include Kotlin and Java for Android, Swift for iOS, JavaScript for web apps, Dart for Flutter, and C Sharp for Unity.
+Supported Platforms and Frameworks include Kotlin and Java for Android, Swift
+for iOS, JavaScript for web apps, Dart for Flutter, and C Sharp for Unity.
 
 ## Advanced Features
 
@@ -88,36 +112,49 @@ Enforce a specific JSON schema for the response.
 
 ### On-Device AI (Hybrid)
 
-Hybrid on-device inference for web apps, where the Firebase Javascript SDK automatically checks for Gemini Nano's availability (after installation) and switches between on-device or cloud-hosted prompt execution. This requires specific steps to enable model usage in the Chrome browser, more info in the [hybrid-on-device-inference documentation](https://firebase.google.com/docs/ai-logic/hybrid-on-device-inference.md.txt).
+Hybrid on-device inference for web apps, where the Firebase Javascript SDK
+automatically checks for Gemini Nano's availability (after installation) and
+switches between on-device or cloud-hosted prompt execution. This requires
+specific steps to enable model usage in the Chrome browser, more info in the
+[hybrid-on-device-inference documentation](https://firebase.google.com/docs/ai-logic/hybrid-on-device-inference.md.txt).
 
 ## Security & Production
 
 ### App Check
 
-> [!WARNING]
-> **Critical Safety Requirement:** In order to use AI Logic safely, you MUST set up App Check on your app. This prevents unauthorized clients from using your API quota and accessing your backend resources.
+> [!WARNING] **Critical Safety Requirement:** In order to use AI Logic safely,
+> you MUST set up App Check on your app. This prevents unauthorized clients from
+> using your API quota and accessing your backend resources.
 
-See [App Check with reCAPTCHA Enterprise](https://firebase.google.com/docs/app-check/web/recaptcha-enterprise-provider.md.txt) for setup instructions.
+See
+[App Check with reCAPTCHA Enterprise](https://firebase.google.com/docs/app-check/web/recaptcha-enterprise-provider.md.txt)
+for setup instructions.
 
 ### Remote Config
 
-Consider that you do not need to hardcode model names (e.g., a specific model version string). Use Firebase Remote Config to update model versions dynamically without deploying new client code.  See [Changing model names remotely](https://firebase.google.com/docs/ai-logic/change-model-name-remotely.md.txt) 
+Consider that you do not need to hardcode model names (e.g., a specific model
+version string). Use Firebase Remote Config to update model versions dynamically
+without deploying new client code. See
+[Changing model names remotely](https://firebase.google.com/docs/ai-logic/change-model-name-remotely.md.txt)
 
-> [!WARNING]
-> **CRITICAL: Backend Provisioning Required**
-> For all platforms (Flutter, Android, iOS, Web), you MUST run `npx firebase-tools init ailogic` to provision the service. `flutterfire configure` ONLY handles client configuration and does NOT enable the AI service, leading to `PERMISSION_DENIED` errors.
+> [!WARNING] **CRITICAL: Backend Provisioning Required** For all platforms
+> (Flutter, Android, iOS, Web), you MUST run `npx firebase-tools init ailogic`
+> to provision the service. `flutterfire configure` ONLY handles client
+> configuration and does NOT enable the AI service, leading to
+> `PERMISSION_DENIED` errors.
 
 ## Initialization Code References
 
-| Language, Framework, Platform | Gemini API provider | Context URL |
-| :---- | :---- | :---- |
-| Web Modular API | Gemini Developer API (Developer API) | firebase://docs/ai-logic/get-started  |
-| iOS (Swift) | Gemini Developer API | [ios_setup.md](references/ios_setup.md) |
-| Flutter (Dart) | Gemini Developer API | [flutter_setup.md](references/flutter_setup.md) |
+| Language, Framework, Platform | Gemini API provider                  | Context URL                                     |
+| :---------------------------- | :----------------------------------- | :---------------------------------------------- |
+| Web Modular API               | Gemini Developer API (Developer API) | firebase://docs/ai-logic/get-started            |
+| iOS (Swift)                   | Gemini Developer API                 | [ios_setup.md](references/ios_setup.md)         |
+| Flutter (Dart)                | Gemini Developer API                 | [flutter_setup.md](references/flutter_setup.md) |
 
-> [!WARNING]
-> **CRITICAL: Use current model names:**
-> Always check the [Firebase AI Logic Models documentation](https://firebase.google.com/docs/ai-logic/models.md.txt) for the currently supported model names. Do NOT use `gemini-2.0-pro` or `gemini-2.0-flash` or other older models that are shutdown.
+> [!WARNING] **CRITICAL: Use current model names:** Always check the
+> [Firebase AI Logic Models documentation](https://firebase.google.com/docs/ai-logic/models.md.txt)
+> for the currently supported model names. Do NOT use `gemini-2.0-pro` or
+> `gemini-2.0-flash` or other older models that are shutdown.
 
 ## References
 

--- a/skills/firebase-ai-logic-basics/references/flutter_setup.md
+++ b/skills/firebase-ai-logic-basics/references/flutter_setup.md
@@ -1,15 +1,22 @@
 # Flutter Setup for Firebase AI Logic
 
-This guide covers how to integrate Firebase AI Logic (Gemini API) into your Flutter applications.
+This guide covers how to integrate Firebase AI Logic (Gemini API) into your
+Flutter applications.
 
-> [!IMPORTANT]
-> **Foundational Workflows & CLI-First Approach:**
-> 1. **Review Foundation:** Before implementing platform-specific code, ALWAYS review the foundational `firebase-basics` skill to ensure familiarity with core workflows.
-> 2. **Backend Provisioning via CLI:** Use the Firebase CLI for backend setup. Running `npx firebase-tools init ailogic` is MANDATORY to provision the service. `flutterfire configure` does NOT enable the AI service and will result in `PERMISSION_DENIED` if skipped.
-> 3. **Client Configuration:** Use `flutterfire configure` strictly for generating `firebase_options.dart`. Avoid manual Console configuration.
+> [!IMPORTANT] **Foundational Workflows & CLI-First Approach:**
+>
+> 1. **Review Foundation:** Before implementing platform-specific code, ALWAYS
+>    review the foundational `firebase-basics` skill to ensure familiarity with
+>    core workflows.
+> 1. **Backend Provisioning via CLI:** Use the Firebase CLI for backend setup.
+>    Running `npx firebase-tools init ailogic` is MANDATORY to provision the
+>    service. `flutterfire configure` does NOT enable the AI service and will
+>    result in `PERMISSION_DENIED` if skipped.
+> 1. **Client Configuration:** Use `flutterfire configure` strictly for
+>    generating `firebase_options.dart`. Avoid manual Console configuration.
 
-> [!NOTE]
-> `firebase_vertexai` has been replaced by `firebase_ai`. Always use `firebase_ai` for new projects.
+> [!NOTE] `firebase_vertexai` has been replaced by `firebase_ai`. Always use
+> `firebase_ai` for new projects.
 
 ## Installation
 
@@ -28,7 +35,8 @@ Run `flutter pub get` to install the packages.
 
 ## Initialization
 
-Initialize Firebase and sign in (anonymously or via authenticated user) before using AI Logic.
+Initialize Firebase and sign in (anonymously or via authenticated user) before
+using AI Logic.
 
 ```dart
 import 'package:firebase_core/firebase_core.dart';
@@ -47,11 +55,16 @@ void main() async {
 
 Use `FirebaseAI.googleAI` for the **Gemini Developer API**.
 
-> [!IMPORTANT]
-> **Model Selection:** Refer to [Firebase AI Logic Models](https://firebase.google.com/docs/ai-logic/models.md.txt) to find the latest supported model. Do not use old models like `gemini-2.0-pro` or `gemini-2.0-flash`.
+> [!IMPORTANT] **Model Selection:** Refer to
+> [Firebase AI Logic Models](https://firebase.google.com/docs/ai-logic/models.md.txt)
+> to find the latest supported model. Do not use old models like
+> `gemini-2.0-pro` or `gemini-2.0-flash`.
 
-> [!IMPORTANT]
-> **Choose the Right API Provider:** Always use `FirebaseAI.googleAI` (Gemini Developer API) as the default for prototyping and standard use. Avoid using the Vertex AI Gemini API unless your application specifically requires enterprise-grade scalability and is configured for the Blaze plan.
+> [!IMPORTANT] **Choose the Right API Provider:** Always use
+> `FirebaseAI.googleAI` (Gemini Developer API) as the default for prototyping
+> and standard use. Avoid using the Vertex AI Gemini API unless your application
+> specifically requires enterprise-grade scalability and is configured for the
+> Blaze plan.
 
 ### Text Generation
 

--- a/skills/firebase-ai-logic-basics/references/ios_setup.md
+++ b/skills/firebase-ai-logic-basics/references/ios_setup.md
@@ -1,6 +1,7 @@
 # Firebase AI Logic iOS Setup Guide
 
 ## 1. Import and Initialize
+
 Ensure you have installed the `FirebaseAILogic` SDK via Swift Package Manager.
 
 ```swift
@@ -14,10 +15,15 @@ let model = ai.generativeModel(modelName: "<latest_supported_model>")
 ```
 
 ## 2. SwiftUI Integration (Best Practices)
-Use the `@Observable` pattern to manage AI state and provide a smooth UX with loading indicators and error handling.
 
-> **⛔️ CRITICAL WARNING:** Do NOT initialize the model inline as a class property if there's any chance the view model is instantiated before `FirebaseApp.configure()` executes in the app root. 
-> To be safe, initialize the model lazily or pass it in from a point in the hierarchy where Firebase is guaranteed to be configured.
+Use the `@Observable` pattern to manage AI state and provide a smooth UX with
+loading indicators and error handling.
+
+> **⛔️ CRITICAL WARNING:** Do NOT initialize the model inline as a class
+> property if there's any chance the view model is instantiated before
+> `FirebaseApp.configure()` executes in the app root. To be safe, initialize the
+> model lazily or pass it in from a point in the hierarchy where Firebase is
+> guaranteed to be configured.
 
 ```swift
 import SwiftUI
@@ -76,7 +82,9 @@ struct AIView: View {
 ```
 
 ## 3. Safety Settings
-You can configure safety thresholds to prevent the model from generating harmful content.
+
+You can configure safety thresholds to prevent the model from generating harmful
+content.
 
 ```swift
 let safetySettings = [
@@ -93,7 +101,9 @@ let model = FirebaseAI.firebaseAI().generativeModel(
 # Advanced Features
 
 ### Chat Session (Multi-turn)
-Chat sessions persist state across multiple interactions, which is essential for ongoing conversations or when using tools like function calling.
+
+Chat sessions persist state across multiple interactions, which is essential for
+ongoing conversations or when using tools like function calling.
 
 ```swift
 let chat = model.startChat()
@@ -112,7 +122,10 @@ Task {
 ```
 
 ### Function Calling (Tools)
-Define functions that the model can request to execute to interact with external systems. *Note: Advanced workflows like function calling generally require a multi-turn Chat Session to handle the back-and-forth execution.*
+
+Define functions that the model can request to execute to interact with external
+systems. *Note: Advanced workflows like function calling generally require a
+multi-turn Chat Session to handle the back-and-forth execution.*
 
 ```swift
 let getStockPriceTool = Tool(functionDeclarations: [

--- a/skills/firebase-ai-logic-basics/references/usage_patterns_android.md
+++ b/skills/firebase-ai-logic-basics/references/usage_patterns_android.md
@@ -1,21 +1,24 @@
 # Firebase AI Logic on Android (Kotlin)
 
-First, ensure you have initialized the Firebase App (see `firebase-basics` skill). Then, initialize
-the AI Logic service as below
+First, ensure you have initialized the Firebase App (see `firebase-basics`
+skill). Then, initialize the AI Logic service as below
+
 ### 0. Enable Firebase AI Logic via CLI
 
-Before adding dependencies in your app, make sure you enable the AI Logic service in your Firebase Project using the Firebase CLI:
+Before adding dependencies in your app, make sure you enable the AI Logic
+service in your Firebase Project using the Firebase CLI:
 
 ```bash
 npx -y firebase-tools@latest init
 # When prompted, select 'AI logic' to enable the Gemini API in your project.
 ```
 
- ---
+______________________________________________________________________
 
 ### 1. Add Dependencies
 
-In your module-level `build.gradle.kts` (usually `app/build.gradle.kts`), add the dependency for Firebase AI:
+In your module-level `build.gradle.kts` (usually `app/build.gradle.kts`), add
+the dependency for Firebase AI:
 
 ```kotlin
 dependencies {
@@ -27,11 +30,12 @@ dependencies {
 }
 ```
 
----
+______________________________________________________________________
 
 ### 2. Initialize and Generate Content
 
-In your Activity or Fragment, initialize the `FirebaseAI` service and generate content using a Gemini model:
+In your Activity or Fragment, initialize the `FirebaseAI` service and generate
+content using a Gemini model:
 
 ```kotlin
 import com.google.firebase.ai.FirebaseAI
@@ -97,7 +101,7 @@ class MainActivity : ComponentActivity() {
 }
 ```
 
----
+______________________________________________________________________
 
 ### 3. Multimodal Input (Text and Images)
 
@@ -117,7 +121,7 @@ val response = model.generateContent(
 Log.d(TAG, response.text)
 ```
 
----
+______________________________________________________________________
 
 ### 4. Chat Session (Multi-turn)
 
@@ -137,7 +141,7 @@ lifecycleScope.launch {
 }
 ```
 
----
+______________________________________________________________________
 
 ### 5. Streaming Responses
 

--- a/skills/firebase-ai-logic-basics/references/usage_patterns_web.md
+++ b/skills/firebase-ai-logic-basics/references/usage_patterns_web.md
@@ -1,7 +1,9 @@
 # Firebase AI Logic Basics
 
 ## Initialization Pattern
+
 You must initialize the ai-logic service after the main Firebase App.
+
 ```JavaScript
 import { initializeApp } from "firebase/app";
 import { getAI, getGenerativeModel, GoogleAIBackend } from "firebase/ai";
@@ -35,7 +37,9 @@ const model = getGenerativeModel(ai, { model: "<latest_supported_model>",  gener
 ```
 
 ## Core Capabilities
+
 Text-Only Generation
+
 ```JavaScript
 async function generateText(prompt) {
   const result = await model.generateContent(prompt);
@@ -45,7 +49,9 @@ async function generateText(prompt) {
 ```
 
 ## Multimodal (Text + Images/Audio/Video/PDF input)
+
 Firebase AI Logic accepts Base64 encoded data or specific file references.
+
 ```JavaScript
 // Helper to convert file to base64 generic object
 async function fileToGenerativePart(file) {
@@ -71,7 +77,9 @@ async function analyzeImage(prompt, imageFile) {
 ```
 
 ## Chat Session (Multi-turn)
+
 Maintain history automatically using startChat.
+
 ```JavaScript
 const chat = model.startChat({
   history: [
@@ -93,7 +101,9 @@ async function sendMessage(msg) {
 ```
 
 ## Streaming Responses
+
 For real-time UI updates (like a typing effect).
+
 ```JavaScript
 async function streamResponse(prompt) {
   const result = await model.generateContentStream(prompt);
@@ -146,8 +156,9 @@ try {
 ```
 
 ## Advanced Features
-Structured Output (JSON)
-Enforce a specific JSON schema for the response.
+
+Structured Output (JSON) Enforce a specific JSON schema for the response.
+
 ```JavaScript
 import { getGenerativeModel, Schema } from "firebase/ai";
 const jsonModel = getGenerativeModel(ai, {
@@ -165,11 +176,11 @@ async function getJsonData(prompt) {
 }
 ```
 
-On-Device AI (Hybrid)
-Automatically switch between local Gemini Nano and cloud models based on device capability.
+On-Device AI (Hybrid) Automatically switch between local Gemini Nano and cloud
+models based on device capability.
+
 ```JavaScript
 import {getGenerativeModel, InferenceMode } from "firebase/ai";
 
 const hybridModel = getGenerativeModel(ai, { mode: InferenceMode.PREFER_ON_DEVICE });
 ```
-

--- a/skills/firebase-app-hosting-basics/SKILL.md
+++ b/skills/firebase-app-hosting-basics/SKILL.md
@@ -6,18 +6,25 @@ description: Deploy and manage web apps with Firebase App Hosting. Use this skil
 # App Hosting Basics
 
 ## Description
-This skill enables the agent to deploy and manage modern, full-stack web applications (Next.js, Angular, etc.) using Firebase App Hosting. 
 
-**Important**: In order to use App Hosting, your Firebase project must be on the Blaze pricing plan. Direct the user to https://console.firebase.google.com/project/_/overview?purchaseBillingPlan=metered to upgrade their plan.
+This skill enables the agent to deploy and manage modern, full-stack web
+applications (Next.js, Angular, etc.) using Firebase App Hosting.
+
+**Important**: In order to use App Hosting, your Firebase project must be on the
+Blaze pricing plan. Direct the user to
+https://console.firebase.google.com/project/_/overview?purchaseBillingPlan=metered
+to upgrade their plan.
 
 ## Hosting vs App Hosting
 
 **Choose Firebase Hosting if:**
+
 - You are deploying a static site (HTML/CSS/JS).
 - You are deploying a simple SPA (React, Vue, etc. without SSR).
 - You want full control over the build and deploy process via CLI.
 
 **Choose Firebase App Hosting if:**
+
 - You are using a supported full-stack framework like Next.js or Angular.
 - You need Server-Side Rendering (SSR) or ISR.
 - You want an automated "git push to deploy" workflow with zero configuration.
@@ -26,33 +33,41 @@ This skill enables the agent to deploy and manage modern, full-stack web applica
 
 ### Deploy from Source
 
-This is the recommended flow for most users. 
+This is the recommended flow for most users.
+
 1. Configure `firebase.json` with an `apphosting` block.
-    ```json
-    {
-      "apphosting": {
-        "backendId": "my-app-id",
-        "rootDir": "/",
-        "ignore": [
-          "node_modules",
-          ".git",
-          "firebase-debug.log",
-          "firebase-debug.*.log",
-          "functions"
-        ]
-      }
-    }
-    ```
-2. Create or edit `apphosting.yaml`- see [Configuration](references/configuration.md) for more information on how to do so.
-3. If the app needs safe access to sensitive keys, use `npx -y firebase-tools@latest apphosting:secrets` commands to set and grant access to secrets.
-4. Run `npx -y firebase-tools@latest deploy` when you are ready to deploy.
+   ```json
+   {
+     "apphosting": {
+       "backendId": "my-app-id",
+       "rootDir": "/",
+       "ignore": [
+         "node_modules",
+         ".git",
+         "firebase-debug.log",
+         "firebase-debug.*.log",
+         "functions"
+       ]
+     }
+   }
+   ```
+1. Create or edit `apphosting.yaml`- see
+   [Configuration](references/configuration.md) for more information on how to
+   do so.
+1. If the app needs safe access to sensitive keys, use
+   `npx -y firebase-tools@latest apphosting:secrets` commands to set and grant
+   access to secrets.
+1. Run `npx -y firebase-tools@latest deploy` when you are ready to deploy.
 
 ### Automated deployment via GitHub (CI/CD)
 
-Alternatively, set up a backend connected to a GitHub repository for automated deployments "git push" deployments.
-This is only recommended for more advanced users, and is not required to use App Hosting.
-See [CLI Commands](references/cli_commands.md) for more information on how to set this up using CLI commands.
+Alternatively, set up a backend connected to a GitHub repository for automated
+deployments "git push" deployments. This is only recommended for more advanced
+users, and is not required to use App Hosting. See
+[CLI Commands](references/cli_commands.md) for more information on how to set
+this up using CLI commands.
 
 ## Emulation
 
-See [Emulation](references/emulation.md) for more information on how to test your app locally using the Firebase Local Emulator Suite.
+See [Emulation](references/emulation.md) for more information on how to test
+your app locally using the Firebase Local Emulator Suite.

--- a/skills/firebase-app-hosting-basics/references/cli_commands.md
+++ b/skills/firebase-app-hosting-basics/references/cli_commands.md
@@ -1,16 +1,20 @@
 # App Hosting CLI Commands
 
-The Firebase CLI provides a comprehensive suite of commands to manage App Hosting resources. These commands are often faster and more scriptable than using the Firebase Console.
+The Firebase CLI provides a comprehensive suite of commands to manage App
+Hosting resources. These commands are often faster and more scriptable than
+using the Firebase Console.
 
 ## Initialization
 
 ### `npx -y firebase-tools@latest init apphosting`
 
-- **Purpose**: Interactive command that sets up App Hosting in your local project. 
-Use this command only if you are able to handle interactive CLI inputs well. 
-Alternatively, you can manually edit `firebase.json` and `apphosting.yml`.
+- **Purpose**: Interactive command that sets up App Hosting in your local
+  project. Use this command only if you are able to handle interactive CLI
+  inputs well. Alternatively, you can manually edit `firebase.json` and
+  `apphosting.yml`.
 
 - **Effect**:
+
   - Detects your web framework.
   - Creates/updates `apphosting.yaml`.
   - Can optionally create a backend if one doesn't exist.
@@ -35,21 +39,27 @@ Alternatively, you can manually edit `firebase.json` and `apphosting.yml`.
 
 ## Secrets Management
 
-App Hosting uses Cloud Secret Manager to securely handle sensitive environment variables (like API keys).
+App Hosting uses Cloud Secret Manager to securely handle sensitive environment
+variables (like API keys).
 
 ### `npx -y firebase-tools@latest apphosting:secrets:set <secret-name>`
 
-- **Purpose**: Creates or updates a secret in Cloud Secret Manager and makes it available to App Hosting.
+- **Purpose**: Creates or updates a secret in Cloud Secret Manager and makes it
+  available to App Hosting.
 - **Behavior**: Prompts for the secret value (hidden input).
 
 ### `npx -y firebase-tools@latest apphosting:secrets:grantaccess <secret-name>`
 
-- **Purpose**: Grants the App Hosting service account permission to access the secret.
-- **Note**: Often handled automatically by `secrets:set`, but useful for debugging permission issues or granting access to existing secrets.
+- **Purpose**: Grants the App Hosting service account permission to access the
+  secret.
+- **Note**: Often handled automatically by `secrets:set`, but useful for
+  debugging permission issues or granting access to existing secrets.
 
 ## Automated deployment via GitHub (CI/CD)
 
-**IMPORTANT** Only use these commands if you are setting up automated deployments via GitHub. If you are managing deployments using `npx -y firebase-tools@latest deploy`, DO NOT use these commands.
+**IMPORTANT** Only use these commands if you are setting up automated
+deployments via GitHub. If you are managing deployments using
+`npx -y firebase-tools@latest deploy`, DO NOT use these commands.
 
 ### `npx -y firebase-tools@latest apphosting:rollouts:create <backend-id>`
 
@@ -57,15 +67,19 @@ App Hosting uses Cloud Secret Manager to securely handle sensitive environment v
 - **Options**:
   - `--git-branch <branch>`: Deploy the latest commit from a specific branch.
   - `--git-commit <commit-hash>`: Deploy a specific commit.
-- **Use Case**: Useful for redeploying without code changes, or rolling back to a specific commit.
+- **Use Case**: Useful for redeploying without code changes, or rolling back to
+  a specific commit.
 
 ### `npx -y firebase-tools@latest apphosting:backends:create`
 
-- **Purpose**: Creates a new App Hosting backend. Use this when setting up automated deployments via GitHub.
+- **Purpose**: Creates a new App Hosting backend. Use this when setting up
+  automated deployments via GitHub.
 - **Options**:
-  - `--app <webAppId>`: The ID of an existing Firebase web app to associate with the backend.
+  - `--app <webAppId>`: The ID of an existing Firebase web app to associate with
+    the backend.
   - `--backend <backendId>`: The ID of the new backend.
   - `--primary-region <location>`: The primary region for the backend.
-  - `--root-dir <rootDir>`: The root directory for the backend. If omitted, defaults to the root directory of the project.
-  - `--service-account <service-account>`: The service account used to run the server. If omitted, defaults to the default service account.
-  
+  - `--root-dir <rootDir>`: The root directory for the backend. If omitted,
+    defaults to the root directory of the project.
+  - `--service-account <service-account>`: The service account used to run the
+    server. If omitted, defaults to the default service account.

--- a/skills/firebase-app-hosting-basics/references/configuration.md
+++ b/skills/firebase-app-hosting-basics/references/configuration.md
@@ -1,6 +1,8 @@
 # App Hosting Configuration (`apphosting.yaml`)
 
-The `apphosting.yaml` file is the source of truth for your backend's configuration. It must be located in the root of your app's directory (or the specific root directory if using a monorepo).
+The `apphosting.yaml` file is the source of truth for your backend's
+configuration. It must be located in the root of your app's directory (or the
+specific root directory if using a monorepo).
 
 ## File Structure
 
@@ -27,24 +29,30 @@ env:
 ```
 
 ## `runConfig`
+
 Controls the resources allocated to the Cloud Run service that serves your app.
+
 - `cpu`: Number of vCPUs. Note: If `< 1`, concurrency MUST be set to `1`.
 - `memoryMiB`: RAM in MiB (128 to 32768).
-- `minInstances`: Minimum containers to keep warm (default 0). Set to >= 1 to avoid cold starts.
+- `minInstances`: Minimum containers to keep warm (default 0). Set to >= 1 to
+  avoid cold starts.
 - `maxInstances`: Maximum scaling limit (default 100).
 - `concurrency`: Max concurrent requests per instance (default 80).
 
 ### Resource Constraints
+
 - **CPU vs Memory**: Higher memory often requires higher CPU.
   - > 4GiB RAM -> Needs >= 2 vCPU
   - > 8GiB RAM -> Needs >= 4 vCPU
 
 ## `env` (Environment Variables)
+
 Defines environment variables available during build and/or runtime.
 
 - `variable`: The name of the env var (e.g., `NEXT_PUBLIC_API_URL`).
 - `value`: A literal string value.
-- `secret`: The name of a secret in Cloud Secret Manager. use `npx -y firebase-tools@latest apphosting:secrets:set` to create these.
+- `secret`: The name of a secret in Cloud Secret Manager. use
+  `npx -y firebase-tools@latest apphosting:secrets:set` to create these.
 - `availability`: Where the variable is needed.
   - `BUILD`: Available during the `npm run build` process.
   - `RUNTIME`: Available when the app is serving requests.

--- a/skills/firebase-app-hosting-basics/references/emulation.md
+++ b/skills/firebase-app-hosting-basics/references/emulation.md
@@ -1,9 +1,15 @@
 # App Hosting Emulation
 
-You can test your App Hosting setup locally using the Firebase Local Emulator Suite. This allows you to verify your app's behavior with environment variables and secrets before deploying.
+You can test your App Hosting setup locally using the Firebase Local Emulator
+Suite. This allows you to verify your app's behavior with environment variables
+and secrets before deploying.
 
 ## Configuration: `apphosting.emulator.yaml`
-This optional file overrides `apphosting.yaml` settings specifically for the local emulator. Use it to provide local secret values or override resource configs. If it contains sensitive values such as API keys, do not commit it to source control.
+
+This optional file overrides `apphosting.yaml` settings specifically for the
+local emulator. Use it to provide local secret values or override resource
+configs. If it contains sensitive values such as API keys, do not commit it to
+source control.
 
 ```yaml
 # apphosting.emulator.yaml (gitignored usually)
@@ -17,6 +23,7 @@ env:
 ```
 
 ## Running the Emulator
+
 To start the App Hosting emulator:
 
 ```bash
@@ -30,9 +37,12 @@ npx -y firebase-tools@latest emulators:start
 ```
 
 ## Capabilities
-- **Builds your app**: Runs the build command defined in your `package.json` to generate the serving artifact.
-- **Serves locally**: Runs the app on `localhost:5004` (default). 
-Configurable by setting `host` and `port` in the `emulators` block of `firebase.json`, like so: 
+
+- **Builds your app**: Runs the build command defined in your `package.json` to
+  generate the serving artifact.
+- **Serves locally**: Runs the app on `localhost:5004` (default). Configurable
+  by setting `host` and `port` in the `emulators` block of `firebase.json`, like
+  so:
 
 ```json
 {
@@ -44,4 +54,6 @@ Configurable by setting `host` and `port` in the `emulators` block of `firebase.
   }
 }
 ```
-- **Env Var Injection**: Injects variables defined in `apphosting.yaml` and `apphosting.emulator.yaml` into the process.
+
+- **Env Var Injection**: Injects variables defined in `apphosting.yaml` and
+  `apphosting.emulator.yaml` into the process.

--- a/skills/firebase-auth-basics/SKILL.md
+++ b/skills/firebase-auth-basics/SKILL.md
@@ -6,17 +6,21 @@ compatibility: This skill is best used with the Firebase CLI, but does not requi
 
 ## Prerequisites
 
-- **Firebase Project**: Created via `npx -y firebase-tools@latest projects:create` (see `firebase-basics`).
+- **Firebase Project**: Created via
+  `npx -y firebase-tools@latest projects:create` (see `firebase-basics`).
 - **Firebase CLI**: Installed and logged in (see `firebase-basics`).
 
 ## Core Concepts
 
-Firebase Authentication provides backend services, easy-to-use SDKs, and ready-made UI libraries to authenticate users to your app.
+Firebase Authentication provides backend services, easy-to-use SDKs, and
+ready-made UI libraries to authenticate users to your app.
 
 ### Users
 
-A user is an entity that can sign in to your app. Each user is identified by a unique ID (`uid`) which is guaranteed to be unique across all providers.
-User properties include:
+A user is an entity that can sign in to your app. Each user is identified by a
+unique ID (`uid`) which is guaranteed to be unique across all providers. User
+properties include:
+
 - `uid`: Unique identifier.
 - `email`: User's email address (if available).
 - `displayName`: User's display name (if available).
@@ -26,17 +30,23 @@ User properties include:
 ### Identity Providers
 
 Firebase Auth supports multiple ways to sign in:
+
 - **Email/Password**: Basic email and password authentication.
-- **Federated Identity Providers**: Google, Facebook, Twitter, GitHub, Microsoft, Apple, etc.
+- **Federated Identity Providers**: Google, Facebook, Twitter, GitHub,
+  Microsoft, Apple, etc.
 - **Phone Number**: SMS-based authentication.
-- **Anonymous**: Temporary guest accounts that can be linked to permanent accounts later.
+- **Anonymous**: Temporary guest accounts that can be linked to permanent
+  accounts later.
 - **Custom Auth**: Integrate with your existing auth system.
 
 Google Sign In is recommended as a good and secure default provider.
 
 ### Tokens
 
-When a user signs in, they receive an ID Token (JWT). This token is used to identify the user when making requests to Firebase services (Realtime Database, Cloud Storage, Firestore) or your own backend.
+When a user signs in, they receive an ID Token (JWT). This token is used to
+identify the user when making requests to Firebase services (Realtime Database,
+Cloud Storage, Firestore) or your own backend.
+
 - **ID Token**: Short-lived (1 hour), verifies identity.
 - **Refresh Token**: Long-lived, used to get new ID tokens.
 
@@ -46,7 +56,8 @@ When a user signs in, they receive an ID Token (JWT). This token is used to iden
 
 #### Option 1. Enabling Authentication via CLI
 
-Only Google Sign In, anonymous auth, and email/password auth can be enabled via CLI. For other providers, use the Firebase Console.
+Only Google Sign In, anonymous auth, and email/password auth can be enabled via
+CLI. For other providers, use the Firebase Console.
 
 Configure Firebase Authentication in `firebase.json` by adding an 'auth' block:
 
@@ -66,13 +77,19 @@ Configure Firebase Authentication in `firebase.json` by adding an 'auth' block:
 }
 ```
 
-> [!NOTE]
-> If the Google Sign-In popup opens and immediately closes with the error `[firebase_auth/unauthorized-domain]`, it means the domain is not authorized.
-> For local development, ensure `localhost` is included in the **Authorized Domains** list in the Firebase Console or via the `authorizedDomains` field in `firebase.json`.
-> **CRITICAL**: Do NOT include the protocol or port number in the Authorized Domains list (e.g., use `localhost`, NOT `http://localhost:9090`).
+> [!NOTE] If the Google Sign-In popup opens and immediately closes with the
+> error `[firebase_auth/unauthorized-domain]`, it means the domain is not
+> authorized. For local development, ensure `localhost` is included in the
+> **Authorized Domains** list in the Firebase Console or via the
+> `authorizedDomains` field in `firebase.json`. **CRITICAL**: Do NOT include the
+> protocol or port number in the Authorized Domains list (e.g., use `localhost`,
+> NOT `http://localhost:9090`).
 
+**CRITICAL**: After configuring `firebase.json`, you MUST deploy the auth
+configuration to the Firebase backend for the changes to take effect. This is
+essential for auth providers like Google Sign-In, email/password, etc. to
+auto-generate the necessary OAuth clients for your app platforms. Run:
 
-**CRITICAL**: After configuring `firebase.json`, you MUST deploy the auth configuration to the Firebase backend for the changes to take effect. This is essential for auth providers like Google Sign-In, email/password, etc. to auto-generate the necessary OAuth clients for your app platforms. Run:
 ```bash
 npx -y firebase-tools@latest deploy --only auth
 ```
@@ -81,19 +98,18 @@ npx -y firebase-tools@latest deploy --only auth
 
 Enable other providers in the Firebase Console.
 
-1.  Go to the https://console.firebase.google.com/project/_/authentication/providers
-2.  Select your project.
-3.  Enable the desired Sign-in providers (e.g., Email/Password, Google).
+1. Go to the
+   https://console.firebase.google.com/project/_/authentication/providers
+1. Select your project.
+1. Enable the desired Sign-in providers (e.g., Email/Password, Google).
 
 ### 2. Client Setup & Usage
 
-**Web**
-See [references/client_sdk_web.md](references/client_sdk_web.md).
+**Web** See [references/client_sdk_web.md](references/client_sdk_web.md).
 
-**Flutter**
-See [references/flutter_setup.md](references/flutter_setup.md).
-**Android (Kotlin)**
-See [references/client_sdk_android.md](references/client_sdk_android.md).
+**Flutter** See [references/flutter_setup.md](references/flutter_setup.md).
+**Android (Kotlin)** See
+[references/client_sdk_android.md](references/client_sdk_android.md).
 
 ### 3. Security Rules
 

--- a/skills/firebase-auth-basics/references/client_sdk_android.md
+++ b/skills/firebase-auth-basics/references/client_sdk_android.md
@@ -1,20 +1,23 @@
 # Firebase Authentication on Android (Kotlin)
 
-This guide walks you through using Firebase Authentication in your Android app using Kotlin DSL (`build.gradle.kts`) and Kotlin code.
+This guide walks you through using Firebase Authentication in your Android app
+using Kotlin DSL (`build.gradle.kts`) and Kotlin code.
 
 ### 1, Enable Authentication via CLI
 
-Before adding dependencies in your app, make sure you enable the Auth service in your Firebase Project using the Firebase CLI:
+Before adding dependencies in your app, make sure you enable the Auth service in
+your Firebase Project using the Firebase CLI:
 
 ```bash
 npx -y firebase-tools@latest init auth
 ```
 
- ---
+______________________________________________________________________
 
 ### 2. Add Dependencies
 
-In your module-level `build.gradle.kts` (usually `app/build.gradle.kts`), add the dependency for Firebase Authentication:
+In your module-level `build.gradle.kts` (usually `app/build.gradle.kts`), add
+the dependency for Firebase Authentication:
 
 ```kotlin
 dependencies {
@@ -27,7 +30,7 @@ dependencies {
 }
 ```
 
----
+______________________________________________________________________
 
 ### 3. Initialize FirebaseAuth
 
@@ -82,7 +85,7 @@ class MainActivity : ComponentActivity() {
 }
 ```
 
----
+______________________________________________________________________
 
 ### 4. Check Current Auth State
 
@@ -101,7 +104,7 @@ public override fun onStart() {
 }
 ```
 
----
+______________________________________________________________________
 
 ### 5. Sign Up New Users (Email/Password)
 
@@ -123,7 +126,7 @@ fun signUpUser(email: String, password: String) {
 }
 ```
 
----
+______________________________________________________________________
 
 ### 6. Sign In Existing Users (Email/Password)
 
@@ -145,7 +148,7 @@ fun signInUser(email: String, password: String) {
 }
 ```
 
----
+______________________________________________________________________
 
 ### 7. Sign Out
 

--- a/skills/firebase-auth-basics/references/client_sdk_web.md
+++ b/skills/firebase-auth-basics/references/client_sdk_web.md
@@ -2,7 +2,8 @@
 
 ## Initialization
 
-First, ensure you have initialized the Firebase App (see `firebase-basics` skill). Then, initialize the Auth service:
+First, ensure you have initialized the Firebase App (see `firebase-basics`
+skill). Then, initialize the Auth service:
 
 ```javascript
 import { getAuth } from "firebase/auth";
@@ -14,7 +15,8 @@ export { auth };
 
 ## Connect to Emulator
 
-If you are running the Authentication emulator (usually on port 9099), connect to it immediately after initialization.
+If you are running the Authentication emulator (usually on port 9099), connect
+to it immediately after initialization.
 
 ```javascript
 import { getAuth, connectAuthEmulator } from "firebase/auth";
@@ -69,12 +71,16 @@ signInWithPopup(auth, provider)
   });
 ```
 
-> [!IMPORTANT]
-> **Troubleshooting `auth/unauthorized-domain`**:
-> If the popup opens and immediately closes with error `[firebase_auth/unauthorized-domain]`, it means the domain hosting your app is not authorized for OAuth operations in your Firebase project.
-> - **Fix**: Add your domain (e.g., `localhost` for local testing) to the Authorized Domains list in the Firebase Console (Authentication > Settings > Authorized domains) or in your `firebase.json` auth config.
-> - **CRITICAL**: Do NOT include the protocol or port number when adding the domain (e.g., use `localhost`, NOT `http://localhost:9090`).
-
+> [!IMPORTANT] **Troubleshooting `auth/unauthorized-domain`**: If the popup
+> opens and immediately closes with error `[firebase_auth/unauthorized-domain]`,
+> it means the domain hosting your app is not authorized for OAuth operations in
+> your Firebase project.
+>
+> - **Fix**: Add your domain (e.g., `localhost` for local testing) to the
+>   Authorized Domains list in the Firebase Console (Authentication > Settings >
+>   Authorized domains) or in your `firebase.json` auth config.
+> - **CRITICAL**: Do NOT include the protocol or port number when adding the
+>   domain (e.g., use `localhost`, NOT `http://localhost:9090`).
 
 ## Sign In with Facebook (Popup)
 
@@ -261,7 +267,8 @@ if (isSignInWithEmailLink(auth, window.location.href)) {
 
 ## Observe Auth State
 
-Recommended way to get the current user. This listener triggers whenever the user signs in or out.
+Recommended way to get the current user. This listener triggers whenever the
+user signs in or out.
 
 ```javascript
 import { getAuth, onAuthStateChanged } from "firebase/auth";

--- a/skills/firebase-auth-basics/references/flutter_setup.md
+++ b/skills/firebase-auth-basics/references/flutter_setup.md
@@ -1,15 +1,32 @@
 # Firebase Auth & Google Sign-In for Flutter
 
-When integrating Firebase Authentication and Google Sign-In into Flutter apps targeting cross-platform environments (like Mobile + Web), you must navigate several breaking changes introduced in `google_sign_in` 7.x+ and some platform-specific quirks.
+When integrating Firebase Authentication and Google Sign-In into Flutter apps
+targeting cross-platform environments (like Mobile + Web), you must navigate
+several breaking changes introduced in `google_sign_in` 7.x+ and some
+platform-specific quirks.
 
 ## 1. `google_sign_in` 7.2.0 API Changes
-- **Method Renamed**: The `signIn()` method is deprecated/removed and has been replaced with `authenticate()`.
-- **Token Separation**: The `GoogleSignInAuthentication` object no longer packages both identity and authorization tokens together. Initial authentication now only provides the `idToken`. If an `accessToken` is required for Google APIs, you must explicitly request server authorization separately.
 
-## 2. Initialization & Web Hang/Crash Pitfalls 
-- **Initialization Requirement**: In 7.x, you must call `await GoogleSignIn.instance.initialize();` globally before using the plugin.
-- **Web Client ID Constraint**: On Flutter Web, if you call `initialize()` without passing a `clientId` argument OR specifying the `<meta name="google-signin-client_id" ... />` tag in `web/index.html`, the Dart Web Debug Service (DWDS) and the app will throw an assertion error and **hang infinitely**, resulting in a blank screen.
-- **Common Workaround**: If you intend to use Firebase Auth's `signInWithPopup(GoogleAuthProvider())` for the web, you can conditionally skip the local `GoogleSignIn` package initialization entirely:
+- **Method Renamed**: The `signIn()` method is deprecated/removed and has been
+  replaced with `authenticate()`.
+- **Token Separation**: The `GoogleSignInAuthentication` object no longer
+  packages both identity and authorization tokens together. Initial
+  authentication now only provides the `idToken`. If an `accessToken` is
+  required for Google APIs, you must explicitly request server authorization
+  separately.
+
+## 2. Initialization & Web Hang/Crash Pitfalls
+
+- **Initialization Requirement**: In 7.x, you must call
+  `await GoogleSignIn.instance.initialize();` globally before using the plugin.
+- **Web Client ID Constraint**: On Flutter Web, if you call `initialize()`
+  without passing a `clientId` argument OR specifying the
+  `<meta name="google-signin-client_id" ... />` tag in `web/index.html`, the
+  Dart Web Debug Service (DWDS) and the app will throw an assertion error and
+  **hang infinitely**, resulting in a blank screen.
+- **Common Workaround**: If you intend to use Firebase Auth's
+  `signInWithPopup(GoogleAuthProvider())` for the web, you can conditionally
+  skip the local `GoogleSignIn` package initialization entirely:
   ```dart
   import 'package:flutter/foundation.dart' show kIsWeb;
 
@@ -19,8 +36,14 @@ When integrating Firebase Authentication and Google Sign-In into Flutter apps ta
   ```
 
 ## 3. Web Logout Crashes
-- If you bypassed `GoogleSignIn` initialization on the web (as demonstrated above), you cannot call its `signOut()` method later. Attempting to execute `await GoogleSignIn.instance.signOut();` during the user's logout flow on the Web platform evaluates against an uninitialized context or unsupported environment, crashing the app.
-- **Solution**: Conditionally separate the logout logic for Web to rely entirely on `FirebaseAuth`:
+
+- If you bypassed `GoogleSignIn` initialization on the web (as demonstrated
+  above), you cannot call its `signOut()` method later. Attempting to execute
+  `await GoogleSignIn.instance.signOut();` during the user's logout flow on the
+  Web platform evaluates against an uninitialized context or unsupported
+  environment, crashing the app.
+- **Solution**: Conditionally separate the logout logic for Web to rely entirely
+  on `FirebaseAuth`:
   ```dart
   if (!kIsWeb) {
       await GoogleSignIn.instance.signOut();
@@ -29,13 +52,23 @@ When integrating Firebase Authentication and Google Sign-In into Flutter apps ta
   ```
 
 ## 4. Prototyping Workaround: Bypassing Firestore Composite Indices
-*Note: This is a Firestore consideration frequently encountered while fetching user-specific auth data.*
 
-When querying data via `FirebaseFirestore.instance`, using `.where('userId', isEqualTo: uid)` combined with a sort on a different field like `.orderBy('createdAt', descending: true)` mandates a custom composite index. 
-- **Quick Alternative**: During local development, you can avoid defining indexes by pulling the data using only `.where()` and applying the `.sort()` operation client-side on the resulting `List` in Dart.
+*Note: This is a Firestore consideration frequently encountered while fetching
+user-specific auth data.*
+
+When querying data via `FirebaseFirestore.instance`, using
+`.where('userId', isEqualTo: uid)` combined with a sort on a different field
+like `.orderBy('createdAt', descending: true)` mandates a custom composite
+index.
+
+- **Quick Alternative**: During local development, you can avoid defining
+  indexes by pulling the data using only `.where()` and applying the `.sort()`
+  operation client-side on the resulting `List` in Dart.
 
 ## 5. Robust `AuthService` Boilerplate
-Here is a comprehensive `AuthService` implementation that properly handles the initialization and platform differences between Flutter Web and Mobile:
+
+Here is a comprehensive `AuthService` implementation that properly handles the
+initialization and platform differences between Flutter Web and Mobile:
 
 ```dart
 import 'package:firebase_auth/firebase_auth.dart';
@@ -99,9 +132,18 @@ class AuthService {
 
 ## 6. Troubleshooting `auth/unauthorized-domain` on Flutter Web
 
-When running Flutter Web locally and using `signInWithPopup`, you might encounter a situation where the Google Sign-In popup opens and immediately closes.
-- **Symptom**: The console shows `Sign-in failed: [firebase_auth/unauthorized-domain] This domain is not authorized for OAuth operation for your Firebase project.`
-- **Cause**: The domain (usually `localhost` during local testing) is not listed in the Authorized Domains in the Firebase Console.
-- **Solution**: Add `localhost` to the Authorized Domains list in the Firebase Console (Authentication > Settings > Authorized domains) or in your `firebase.json` auth config.
-- **CRITICAL**: Do NOT include the protocol or port number when adding the domain (e.g., use `localhost`, NOT `http://localhost:9090`). Flutter Web often runs on random ports or specific ports, but Firebase Auth only cares about the domain.
+When running Flutter Web locally and using `signInWithPopup`, you might
+encounter a situation where the Google Sign-In popup opens and immediately
+closes.
 
+- **Symptom**: The console shows
+  `Sign-in failed: [firebase_auth/unauthorized-domain] This domain is not authorized for OAuth operation for your Firebase project.`
+- **Cause**: The domain (usually `localhost` during local testing) is not listed
+  in the Authorized Domains in the Firebase Console.
+- **Solution**: Add `localhost` to the Authorized Domains list in the Firebase
+  Console (Authentication > Settings > Authorized domains) or in your
+  `firebase.json` auth config.
+- **CRITICAL**: Do NOT include the protocol or port number when adding the
+  domain (e.g., use `localhost`, NOT `http://localhost:9090`). Flutter Web often
+  runs on random ports or specific ports, but Firebase Auth only cares about the
+  domain.

--- a/skills/firebase-auth-basics/references/ios_setup.md
+++ b/skills/firebase-auth-basics/references/ios_setup.md
@@ -1,21 +1,35 @@
 # Firebase Auth iOS Setup Guide
 
 # ⛔️ CRITICAL RULE: NO INLINE INITIALIZATION ⛔️
-NEVER write `let auth = Auth.auth()` as an inline class or struct property if there is ANY chance the object is instantiated before `FirebaseApp.configure()` executes in the app root.
-- **FATAL CRASH:** `@Observable class AuthManager { let auth = Auth.auth() }` initialized as a `@State` in the App root.
-- **SAFE PATTERN:** Initialize `Auth.auth()` lazily (`lazy var auth = Auth.auth()`) OR explicitly initialize the manager *after* `FirebaseApp.configure()` finishes.
+
+NEVER write `let auth = Auth.auth()` as an inline class or struct property if
+there is ANY chance the object is instantiated before `FirebaseApp.configure()`
+executes in the app root.
+
+- **FATAL CRASH:** `@Observable class AuthManager { let auth = Auth.auth() }`
+  initialized as a `@State` in the App root.
+- **SAFE PATTERN:** Initialize `Auth.auth()` lazily
+  (`lazy var auth = Auth.auth()`) OR explicitly initialize the manager *after*
+  `FirebaseApp.configure()` finishes.
 
 ## 1. Import and Initialize
-Ensure you have installed the `FirebaseAuth` SDK. Use the `xcode-project-setup` skill to automate adding the SPM dependency to the Xcode project.
 
-> **Note:** Ensure `FirebaseApp.configure()` has been executed in your app's entry point before calling any `Auth.auth()` methods, otherwise your app will crash. Do not initialize Auth objects in SwiftUI `@State` properties at the App root level.
+Ensure you have installed the `FirebaseAuth` SDK. Use the `xcode-project-setup`
+skill to automate adding the SPM dependency to the Xcode project.
+
+> **Note:** Ensure `FirebaseApp.configure()` has been executed in your app's
+> entry point before calling any `Auth.auth()` methods, otherwise your app will
+> crash. Do not initialize Auth objects in SwiftUI `@State` properties at the
+> App root level.
 
 ```swift
 import FirebaseAuth
 ```
 
 ## 2. Authentication State
-To listen for authentication state changes (recommended way to check if a user is signed in):
+
+To listen for authentication state changes (recommended way to check if a user
+is signed in):
 
 ```swift
 var handle: AuthStateDidChangeListenerHandle?
@@ -36,9 +50,11 @@ if let handle = handle {
 
 ## 3. Email and Password Authentication (Modern Concurrency)
 
-Modern Swift projects should prioritize `async/await` for authentication calls to avoid nested completion handlers and improve readability.
+Modern Swift projects should prioritize `async/await` for authentication calls
+to avoid nested completion handlers and improve readability.
 
 ### Sign Up
+
 ```swift
 do {
     let authResult = try await Auth.auth().createUser(withEmail: "user@example.com", password: "password")
@@ -49,6 +65,7 @@ do {
 ```
 
 ### Sign In
+
 ```swift
 do {
     let authResult = try await Auth.auth().signIn(withEmail: "user@example.com", password: "password")
@@ -59,6 +76,7 @@ do {
 ```
 
 ## 4. Sign Out
+
 ```swift
 do {
   try Auth.auth().signOut()
@@ -67,4 +85,3 @@ do {
   print("Error signing out: \(signOutError)")
 }
 ```
-

--- a/skills/firebase-auth-basics/references/security_rules.md
+++ b/skills/firebase-auth-basics/references/security_rules.md
@@ -1,31 +1,41 @@
 # Authentication in Security Rules
 
-Firebase Security Rules work with Firebase Authentication to provide rule-based access control. For better advice on writing safe security rules,
-enable the `firebase-firestore-basics`  or `firebase-storage-basics` skills.
- 
-The `request.auth` variable contains authentication information for the user requesting data.
+Firebase Security Rules work with Firebase Authentication to provide rule-based
+access control. For better advice on writing safe security rules, enable the
+`firebase-firestore-basics` or `firebase-storage-basics` skills.
+
+The `request.auth` variable contains authentication information for the user
+requesting data.
 
 ## Basic Checks
 
 ### Check if user is signed in
+
 ```
 allow read, write: if request.auth != null;
 ```
 
 ### Check if user owns the data
+
 Access data only if the document ID matches the user's UID.
+
 ```
 allow read, write: if request.auth != null && request.auth.uid == userId;
 ```
+
 (Where `userId` is a path variable, e.g., `match /users/{userId}`)
 
 ### Check if user owns the document (field-based)
-Access data only if the document has a `owner_uid` field matching the user's UID.
+
+Access data only if the document has a `owner_uid` field matching the user's
+UID.
+
 ```
 allow read, write: if request.auth != null && request.auth.uid == resource.data.owner_uid;
 ```
 
 ## Token Properties
+
 `request.auth.token` contains standard JWT claims and custom claims.
 
 - `request.auth.token.email`: The user's email address.
@@ -33,6 +43,7 @@ allow read, write: if request.auth != null && request.auth.uid == resource.data.
 - `request.auth.token.name`: The user's display name.
 
 ### Example: Email Verification Check
+
 ```
 allow create: if request.auth.token.email_verified == true;
 ```

--- a/skills/firebase-basics/SKILL.md
+++ b/skills/firebase-basics/SKILL.md
@@ -12,90 +12,127 @@ description: >-
 
 Complete these setup steps before proceeding:
 
-1.  **Local Environment Setup:** Verify the environment is properly set up so we
-    can use Firebase tools:
+1. **Local Environment Setup:** Verify the environment is properly set up so we
+   can use Firebase tools:
 
-    -   Run `npx -y firebase-tools@latest --version` to check if the Firebase
-        CLI is installed.
-    -   Verify if the Firebase MCP server is installed using your existing
-        tools.
-    -   **CRITICAL**: Before configuring any extensions or agent environments
-        below, you MUST read
-        [references/local-env-setup.md](references/local-env-setup.md).
-    -   **DO NOT SKIP** this step: if 'firebase-basics' is the only
-        Firebase skill available to you, you must follow the reference for your
-        agent environment to set up the full suite of Firebase skills:
-        -   **Gemini CLI**: Review
-            [references/setup/gemini_cli.md](references/setup/gemini_cli.md)
-        -   **Antigravity**: Review
-            [references/setup/antigravity.md](references/setup/antigravity.md)
-        -   **Android Studio**: Review
-            [references/setup/android_studio.md](references/setup/android_studio.md)
-        -   **Claude Code**: Review
-            [references/setup/claude_code.md](references/setup/claude_code.md)
-        -   **Cursor**: Review
-            [references/setup/cursor.md](references/setup/cursor.md)
-        -   **GitHub Copilot**: Review
-            [references/setup/github_copilot.md](references/setup/github_copilot.md)
-        -   **Other Agents**: Review
-            [references/setup/other_agents.md](references/setup/other_agents.md)
+   - Run `npx -y firebase-tools@latest --version` to check if the Firebase CLI
+     is installed.
+   - Verify if the Firebase MCP server is installed using your existing tools.
+   - **CRITICAL**: Before configuring any extensions or agent environments
+     below, you MUST read
+     [references/local-env-setup.md](references/local-env-setup.md).
+   - **DO NOT SKIP** this step: if 'firebase-basics' is the only Firebase skill
+     available to you, you must follow the reference for your agent environment
+     to set up the full suite of Firebase skills:
+     - **Gemini CLI**: Review
+       [references/setup/gemini_cli.md](references/setup/gemini_cli.md)
+     - **Antigravity**: Review
+       [references/setup/antigravity.md](references/setup/antigravity.md)
+     - **Android Studio**: Review
+       [references/setup/android_studio.md](references/setup/android_studio.md)
+     - **Claude Code**: Review
+       [references/setup/claude_code.md](references/setup/claude_code.md)
+     - **Cursor**: Review
+       [references/setup/cursor.md](references/setup/cursor.md)
+     - **GitHub Copilot**: Review
+       [references/setup/github_copilot.md](references/setup/github_copilot.md)
+     - **Other Agents**: Review
+       [references/setup/other_agents.md](references/setup/other_agents.md)
 
-2.  **Authentication:** Ensure you are logged in to Firebase so that commands
-    have the correct permissions. Run `npx -y firebase-tools@latest login`. For
-    environments without a browser (e.g., remote shells), use `npx -y
-    firebase-tools@latest login --no-localhost`.
+1. **Authentication:** Ensure you are logged in to Firebase so that commands
+   have the correct permissions. Run `npx -y firebase-tools@latest login`. For
+   environments without a browser (e.g., remote shells), use
+   `npx -y firebase-tools@latest login --no-localhost`.
 
-    -   The command should output the current user.
-    -   If you are not logged in, follow the interactive instructions from this
-        command to authenticate.
+   - The command should output the current user.
+   - If you are not logged in, follow the interactive instructions from this
+     command to authenticate.
 
-3. **Active Project:**
-   Most Firebase tasks require an active project context.
+1. **Active Project:** Most Firebase tasks require an active project context.
 
-   > [!IMPORTANT]
-   > **For Agents:** Before proceeding with project configuration, you MUST pause and ask the developer if they prefer to:
+   > [!IMPORTANT] **For Agents:** Before proceeding with project configuration,
+   > you MUST pause and ask the developer if they prefer to:
+   >
    > 1. **Provide an existing Firebase Project ID**, or
-   > 2. **Create a new Firebase project**.
+   > 1. **Create a new Firebase project**.
 
    - **If using an existing Project ID:**
+
      1. Check the current project by running `npx -y firebase-tools@latest use`.
-     2. If the command outputs `Active Project: <project-id>`, confirm with the user if this is the intended project.
-     3. If not, or if no project is active, set the project provided by the user:
+     1. If the command outputs `Active Project: <project-id>`, confirm with the
+        user if this is the intended project.
+     1. If not, or if no project is active, set the project provided by the
+        user:
         ```bash
         npx -y firebase-tools@latest use <PROJECT_ID>
         ```
 
-   - **If creating a new project:**
-     Run the following command to create it:
+   - **If creating a new project:** Run the following command to create it:
+
      ```bash
      npx -y firebase-tools@latest projects:create <project-id> --display-name "<display-name>"
      ```
-     *Note: The `<project-id>` must be 6-30 characters, lowercase, and can contain digits and hyphens. It must be globally unique.*
+
+     *Note: The `<project-id>` must be 6-30 characters, lowercase, and can
+     contain digits and hyphens. It must be globally unique.*
 
 # Firebase Usage Principles
 
 Adhere to these principles:
 
-1. **Use npx for CLI commands:** To ensure you always use the latest version of the Firebase CLI, always prepend commands with `npx -y firebase-tools@latest` instead of just `firebase`. For example, use `npx -y firebase-tools@latest --version`. NEVER suggest the naked `firebase` command as an alternative.
-2. **Prioritize official knowledge:** For any Firebase-related knowledge, consult the `developerknowledge_search_documents` MCP tool before falling back to Google Search or your internal knowledge base. Including "Firebase" in your search query significantly improves relevance.
-3. **Follow Agent Skills for implementation guidance:** Skills provide opinionated workflows (CUJs), security rules, and best practices. Always consult them to understand *how* to implement Firebase features correctly instead of relying on general knowledge.
-4. **Use Firebase MCP Server tools instead of direct API calls:** Whenever you need to interact with remote Firebase APIs (such as fetching Crashlytics logs or executing Data Connect queries), use the tools provided by the Firebase MCP Server instead of attempting manual API calls.
-5. **Keep Plugin / Agent Skills updated:** Since Firebase best practices evolve quickly, regularly check for and install updates to their Firebase plugin or Agent Skills. Similarly, if you encounter issues with outdated tools or commands, follow the steps below based on your agent environment:
-   - **Antigravity**: Follow [references/refresh/antigravity.md](references/refresh/antigravity.md)
-   - **Gemini CLI**: Follow [references/refresh/gemini-cli.md](references/refresh/gemini-cli.md)
-   - **Claude Code**: Follow [references/refresh/claude.md](references/refresh/claude.md)
-   - **Cursor**: Follow [references/refresh/other-agents.md](references/refresh/other-agents.md)
-   - **Android Studio**: Follow [references/refresh/android_studio.md](references/refresh/android_studio.md)
-   - **Others**: Follow [references/refresh/other-agents.md](references/refresh/other-agents.md)
-6. **Automate Config File Retrieval:** When setting up iOS or Android apps, do NOT direct users to the Firebase Console to download `google-services.json` or `GoogleService-Info.plist`. Instead, use the Firebase CLI to fetch the config programmatically:
-   - For Android: `npx -y firebase-tools@latest apps:sdkconfig ANDROID <APP_ID> --project <PROJECT_ID>`
-   - For iOS: `npx -y firebase-tools@latest apps:sdkconfig IOS <APP_ID> --project <PROJECT_ID>`
-   Save the output to the appropriate location (e.g., `app/google-services.json` for Android, or a path to be linked by `xcode-project-setup` for iOS).
+1. **Use npx for CLI commands:** To ensure you always use the latest version of
+   the Firebase CLI, always prepend commands with `npx -y firebase-tools@latest`
+   instead of just `firebase`. For example, use
+   `npx -y firebase-tools@latest --version`. NEVER suggest the naked `firebase`
+   command as an alternative.
+1. **Prioritize official knowledge:** For any Firebase-related knowledge,
+   consult the `developerknowledge_search_documents` MCP tool before falling
+   back to Google Search or your internal knowledge base. Including "Firebase"
+   in your search query significantly improves relevance.
+1. **Follow Agent Skills for implementation guidance:** Skills provide
+   opinionated workflows (CUJs), security rules, and best practices. Always
+   consult them to understand *how* to implement Firebase features correctly
+   instead of relying on general knowledge.
+1. **Use Firebase MCP Server tools instead of direct API calls:** Whenever you
+   need to interact with remote Firebase APIs (such as fetching Crashlytics logs
+   or executing Data Connect queries), use the tools provided by the Firebase
+   MCP Server instead of attempting manual API calls.
+1. **Keep Plugin / Agent Skills updated:** Since Firebase best practices evolve
+   quickly, regularly check for and install updates to their Firebase plugin or
+   Agent Skills. Similarly, if you encounter issues with outdated tools or
+   commands, follow the steps below based on your agent environment:
+   - **Antigravity**: Follow
+     [references/refresh/antigravity.md](references/refresh/antigravity.md)
+   - **Gemini CLI**: Follow
+     [references/refresh/gemini-cli.md](references/refresh/gemini-cli.md)
+   - **Claude Code**: Follow
+     [references/refresh/claude.md](references/refresh/claude.md)
+   - **Cursor**: Follow
+     [references/refresh/other-agents.md](references/refresh/other-agents.md)
+   - **Android Studio**: Follow
+     [references/refresh/android_studio.md](references/refresh/android_studio.md)
+   - **Others**: Follow
+     [references/refresh/other-agents.md](references/refresh/other-agents.md)
+1. **Automate Config File Retrieval:** When setting up iOS or Android apps, do
+   NOT direct users to the Firebase Console to download `google-services.json`
+   or `GoogleService-Info.plist`. Instead, use the Firebase CLI to fetch the
+   config programmatically:
+   - For Android:
+     `npx -y firebase-tools@latest apps:sdkconfig ANDROID <APP_ID> --project <PROJECT_ID>`
+   - For iOS:
+     `npx -y firebase-tools@latest apps:sdkconfig IOS <APP_ID> --project <PROJECT_ID>`
+     Save the output to the appropriate location (e.g.,
+     `app/google-services.json` for Android, or a path to be linked by
+     `xcode-project-setup` for iOS).
 
 # References
 
-- **Initialize Firebase:** See [references/firebase-service-init.md](references/firebase-service-init.md) when you need to initialize new Firebase services using the CLI.
-- **Exploring Commands:** See [references/firebase-cli-guide.md](references/firebase-cli-guide.md) to discover and understand CLI functionality.
+- **Initialize Firebase:** See
+  [references/firebase-service-init.md](references/firebase-service-init.md)
+  when you need to initialize new Firebase services using the CLI.
+- **Exploring Commands:** See
+  [references/firebase-cli-guide.md](references/firebase-cli-guide.md) to
+  discover and understand CLI functionality.
 - **SDK Setup:** For detailed guides on adding Firebase to your app:
   - **Web**: See [references/web_setup.md](references/web_setup.md)
   - **Android**: See [references/android_setup.md](references/android_setup.md)
@@ -103,10 +140,9 @@ Adhere to these principles:
 
 # Common Issues
 
--   **Login Issues:** If the browser fails to open during the login step, use
-    `npx -y firebase-tools@latest login --no-localhost` instead.
--   **Genkit:**
-    If using Genkit, install the skills:
-    ```bash
-    npx skills add genkit-ai/skills
-    ```
+- **Login Issues:** If the browser fails to open during the login step, use
+  `npx -y firebase-tools@latest login --no-localhost` instead.
+- **Genkit:** If using Genkit, install the skills:
+  ```bash
+  npx skills add genkit-ai/skills
+  ```

--- a/skills/firebase-basics/references/android_setup.md
+++ b/skills/firebase-basics/references/android_setup.md
@@ -1,34 +1,41 @@
 # 🛠️ Firebase Android Setup Guide
 
----
+______________________________________________________________________
+
 ## 📋 Prerequisites
-Before running these commands, ensure you are authenticated:
-`npx -y firebase-tools@latest login` (or `npx -y firebase-tools@latest login --no-localhost` on remote servers)
----
+
+## Before running these commands, ensure you are authenticated: `npx -y firebase-tools@latest login` (or `npx -y firebase-tools@latest login --no-localhost` on remote servers)
 
 ## 0. Create an Android application
+
 if you haven't already created an android application, create one.
 
 ## 1. Create a Firebase Project
-If you haven't already created a project, create a new cloud project with a unique ID:
+
+If you haven't already created a project, create a new cloud project with a
+unique ID:
 `npx -y firebase-tools@latest projects:create <UNIQUE_PROJECT_ID> --display-name '<DISPLAY_NAME>'`
 *Example:*
 `npx -y firebase-tools@latest projects:create my-cool-app-20260330 --display-name 'MyCoolApp'`
+
 ### 2. Register Your Android App
-Link your Android app module (package name) to your project. Notice that the display name is passed as a positional argument at the end:
+
+Link your Android app module (package name) to your project. Notice that the
+display name is passed as a positional argument at the end:
 `npx -y firebase-tools@latest apps:create ANDROID '<APP_DISPLAY_NAME>' --package-name '<PACKAGE_NAME>' --project <PROJECT_ID>`
 *Example:*
 `npx -y firebase-tools@latest apps:create ANDROID 'MyApplication' --package-name 'com.example.myapplication' --project my-cool-app-20260330`
+
 ### 3. Download `google-services.json`
-Fetch the configuration file using the App ID (which is printed in the output of the previous command):
-`npx -y firebase-tools@latest apps:sdkconfig ANDROID <APP_ID> --project <PROJECT_ID>`
-*Example output extraction to file:*
-` # (Output must be saved as app/google-services.json)`
----
+
+## Fetch the configuration file using the App ID (which is printed in the output of the previous command): `npx -y firebase-tools@latest apps:sdkconfig ANDROID <APP_ID> --project <PROJECT_ID>` *Example output extraction to file:* ` # (Output must be saved as app/google-services.json)`
+
 ## ✅ Verification Plan
+
 ### Manual Verification
+
 Validate that the project was created and registered successfully:
 `npx -y firebase-tools@latest projects:list`
 `npx -y firebase-tools@latest apps:list --project <PROJECT_ID>`
 
----
+______________________________________________________________________

--- a/skills/firebase-basics/references/firebase-cli-guide.md
+++ b/skills/firebase-basics/references/firebase-cli-guide.md
@@ -3,11 +3,13 @@
 The Firebase CLI documents itself. Use help commands to discover functionality.
 
 - **Global Help**: List all available commands and categories.
+
   ```bash
   npx -y firebase-tools@latest --help
   ```
 
 - **Command Help**: Get detailed usage for a specific command.
+
   ```bash
   npx -y firebase-tools@latest [command] --help
   # Example:

--- a/skills/firebase-basics/references/firebase-service-init.md
+++ b/skills/firebase-basics/references/firebase-service-init.md
@@ -1,18 +1,20 @@
 # Initialization
 
-Before initializing, check if you are already in a Firebase project directory by looking for `firebase.json`.
+Before initializing, check if you are already in a Firebase project directory by
+looking for `firebase.json`.
 
-1. **Project Directory:**
-   Navigate to the root directory of the codebase. 
-   *(Only if starting a completely new project from scratch without an existing codebase, create a directory first: `mkdir my-project && cd my-project`)*
+1. **Project Directory:** Navigate to the root directory of the codebase. *(Only
+   if starting a completely new project from scratch without an existing
+   codebase, create a directory first: `mkdir my-project && cd my-project`)*
 
-2. **Initialize Services:**
-   Run the initialization command:
+1. **Initialize Services:** Run the initialization command:
+
    ```bash
    npx -y firebase-tools@latest init
    ```
 
 The CLI will guide you through:
+
 - Selecting features (Firestore, Functions, Hosting, etc.).
 - Associating with an existing project or creating a new one.
 - Configuring files (e.g. `firebase.json`, `.firebaserc`).

--- a/skills/firebase-basics/references/flutter_setup.md
+++ b/skills/firebase-basics/references/flutter_setup.md
@@ -1,42 +1,56 @@
 # Flutter & Firebase Setup Guide
 
-This guide covers the initial setup of Flutter and its integration with Firebase using the FlutterFire CLI.
+This guide covers the initial setup of Flutter and its integration with Firebase
+using the FlutterFire CLI.
 
 ## Prerequisites
 
 1. **Flutter SDK**: Ensure Flutter is installed and available in the PATH.
-   
+
    **Standard Setup (Manual):**
-   1. **Determine Architecture**: Check if you are on Intel (`x64`) or Apple Silicon (`arm64`) using `uname -m`.
-   2. **Download SDK**: Fetch the latest stable SDK from the [Flutter Archive](https://docs.flutter.dev/install/archive?tab=macos).
-   3. **Extract**: Unzip the SDK to a permanent directory (e.g., `~/development/flutter`).
-   4. **Update PATH**: Add the `bin` folder to your shell configuration (e.g., `~/.zshrc`).
+
+   1. **Determine Architecture**: Check if you are on Intel (`x64`) or Apple
+      Silicon (`arm64`) using `uname -m`.
+   1. **Download SDK**: Fetch the latest stable SDK from the
+      [Flutter Archive](https://docs.flutter.dev/install/archive?tab=macos).
+   1. **Extract**: Unzip the SDK to a permanent directory (e.g.,
+      `~/development/flutter`).
+   1. **Update PATH**: Add the `bin` folder to your shell configuration (e.g.,
+      `~/.zshrc`).
       ```bash
       echo 'export PATH="$PATH:$HOME/development/flutter/bin"' >> ~/.zshrc
       source ~/.zshrc
       ```
-   5. **Verify**: Run `flutter doctor` to ensure the SDK is correctly linked and initialized.
+   1. **Verify**: Run `flutter doctor` to ensure the SDK is correctly linked and
+      initialized.
 
-2. **Firebase CLI**: Ensure the Firebase CLI is available.
+1. **Firebase CLI**: Ensure the Firebase CLI is available.
+
    - Run `npx -y firebase-tools@latest --version`.
    - Login with `npx -y firebase-tools@latest login`.
 
-3. **FlutterFire CLI**: Install the official FlutterFire CLI globally.
+1. **FlutterFire CLI**: Install the official FlutterFire CLI globally.
+
    - Run `dart pub global activate flutterfire_cli`.
-   - **Note**: Ensure `~/.pub-cache/bin` is also in your PATH if `flutterfire` is not found.
+   - **Note**: Ensure `~/.pub-cache/bin` is also in your PATH if `flutterfire`
+     is not found.
 
 ## Step 1: Create a Flutter Project
+
 If you don't have a project yet, create one:
+
 ```bash
 flutter create my_awesome_app
 cd my_awesome_app
 ```
 
 ## Step 2: Configure Firebase
-> [!IMPORTANT]
-> **For Agents:** Before running the configuration command, you MUST pause and ask the developer if they prefer to:
+
+> [!IMPORTANT] **For Agents:** Before running the configuration command, you
+> MUST pause and ask the developer if they prefer to:
+>
 > 1. Create a new Firebase project, or
-> 2. Provide an existing Firebase Project ID.
+> 1. Provide an existing Firebase Project ID.
 
 - If the developer provides an existing Project ID, run:
   ```bash
@@ -48,19 +62,22 @@ cd my_awesome_app
   ```
 
 This tool automates:
+
 - Registering your apps (iOS, Android, Web, etc.) with a Firebase project.
 - Generating the `lib/firebase_options.dart` file.
 
-
 ## Step 3: Initialize Firebase in Code
+
 Add the `firebase_core` package and initialize it in your `main.dart`.
 
 1. Add the dependency:
+
 ```bash
 flutter pub add firebase_core
 ```
 
 2. Update `lib/main.dart`:
+
 ```dart
 import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
@@ -76,27 +93,51 @@ void main() async {
 ```
 
 ## Step 4: Add Firebase Services
-To add specific services (Firestore, Auth, etc.), follow the "Pub Add & Configure" pattern:
+
+To add specific services (Firestore, Auth, etc.), follow the "Pub Add &
+Configure" pattern:
 
 1. Add the service: `flutter pub add cloud_firestore`
-2. **Crucial**: Re-run `flutterfire configure` to sync platform configurations.
-3. Import and use the package in your code.
+1. **Crucial**: Re-run `flutterfire configure` to sync platform configurations.
+1. Import and use the package in your code.
 
 ## Step 5: Important Gotchas & Platform Specifics
 
 ### 1. Re-running `flutterfire configure` Upon Renaming
-When creating a new project, developers often change the bundle identifier (iOS) or `applicationId` (Android) after the fact. If the package names change, `flutterfire configure` **must** be re-run to update the respective Google service files and `firebase_options.dart`.
+
+When creating a new project, developers often change the bundle identifier (iOS)
+or `applicationId` (Android) after the fact. If the package names change,
+`flutterfire configure` **must** be re-run to update the respective Google
+service files and `firebase_options.dart`.
 
 ### 2. Platform-Specific Build Requirements
-- **Android**: Adding Firebase often requires a higher `minSdkVersion` (commonly `21` or `23`) than the platform default. Be prepared to update `android/app/build.gradle` automatically when installing certain plugins.
-- **iOS**: Always check if there is a `Podfile` in the `/ios` directory whenever native services (like `cloud_firestore`) are added. If there is, run `pod install`. Failing to do this will cause Xcode build errors. Note that Flutter is moving towards Swift Package Manager (SPM), and FlutterFire supports SPM, so a `Podfile` may not exist if the project only uses SPM dependencies.
+
+- **Android**: Adding Firebase often requires a higher `minSdkVersion` (commonly
+  `21` or `23`) than the platform default. Be prepared to update
+  `android/app/build.gradle` automatically when installing certain plugins.
+- **iOS**: Always check if there is a `Podfile` in the `/ios` directory whenever
+  native services (like `cloud_firestore`) are added. If there is, run
+  `pod install`. Failing to do this will cause Xcode build errors. Note that
+  Flutter is moving towards Swift Package Manager (SPM), and FlutterFire
+  supports SPM, so a `Podfile` may not exist if the project only uses SPM
+  dependencies.
 
 ### 3. Web CORS Best Practices
-When testing Firebase features locally on Chrome, requests to Google servers can sometimes get blocked by CORS policies. Avoid relying on `--disable-web-security` flags as it promotes bad security practices. Instead, run the app on localhost with a specific port, and ensure `localhost` is added to your Firebase Auth "Authorized Domains".
-  ```bash
-  flutter run -d chrome --web-hostname=localhost --web-port=5000
-  ```
+
+When testing Firebase features locally on Chrome, requests to Google servers can
+sometimes get blocked by CORS policies. Avoid relying on
+`--disable-web-security` flags as it promotes bad security practices. Instead,
+run the app on localhost with a specific port, and ensure `localhost` is added
+to your Firebase Auth "Authorized Domains".
+
+```bash
+flutter run -d chrome --web-hostname=localhost --web-port=5000
+```
 
 ### 4. Elaborating on `WidgetsFlutterBinding.ensureInitialized()`
-In your `main.dart`, this call is mandatory before `Firebase.initializeApp()`. 
-*Why?* Because Firebase initialization requires communication across Flutter's native iOS/Android method channels. `ensureInitialized()` guarantees the Fluter engine is fully booted up and ready to handle these native platform calls before `runApp()` executes.
+
+In your `main.dart`, this call is mandatory before `Firebase.initializeApp()`.
+*Why?* Because Firebase initialization requires communication across Flutter's
+native iOS/Android method channels. `ensureInitialized()` guarantees the Fluter
+engine is fully booted up and ready to handle these native platform calls before
+`runApp()` executes.

--- a/skills/firebase-basics/references/ios_setup.md
+++ b/skills/firebase-basics/references/ios_setup.md
@@ -2,45 +2,72 @@
 
 # ⛔️ CRITICAL RULE: STATE MANAGEMENT (OBSERVATION VS COMBINE) ⛔️
 
-When writing or updating SwiftUI code, you **MUST** prioritize the modern Swift **Observation framework (`@Observable` macro and `@State`)** as your default approach.
- 
-However, it is acceptable to use **Combine** (`ObservableObject`, `@Published`, `@StateObject`, `@EnvironmentObject`) under the following conditions:
-- The user explicitly asks you to use Combine.
-- There are strong signals in the existing codebase that the project is heavily relying on Combine. 
+When writing or updating SwiftUI code, you **MUST** prioritize the modern Swift
+**Observation framework (`@Observable` macro and `@State`)** as your default
+approach.
 
-If neither of those conditions are true, default to the Swift 5.9+ Observation framework.
+However, it is acceptable to use **Combine** (`ObservableObject`, `@Published`,
+`@StateObject`, `@EnvironmentObject`) under the following conditions:
+
+- The user explicitly asks you to use Combine.
+- There are strong signals in the existing codebase that the project is heavily
+  relying on Combine.
+
+If neither of those conditions are true, default to the Swift 5.9+ Observation
+framework.
 
 # ⛔️ CRITICAL RULE: INITIALIZATION ORDER ⛔️
 
-When using SwiftUI, you **MUST** ensure `FirebaseApp.configure()` is called **BEFORE** any Firebase-dependent state objects are initialized. 
+When using SwiftUI, you **MUST** ensure `FirebaseApp.configure()` is called
+**BEFORE** any Firebase-dependent state objects are initialized.
 
-- **UNSAFE (CRASH):** Declaring a `@State` (for `@Observable`) or `@StateObject` (for Combine) property in the root `App` struct if its initializer touches Firebase. Property initializers run *before* the `App.init()` body, meaning the object's `init()` will fire before Firebase is configured.
-- **SAFE:** Initialize Firebase in `App.init()` and pass your state objects into the sub-views (like `ContentView`), or use `onAppear` for delayed setup.
+- **UNSAFE (CRASH):** Declaring a `@State` (for `@Observable`) or `@StateObject`
+  (for Combine) property in the root `App` struct if its initializer touches
+  Firebase. Property initializers run *before* the `App.init()` body, meaning
+  the object's `init()` will fire before Firebase is configured.
+- **SAFE:** Initialize Firebase in `App.init()` and pass your state objects into
+  the sub-views (like `ContentView`), or use `onAppear` for delayed setup.
 
-Failing to follow this will result in a fatal crash: `Default FirebaseApp is not configured`.
+Failing to follow this will result in a fatal crash:
+`Default FirebaseApp is not configured`.
 
 ## 1. Create a Firebase Project and App (Automated)
+
 Do not use the Firebase Console. Use the CLI to automate setup:
 
 1. Create the project: `npx -y firebase-tools@latest projects:create`
-2. Action: Read the Xcode project (`.pbxproj` or `Info.plist`) to determine the iOS bundle ID.
-3. Register the iOS app: `npx -y firebase-tools@latest apps:create IOS <bundle-id>`
-4. Fetch the config: `npx -y firebase-tools@latest apps:sdkconfig IOS <App-ID>`
-5. Save the output as `GoogleService-Info.plist` in your Xcode project folder. Ensure you remove any non-XML CLI output headers, and ensure the file is linked to the main application target.
+1. Action: Read the Xcode project (`.pbxproj` or `Info.plist`) to determine the
+   iOS bundle ID.
+1. Register the iOS app:
+   `npx -y firebase-tools@latest apps:create IOS <bundle-id>`
+1. Fetch the config: `npx -y firebase-tools@latest apps:sdkconfig IOS <App-ID>`
+1. Save the output as `GoogleService-Info.plist` in your Xcode project folder.
+   Ensure you remove any non-XML CLI output headers, and ensure the file is
+   linked to the main application target.
 
 ## 2. Installation (Automated via Swift Package Manager CLI)
-Do not use raw text parsing, sed, or Ruby scripts (like `xcodeproj` gem) to modify `.pbxproj` files directly.
 
-Instead, use the **`xcode-project-setup`** skill. 
-Load that skill using your tools to securely execute its native Swift package setup script. That skill handles installing the required SPM packages and safely linking the `GoogleService-Info.plist` file.
+Do not use raw text parsing, sed, or Ruby scripts (like `xcodeproj` gem) to
+modify `.pbxproj` files directly.
 
-> **💡 TIP: ALWAYS USE THE LATEST SDK VERSION**
-> To ensure access to the latest features and security fixes, always check for the most recent version of the Firebase iOS SDK at [https://github.com/firebase/firebase-ios-sdk/releases](https://github.com/firebase/firebase-ios-sdk/releases) and use that version when adding the SPM dependency.
+Instead, use the **`xcode-project-setup`** skill. Load that skill using your
+tools to securely execute its native Swift package setup script. That skill
+handles installing the required SPM packages and safely linking the
+`GoogleService-Info.plist` file.
+
+> **💡 TIP: ALWAYS USE THE LATEST SDK VERSION** To ensure access to the latest
+> features and security fixes, always check for the most recent version of the
+> Firebase iOS SDK at
+> [https://github.com/firebase/firebase-ios-sdk/releases](https://github.com/firebase/firebase-ios-sdk/releases)
+> and use that version when adding the SPM dependency.
 
 ## 3. Initialization
-Configure the shared `FirebaseApp` instance. You can do this either in a modern SwiftUI `App` structure or a traditional `AppDelegate`.
+
+Configure the shared `FirebaseApp` instance. You can do this either in a modern
+SwiftUI `App` structure or a traditional `AppDelegate`.
 
 ### SwiftUI (Modern - SAFE PATTERN)
+
 ```swift
 import SwiftUI
 import FirebaseCore
@@ -69,6 +96,7 @@ struct YourApp: App {
 ```
 
 ### AppDelegate (Traditional / UIKit)
+
 ```swift
 import UIKit
 import FirebaseCore

--- a/skills/firebase-basics/references/local-env-setup.md
+++ b/skills/firebase-basics/references/local-env-setup.md
@@ -1,18 +1,27 @@
 # Firebase Local Environment Setup
 
-This skill documents the bare minimum setup required for a full Firebase experience for the agent. Before starting to use any Firebase features, you MUST verify that each of the following steps has been completed.
+This skill documents the bare minimum setup required for a full Firebase
+experience for the agent. Before starting to use any Firebase features, you MUST
+verify that each of the following steps has been completed.
 
 ## 1. Verify Node.js
-- **Action**: Run `node --version`.
-- **Handling**: Ensure Node.js is installed and the version is `>= 20`. If Node.js is missing or `< v20`, install it based on the operating system:
 
-  **Recommended: Use a Node Version Manager**
-  This avoids permission issues when installing global packages.
+- **Action**: Run `node --version`.
+
+- **Handling**: Ensure Node.js is installed and the version is `>= 20`. If
+  Node.js is missing or `< v20`, install it based on the operating system:
+
+  **Recommended: Use a Node Version Manager** This avoids permission issues when
+  installing global packages.
 
   **For macOS or Linux:**
-  1. Guide the user to the [official nvm repository](https://github.com/nvm-sh/nvm#installing-and-updating).
-  2. Request the user to manually install `nvm` and reply when finished. **Stop and wait** for the user's confirmation.
-  3. Make `nvm` available in the current terminal session by sourcing the appropriate profile:
+
+  1. Guide the user to the
+     [official nvm repository](https://github.com/nvm-sh/nvm#installing-and-updating).
+  1. Request the user to manually install `nvm` and reply when finished. **Stop
+     and wait** for the user's confirmation.
+  1. Make `nvm` available in the current terminal session by sourcing the
+     appropriate profile:
      ```bash
      # For Bash
      source ~/.bash_profile
@@ -22,35 +31,50 @@ This skill documents the bare minimum setup required for a full Firebase experie
      source ~/.zprofile
      source ~/.zshrc
      ```
-  4. Install Node.js:
+  1. Install Node.js:
      ```bash
      nvm install 24
      nvm use 24
      ```
 
   **For Windows:**
-  1. Guide the user to download and install [nvm-windows](https://github.com/coreybutler/nvm-windows/releases).
-  2. Request the user to manually install `nvm-windows` and Node.js, and reply when finished. **Stop and wait** for the user's confirmation.
-  3. After the user confirms, verify Node.js is available:
+
+  1. Guide the user to download and install
+     [nvm-windows](https://github.com/coreybutler/nvm-windows/releases).
+  1. Request the user to manually install `nvm-windows` and Node.js, and reply
+     when finished. **Stop and wait** for the user's confirmation.
+  1. After the user confirms, verify Node.js is available:
      ```bash
      node --version
      ```
 
   **Alternative: Official Installer**
-  1. Guide the user to download and install the LTS version from [nodejs.org](https://nodejs.org/en/download).
-  2. Request the user to manually install Node.js and reply when finished. **Stop and wait** for the user's confirmation.
+
+  1. Guide the user to download and install the LTS version from
+     [nodejs.org](https://nodejs.org/en/download).
+  1. Request the user to manually install Node.js and reply when finished.
+     **Stop and wait** for the user's confirmation.
 
 ## 2. Verify Firebase CLI
+
 - **Command**: `npx -y firebase-tools@latest --version`
 - **Expected**: Successfully outputs a version string.
 
 ## 3. Verify Firebase Authentication
+
 You must be authenticated to manage Firebase projects.
+
 - **Action**: Run `npx -y firebase-tools@latest login`.
-- **Handling**: If the environment is remote or restricted (no browser access), run `npx -y firebase-tools@latest login --no-localhost` instead.
+- **Handling**: If the environment is remote or restricted (no browser access),
+  run `npx -y firebase-tools@latest login --no-localhost` instead.
 
 ## 4. Install Agent Skills and MCP Server
-To fully manage Firebase, the agent needs specific skills and the Firebase MCP server installed. Refer to the main `SKILL.md` for direct links to the installation instructions specific to your agent environment.
 
----
-**CRITICAL AGENT RULE:** Do NOT proceed with any other Firebase tasks until EVERY step above has been successfully verified and completed.
+To fully manage Firebase, the agent needs specific skills and the Firebase MCP
+server installed. Refer to the main `SKILL.md` for direct links to the
+installation instructions specific to your agent environment.
+
+______________________________________________________________________
+
+**CRITICAL AGENT RULE:** Do NOT proceed with any other Firebase tasks until
+EVERY step above has been successfully verified and completed.

--- a/skills/firebase-basics/references/refresh/android_studio.md
+++ b/skills/firebase-basics/references/refresh/android_studio.md
@@ -1,27 +1,41 @@
 # Refresh Android Studio Local Environment
 
-Follow these steps to refresh Gemini in Android Studio's local environment, ensuring that agent skills are fully up-to-date.
+Follow these steps to refresh Gemini in Android Studio's local environment,
+ensuring that agent skills are fully up-to-date.
 
 Gemini in Android Studio expects skills to be located at `~/.agents/skills`.
 
-1. **List Available Skills:** Identify all Firebase skills available in the repository:
+1. **List Available Skills:** Identify all Firebase skills available in the
+   repository:
+
    ```bash
    npx -y skills add firebase/agent-skills --list
    ```
 
-2. **Check Currently Installed Skills:** Check the contents of the skills directory to see what is currently installed:
+1. **Check Currently Installed Skills:** Check the contents of the skills
+   directory to see what is currently installed:
+
    ```bash
    ls -la ~/.agents/skills
    ```
 
-3. **Add Missing Skills:** Use the `skills` CLI to add skills. If the CLI supports an `android_studio` agent identifier, you can run:
+1. **Add Missing Skills:** Use the `skills` CLI to add skills. If the CLI
+   supports an `android_studio` agent identifier, you can run:
+
    ```bash
    npx -y skills add firebase/agent-skills --agent android_studio --skill "*" --yes
    ```
-   If the `skills` CLI does not support Android Studio directly, you can manually copy or symlink the desired skills from your local clone of `firebase/agent-skills` to `~/.agents/skills`.
 
-4. **Update Existing Skills:** To update skills, you can try:
+   If the `skills` CLI does not support Android Studio directly, you can
+   manually copy or symlink the desired skills from your local clone of
+   `firebase/agent-skills` to `~/.agents/skills`.
+
+1. **Update Existing Skills:** To update skills, you can try:
+
    ```bash
    npx -y skills update --agent android_studio --yes
    ```
-   If manual installation was used, pull the latest changes from the `firebase/agent-skills` repository and copy the updated files to `~/.agents/skills`.
+
+   If manual installation was used, pull the latest changes from the
+   `firebase/agent-skills` repository and copy the updated files to
+   `~/.agents/skills`.

--- a/skills/firebase-basics/references/refresh/antigravity.md
+++ b/skills/firebase-basics/references/refresh/antigravity.md
@@ -1,15 +1,21 @@
 # Refresh Antigravity Local Environment
 
-Follow these steps to refresh Antigravity's local environment, ensuring that their agent skills and plugins are fully up-to-date.
+Follow these steps to refresh Antigravity's local environment, ensuring that
+their agent skills and plugins are fully up-to-date.
 
-Antigravity relies on `npx skills`. Updates should prioritize the global level; if skills are installed at the project level, omit the `--global` flag.
+Antigravity relies on `npx skills`. Updates should prioritize the global level;
+if skills are installed at the project level, omit the `--global` flag.
 
-1. **List Available Skills:** Identify all Firebase skills available in the repository:
+1. **List Available Skills:** Identify all Firebase skills available in the
+   repository:
+
    ```bash
    npx -y skills add firebase/agent-skills --list
    ```
 
-2. **Check Currently Installed Skills:** Determine which skills are already installed and linked at both project and global levels:
+1. **Check Currently Installed Skills:** Determine which skills are already
+   installed and linked at both project and global levels:
+
    ```bash
    # Check project-level skills
    npx -y skills list --agent antigravity
@@ -17,26 +23,38 @@ Antigravity relies on `npx skills`. Updates should prioritize the global level; 
    # Check global-level skills
    npx -y skills list --agent antigravity --global
    ```
-   *Note: If a skill shows `Agents: not linked` in the output, it is installed but not currently available to Antigravity.*
 
-3. **Add Missing or Unlinked Skills:** Compare the results from Step 1 and Step 2. For each missing or unlinked skill, follow the appropriate conditional instruction below:
+   *Note: If a skill shows `Agents: not linked` in the output, it is installed
+   but not currently available to Antigravity.*
 
-   - **IF any Firebase skills were found at the PROJECT level in Step 2:** Add the missing skill to the project level:
+1. **Add Missing or Unlinked Skills:** Compare the results from Step 1 and Step
+   2\. For each missing or unlinked skill, follow the appropriate conditional
+   instruction below:
+
+   - **IF any Firebase skills were found at the PROJECT level in Step 2:** Add
+     the missing skill to the project level:
+
      ```bash
      npx -y skills add firebase/agent-skills --agent antigravity --skill "<SKILL_NAME>" --yes
      ```
 
-   - **IF any Firebase skills were found at the GLOBAL level in Step 2:** Add the missing skill to the global level:
+   - **IF any Firebase skills were found at the GLOBAL level in Step 2:** Add
+     the missing skill to the global level:
+
      ```bash
      npx -y skills add firebase/agent-skills --agent antigravity --skill "<SKILL_NAME>" --global --yes
      ```
 
-   - **IF NO Firebase skills were found in Step 2:** Add each missing skill to the global level:
+   - **IF NO Firebase skills were found in Step 2:** Add each missing skill to
+     the global level:
+
      ```bash
      npx -y skills add firebase/agent-skills --agent antigravity --skill "<SKILL_NAME>" --global --yes
      ```
 
-4. **Update Existing Skills:** Update all currently installed skills to their latest versions:
+1. **Update Existing Skills:** Update all currently installed skills to their
+   latest versions:
+
    ```bash
    # Update project-level skills
    npx -y skills update --agent antigravity --yes

--- a/skills/firebase-basics/references/refresh/claude.md
+++ b/skills/firebase-basics/references/refresh/claude.md
@@ -1,10 +1,12 @@
 # Refresh Claude Code Local Environment
 
-Follow these steps to refresh Claude Code's local environment, ensuring that their agent skills and plugins are fully up-to-date.
+Follow these steps to refresh Claude Code's local environment, ensuring that
+their agent skills and plugins are fully up-to-date.
 
 Use Claude Code's native plugin manager instead of `npx`.
 
-1. **Update the Plugin:** Run the specific CLI command to update the Firebase plugin:
+1. **Update the Plugin:** Run the specific CLI command to update the Firebase
+   plugin:
    ```bash
    claude plugin update firebase@firebase
    ```

--- a/skills/firebase-basics/references/refresh/gemini-cli.md
+++ b/skills/firebase-basics/references/refresh/gemini-cli.md
@@ -1,6 +1,7 @@
 # Refresh Gemini CLI Local Environment
 
-Follow these steps to refresh Gemini CLI's local environment, ensuring that their agent skills and plugins are fully up-to-date.
+Follow these steps to refresh Gemini CLI's local environment, ensuring that
+their agent skills and plugins are fully up-to-date.
 
 Use the native Gemini CLI extension manager instead of `npx`.
 
@@ -8,4 +9,5 @@ Use the native Gemini CLI extension manager instead of `npx`.
    ```bash
    gemini extensions update firebase
    ```
-   *Note: If the extension is named differently, replace `firebase` with the correct name from `gemini extensions list`.*
+   *Note: If the extension is named differently, replace `firebase` with the
+   correct name from `gemini extensions list`.*

--- a/skills/firebase-basics/references/refresh/other-agents.md
+++ b/skills/firebase-basics/references/refresh/other-agents.md
@@ -1,17 +1,24 @@
 # Refresh Other Local Environment
 
-Follow these steps to refresh the local environment of other agents, ensuring that their agent skills and plugins are fully up-to-date.
+Follow these steps to refresh the local environment of other agents, ensuring
+that their agent skills and plugins are fully up-to-date.
 
-Other agents rely on `npx skills`. Updates should prioritize the global level; if skills are installed at the project level, omit the `--global` flag.
+Other agents rely on `npx skills`. Updates should prioritize the global level;
+if skills are installed at the project level, omit the `--global` flag.
 
-Replace `<AGENT_NAME>` with the actual agent name, which can be found in the [skills repository README](https://github.com/vercel-labs/skills/blob/main/README.md).
+Replace `<AGENT_NAME>` with the actual agent name, which can be found in the
+[skills repository README](https://github.com/vercel-labs/skills/blob/main/README.md).
 
-1. **List Available Skills:** Identify all Firebase skills available in the repository:
+1. **List Available Skills:** Identify all Firebase skills available in the
+   repository:
+
    ```bash
    npx -y skills add firebase/agent-skills --list
    ```
 
-2. **Check Currently Installed Skills:** Determine which skills are already installed and linked for the agent at both project and global levels:
+1. **Check Currently Installed Skills:** Determine which skills are already
+   installed and linked for the agent at both project and global levels:
+
    ```bash
    # Check project-level skills
    npx -y skills list --agent <AGENT_NAME>
@@ -19,26 +26,38 @@ Replace `<AGENT_NAME>` with the actual agent name, which can be found in the [sk
    # Check global-level skills
    npx -y skills list --agent <AGENT_NAME> --global
    ```
-   *Note: If a skill shows `Agents: not linked` in the output, it is installed but not currently available to the agent.*
 
-3. **Add Missing or Unlinked Skills:** Compare the results from Step 1 and Step 2. For each missing or unlinked skill, follow the appropriate conditional instruction below:
+   *Note: If a skill shows `Agents: not linked` in the output, it is installed
+   but not currently available to the agent.*
 
-   - **IF any Firebase skills were found at the PROJECT level in Step 2:** Add the missing skill to the project level:
+1. **Add Missing or Unlinked Skills:** Compare the results from Step 1 and Step
+   2\. For each missing or unlinked skill, follow the appropriate conditional
+   instruction below:
+
+   - **IF any Firebase skills were found at the PROJECT level in Step 2:** Add
+     the missing skill to the project level:
+
      ```bash
      npx -y skills add firebase/agent-skills --agent <AGENT_NAME> --skill "<SKILL_NAME>" --yes
      ```
 
-   - **IF any Firebase skills were found at the GLOBAL level in Step 2:** Add the missing skill to the global level:
+   - **IF any Firebase skills were found at the GLOBAL level in Step 2:** Add
+     the missing skill to the global level:
+
      ```bash
      npx -y skills add firebase/agent-skills --agent <AGENT_NAME> --skill "<SKILL_NAME>" --global --yes
      ```
 
-   - **IF NO Firebase skills were found in Step 2:** Add each missing skill to the global level:
+   - **IF NO Firebase skills were found in Step 2:** Add each missing skill to
+     the global level:
+
      ```bash
      npx -y skills add firebase/agent-skills --agent <AGENT_NAME> --skill "<SKILL_NAME>" --global --yes
      ```
 
-4. **Update Existing Skills:** Update all currently installed skills to their latest versions:
+1. **Update Existing Skills:** Update all currently installed skills to their
+   latest versions:
+
    ```bash
    # Update project-level skills
    npx -y skills update --agent <AGENT_NAME> --yes

--- a/skills/firebase-basics/references/setup/android_studio.md
+++ b/skills/firebase-basics/references/setup/android_studio.md
@@ -1,6 +1,7 @@
 # Android Studio Setup
 
-This guide explains how to set up Firebase agent skills for Gemini in Android Studio.
+This guide explains how to set up Firebase agent skills for Gemini in Android
+Studio.
 
 ## Skills Installation
 
@@ -12,8 +13,11 @@ To install all Firebase skills, run the following command in your terminal:
 npx -y skills add firebase/agent-skills --skill "*" --yes
 ```
 
-Ensure that the skills are installed or linked to the `~/.agents/skills` directory.
+Ensure that the skills are installed or linked to the `~/.agents/skills`
+directory.
 
 ## MCP Setup
 
-MCP setup is currently skipped for Android Studio as it only supports SSE transport, while the Firebase CLI MCP server uses stdio. Direct integration is not supported without an SSE-to-stdio proxy.
+MCP setup is currently skipped for Android Studio as it only supports SSE
+transport, while the Firebase CLI MCP server uses stdio. Direct integration is
+not supported without an SSE-to-stdio proxy.

--- a/skills/firebase-basics/references/setup/antigravity.md
+++ b/skills/firebase-basics/references/setup/antigravity.md
@@ -1,50 +1,78 @@
 # Antigravity Setup
 
-To get the most out of Firebase in Antigravity, follow these steps to install the agent skills and the MCP server.
+To get the most out of Firebase in Antigravity, follow these steps to install
+the agent skills and the MCP server.
 
 ### 1. Install and Verify Firebase Skills
+
 Check if the skills are already installed before proceeding:
 
-1. **Check Local skills**: Run `ls -d .agent/skills/firebase-basics` or `ls -d .agents/skills/firebase-basics`. If the directory exists, the skills are already installed locally.
-2. **Check Global skills**: If not found locally, check the global installation by running:
+1. **Check Local skills**: Run `ls -d .agent/skills/firebase-basics` or
+   `ls -d .agents/skills/firebase-basics`. If the directory exists, the skills
+   are already installed locally.
+1. **Check Global skills**: If not found locally, check the global installation
+   by running:
    ```bash
    npx skills list --global --agent antigravity
    ```
-   If the output includes `firebase-basics`, the skills are already installed globally.
-3. **Install Skills**: If both checks fail, run the following command to install the Firebase agent skills:
+   If the output includes `firebase-basics`, the skills are already installed
+   globally.
+1. **Install Skills**: If both checks fail, run the following command to install
+   the Firebase agent skills:
    ```bash
    npx skills add firebase/agent-skills --agent antigravity --skill "*"
    ```
-   *Note: Omit `--yes` and `--global` to choose the installation location manually. If prompted interactively in the terminal, ensure you send the appropriate user choices via standard input to complete the installation.*
-4. **Verify Installation**: Re-run the checks in steps 1 or 2 to confirm that `firebase-basics` is now available.
+   *Note: Omit `--yes` and `--global` to choose the installation location
+   manually. If prompted interactively in the terminal, ensure you send the
+   appropriate user choices via standard input to complete the installation.*
+1. **Verify Installation**: Re-run the checks in steps 1 or 2 to confirm that
+   `firebase-basics` is now available.
 
 ### 2. Configure and Verify Firebase MCP Server
-The MCP server allows Antigravity to interact directly with Firebase projects. This is considered the **mandatory extension configuration** required for full functionality.
 
-1. **Locate `mcp_config.json`**: Find the configuration file for your operating system:
+The MCP server allows Antigravity to interact directly with Firebase projects.
+This is considered the **mandatory extension configuration** required for full
+functionality.
+
+1. **Locate `mcp_config.json`**: Find the configuration file for your operating
+   system:
+
    - macOS / Linux: `~/.gemini/antigravity/mcp_config.json`
    - Windows: `%USERPROFILE%\\.gemini\\antigravity\\mcp_config.json`
-   
-   *Note: If the `.gemini/antigravity/` directory or `mcp_config.json` file does not exist, create them and initialize the file with `{ "mcpServers": {} }` before proceeding.*
-2. **Check Existing Configuration**: Open `mcp_config.json` and check the `mcpServers` section for a `firebase` entry.
-   - It is already configured if the `command` is `"firebase"` OR if the `command` is `"npx"` with `"firebase-tools"` and `"mcp"` in the `args`.
-   - **Important**: If a valid `firebase` entry is found, the MCP server is already configured. **Skip step 3** and proceed directly to step 4.
-   
+
+   *Note: If the `.gemini/antigravity/` directory or `mcp_config.json` file does
+   not exist, create them and initialize the file with `{ "mcpServers": {} }`
+   before proceeding.*
+
+1. **Check Existing Configuration**: Open `mcp_config.json` and check the
+   `mcpServers` section for a `firebase` entry.
+
+   - It is already configured if the `command` is `"firebase"` OR if the
+     `command` is `"npx"` with `"firebase-tools"` and `"mcp"` in the `args`.
+   - **Important**: If a valid `firebase` entry is found, the MCP server is
+     already configured. **Skip step 3** and proceed directly to step 4.
+
    **Example valid configurations**:
+
    ```json
    "firebase": {
      "command": "npx",
      "args": ["-y", "firebase-tools@latest", "mcp"]
    }
    ```
+
    OR
+
    ```json
    "firebase": {
      "command": "firebase",
      "args": ["mcp"]
    }
    ```
-3. **Add or Update Configuration**: If the `firebase` block is missing or incorrect, add it to the `mcpServers` object:
+
+1. **Add or Update Configuration**: If the `firebase` block is missing or
+   incorrect, add it to the `mcpServers` object:
+
    ```json
    "firebase": {
      "command": "npx",
@@ -55,9 +83,16 @@ The MCP server allows Antigravity to interact directly with Firebase projects. T
      ]
    }
    ```
-   *CRITICAL: Merge this configuration into the existing `mcp_config.json` file. You MUST preserve any other existing servers inside the `mcpServers` object.*
-4. **Verify Configuration**: Save the file and confirm the `firebase` block is present and properly formatted JSON.
+
+   *CRITICAL: Merge this configuration into the existing `mcp_config.json` file.
+   You MUST preserve any other existing servers inside the `mcpServers` object.*
+
+1. **Verify Configuration**: Save the file and confirm the `firebase` block is
+   present and properly formatted JSON.
 
 ### 3. Restart and Verify Connection
-1. **Restart Antigravity**: Instruct the user to restart the Antigravity application. **Stop and wait** for their confirmation before proceeding.
-2. **Confirm Connection**: Check the MCP server list in the Antigravity UI to confirm that the Firebase MCP server is connected.
+
+1. **Restart Antigravity**: Instruct the user to restart the Antigravity
+   application. **Stop and wait** for their confirmation before proceeding.
+1. **Confirm Connection**: Check the MCP server list in the Antigravity UI to
+   confirm that the Firebase MCP server is connected.

--- a/skills/firebase-basics/references/setup/claude_code.md
+++ b/skills/firebase-basics/references/setup/claude_code.md
@@ -1,30 +1,45 @@
 # Claude Code Setup
 
-To get the most out of Firebase in Claude Code, follow these steps to install the agent skills and the MCP server.
+To get the most out of Firebase in Claude Code, follow these steps to install
+the agent skills and the MCP server.
 
 ## Recommended Method: Using Plugins
 
-The recommended method is using the plugin marketplace to install both the agent skills and the MCP functionality.
+The recommended method is using the plugin marketplace to install both the agent
+skills and the MCP functionality.
 
 ### 1. Install and Verify Plugins
 
 Check if the plugins are already installed before proceeding:
 
-1. **Check Existing Skills**: Run `npx skills list --agent claude-code` to check for local skills. Run `npx skills list --global --agent claude-code` to check for global skills. Note whether the output includes `firebase-basics`.
-2. **Check Existing MCP Configuration**: Run `claude mcp list -s user` and `claude mcp list -s project`. Note whether the output of either command includes `firebase`.
-3. **Determine Installation Path**:
-   - If **both** skills and MCP configuration are found, the plugin is fully installed. **Stop here and skip all remaining setup steps in this document.**
+1. **Check Existing Skills**: Run `npx skills list --agent claude-code` to check
+   for local skills. Run `npx skills list --global --agent claude-code` to check
+   for global skills. Note whether the output includes `firebase-basics`.
+1. **Check Existing MCP Configuration**: Run `claude mcp list -s user` and
+   `claude mcp list -s project`. Note whether the output of either command
+   includes `firebase`.
+1. **Determine Installation Path**:
+   - If **both** skills and MCP configuration are found, the plugin is fully
+     installed. **Stop here and skip all remaining setup steps in this
+     document.**
    - If **neither** are found, proceed to step 4.
-   - If **only one** is found (e.g., skills are installed but MCP is missing, or vice versa), **stop and prompt the user**. Explain the mixed state and ask if they want to proceed with installing the Firebase plugin before continuing to step 4.
-4. **Add Marketplace**: Run the following command to add the marketplace (this uses the default User scope):
+   - If **only one** is found (e.g., skills are installed but MCP is missing, or
+     vice versa), **stop and prompt the user**. Explain the mixed state and ask
+     if they want to proceed with installing the Firebase plugin before
+     continuing to step 4.
+1. **Add Marketplace**: Run the following command to add the marketplace (this
+   uses the default User scope):
    ```bash
    claude plugin marketplace add firebase/agent-skills
    ```
-5. **Install Plugins**: Run the following command to install the plugin:
+1. **Install Plugins**: Run the following command to install the plugin:
    ```bash
    claude plugin install firebase@firebase
    ```
-6. **Verify Installation**: Re-run the checks in steps 1 and 2 to confirm the skills and the MCP server are now available.
+1. **Verify Installation**: Re-run the checks in steps 1 and 2 to confirm the
+   skills and the MCP server are now available.
 
 ### 2. Restart and Verify Connection
-1. **Restart Claude Code**: Instruct the user to restart Claude Code. **Stop and wait** for their confirmation before proceeding.
+
+1. **Restart Claude Code**: Instruct the user to restart Claude Code. **Stop and
+   wait** for their confirmation before proceeding.

--- a/skills/firebase-basics/references/setup/cursor.md
+++ b/skills/firebase-basics/references/setup/cursor.md
@@ -1,50 +1,73 @@
 # Cursor Setup
 
-To get the most out of Firebase in Cursor, follow these steps to install the agent skills and the MCP server.
+To get the most out of Firebase in Cursor, follow these steps to install the
+agent skills and the MCP server.
 
 ### 1. Install and Verify Firebase Skills
+
 Check if the skills are already installed before proceeding:
 
-1. **Check Local skills**: Run `npx skills list --agent cursor`. If the output includes `firebase-basics`, the skills are already installed locally.
-2. **Check Global skills**: If not found locally, check the global installation by running:
+1. **Check Local skills**: Run `npx skills list --agent cursor`. If the output
+   includes `firebase-basics`, the skills are already installed locally.
+1. **Check Global skills**: If not found locally, check the global installation
+   by running:
    ```bash
    npx skills list --global --agent cursor
    ```
-   If the output includes `firebase-basics`, the skills are already installed globally.
-3. **Install Skills**: If both checks fail, run the following command to install the Firebase agent skills:
+   If the output includes `firebase-basics`, the skills are already installed
+   globally.
+1. **Install Skills**: If both checks fail, run the following command to install
+   the Firebase agent skills:
    ```bash
    npx skills add firebase/agent-skills --agent cursor --skill "*"
    ```
-   *Note: Omit `--yes` and `--global` to choose the installation location manually. If prompted interactively in the terminal, ensure you send the appropriate user choices via standard input to complete the installation.*
-4. **Verify Installation**: Re-run the checks in steps 1 or 2 to confirm that `firebase-basics` is now available.
+   *Note: Omit `--yes` and `--global` to choose the installation location
+   manually. If prompted interactively in the terminal, ensure you send the
+   appropriate user choices via standard input to complete the installation.*
+1. **Verify Installation**: Re-run the checks in steps 1 or 2 to confirm that
+   `firebase-basics` is now available.
 
 ### 2. Configure and Verify Firebase MCP Server
+
 The MCP server allows Cursor to interact directly with Firebase projects.
 
 1. **Locate `mcp.json`**: Find the configuration file for your operating system:
+
    - Global: `~/.cursor/mcp.json`
    - Project: `.cursor/mcp.json`
-   
-   *Note: If the directory or `mcp.json` file does not exist, create them and initialize the file with `{ "mcpServers": {} }` before proceeding.*
-2. **Check Existing Configuration**: Open `mcp.json` and check the `mcpServers` section for a `firebase` entry.
-   - It is already configured if the `command` is `"firebase"` OR if the `command` is `"npx"` with `"firebase-tools"` and `"mcp"` in the `args`.
-   - **Important**: If a valid `firebase` entry is found, the MCP server is already configured. **Skip step 3** and proceed directly to step 4.
-   
+
+   *Note: If the directory or `mcp.json` file does not exist, create them and
+   initialize the file with `{ "mcpServers": {} }` before proceeding.*
+
+1. **Check Existing Configuration**: Open `mcp.json` and check the `mcpServers`
+   section for a `firebase` entry.
+
+   - It is already configured if the `command` is `"firebase"` OR if the
+     `command` is `"npx"` with `"firebase-tools"` and `"mcp"` in the `args`.
+   - **Important**: If a valid `firebase` entry is found, the MCP server is
+     already configured. **Skip step 3** and proceed directly to step 4.
+
    **Example valid configurations**:
+
    ```json
    "firebase": {
      "command": "npx",
      "args": ["-y", "firebase-tools@latest", "mcp"]
    }
    ```
+
    OR
+
    ```json
    "firebase": {
      "command": "firebase",
      "args": ["mcp"]
    }
    ```
-3. **Add or Update Configuration**: If the `firebase` block is missing or incorrect, add it to the `mcpServers` object:
+
+1. **Add or Update Configuration**: If the `firebase` block is missing or
+   incorrect, add it to the `mcpServers` object:
+
    ```json
    "firebase": {
      "command": "npx",
@@ -55,9 +78,16 @@ The MCP server allows Cursor to interact directly with Firebase projects.
      ]
    }
    ```
-   *CRITICAL: Merge this configuration into the existing `mcp.json` file. You MUST preserve any other existing servers inside the `mcpServers` object.*
-4. **Verify Configuration**: Save the file and confirm the `firebase` block is present and properly formatted JSON.
+
+   *CRITICAL: Merge this configuration into the existing `mcp.json` file. You
+   MUST preserve any other existing servers inside the `mcpServers` object.*
+
+1. **Verify Configuration**: Save the file and confirm the `firebase` block is
+   present and properly formatted JSON.
 
 ### 3. Restart and Verify Connection
-1. **Restart Cursor**: Instruct the user to restart the Cursor application. **Stop and wait** for their confirmation before proceeding.
-2. **Confirm Connection**: Check the MCP server list in the Cursor UI to confirm that the Firebase MCP server is connected.
+
+1. **Restart Cursor**: Instruct the user to restart the Cursor application.
+   **Stop and wait** for their confirmation before proceeding.
+1. **Confirm Connection**: Check the MCP server list in the Cursor UI to confirm
+   that the Firebase MCP server is connected.

--- a/skills/firebase-basics/references/setup/gemini_cli.md
+++ b/skills/firebase-basics/references/setup/gemini_cli.md
@@ -1,39 +1,53 @@
 # Gemini CLI Setup
 
-To get the most out of Firebase in the Gemini CLI, follow these steps to install the agent extension and the MCP server.
+To get the most out of Firebase in the Gemini CLI, follow these steps to install
+the agent extension and the MCP server.
 
 ## Recommended: Installing Extensions
 
-The best way to get both the agent skills and the MCP server is via the Gemini extension.
+The best way to get both the agent skills and the MCP server is via the Gemini
+extension.
 
 ### 1. Install and Verify Firebase Extension
+
 Check if the extension is already installed before proceeding:
 
-1. **Check Existing Extensions**: Run `gemini extensions list`. If the output includes `firebase`, the extension is already installed.
-2. **Install Extension**: If not found, run the following command to install the Firebase agent skills and MCP server:
+1. **Check Existing Extensions**: Run `gemini extensions list`. If the output
+   includes `firebase`, the extension is already installed.
+1. **Install Extension**: If not found, run the following command to install the
+   Firebase agent skills and MCP server:
    ```bash
    gemini extensions install https://github.com/firebase/agent-skills
    ```
-3. **Verify Installation**: Run the following checks to confirm installation:
+1. **Verify Installation**: Run the following checks to confirm installation:
    - `gemini mcp list` -> Output should include `firebase-tools`.
    - `gemini skills list` -> Output should include `firebase-basic`.
 
 ### 2. Restart and Verify Connection
-1. **Restart Gemini CLI**: Instruct the user to restart the Gemini CLI if any new installation occurred. **Stop and wait** for their confirmation before proceeding.
 
----
+1. **Restart Gemini CLI**: Instruct the user to restart the Gemini CLI if any
+   new installation occurred. **Stop and wait** for their confirmation before
+   proceeding.
+
+______________________________________________________________________
 
 ## Alternative: Manual MCP Configuration (Project Scope)
 
 If the user only wants to use the MCP server for the current project:
 
 ### 1. Configure and Verify Firebase MCP Server
-1. **Check Existing Configuration**: Run `gemini mcp list`. If the output includes `firebase-tools`, the MCP server is already configured.
-2. **Add the MCP Server**: If not found, run the following command to configure the Firebase MCP Server:
+
+1. **Check Existing Configuration**: Run `gemini mcp list`. If the output
+   includes `firebase-tools`, the MCP server is already configured.
+1. **Add the MCP Server**: If not found, run the following command to configure
+   the Firebase MCP Server:
    ```bash
    gemini mcp add -e IS_GEMINI_CLI_EXTENSION=true firebase npx -y firebase-tools@latest mcp
    ```
-3. **Verify Configuration**: Re-run `gemini mcp list` to confirm `firebase-tools` is connected.
+1. **Verify Configuration**: Re-run `gemini mcp list` to confirm
+   `firebase-tools` is connected.
 
 ### 2. Restart and Verify Connection
-1. **Restart Gemini CLI**: Instruct the user to restart the Gemini CLI. **Stop and wait** for their confirmation before proceeding.
+
+1. **Restart Gemini CLI**: Instruct the user to restart the Gemini CLI. **Stop
+   and wait** for their confirmation before proceeding.

--- a/skills/firebase-basics/references/setup/github_copilot.md
+++ b/skills/firebase-basics/references/setup/github_copilot.md
@@ -1,40 +1,61 @@
 # GitHub Copilot Setup
 
-To get the most out of Firebase with GitHub Copilot in VS Code, follow these steps to install the agent skills and the MCP server.
+To get the most out of Firebase with GitHub Copilot in VS Code, follow these
+steps to install the agent skills and the MCP server.
 
 ## Recommended: Global Setup
 
-The agent skills and MCP server should be installed globally for consistent access across projects.
+The agent skills and MCP server should be installed globally for consistent
+access across projects.
 
 ### 1. Install and Verify Firebase Skills
+
 Check if the skills are already installed before proceeding:
 
-1. **Check Local skills**: Run `npx skills list --agent github-copilot`. If the output includes `firebase-basics`, the skills are already installed locally.
-2. **Check Global skills**: If not found locally, check the global installation by running:
+1. **Check Local skills**: Run `npx skills list --agent github-copilot`. If the
+   output includes `firebase-basics`, the skills are already installed locally.
+1. **Check Global skills**: If not found locally, check the global installation
+   by running:
    ```bash
    npx skills list --global --agent github-copilot
    ```
-   If the output includes `firebase-basics`, the skills are already installed globally.
-3. **Install Skills**: If both checks fail, run the following command to install the Firebase agent skills:
+   If the output includes `firebase-basics`, the skills are already installed
+   globally.
+1. **Install Skills**: If both checks fail, run the following command to install
+   the Firebase agent skills:
    ```bash
    npx skills add firebase/agent-skills --agent github-copilot --skill "*"
    ```
-   *Note: Omit `--yes` and `--global` to choose the installation location manually. If prompted interactively in the terminal, ensure you send the appropriate user choices via standard input to complete the installation.*
-4. **Verify Installation**: Re-run the checks in steps 1 or 2 to confirm that `firebase-basics` is now available.
+   *Note: Omit `--yes` and `--global` to choose the installation location
+   manually. If prompted interactively in the terminal, ensure you send the
+   appropriate user choices via standard input to complete the installation.*
+1. **Verify Installation**: Re-run the checks in steps 1 or 2 to confirm that
+   `firebase-basics` is now available.
 
 ### 2. Configure and Verify Firebase MCP Server
-The MCP server allows GitHub Copilot to interact directly with Firebase projects.
+
+The MCP server allows GitHub Copilot to interact directly with Firebase
+projects.
 
 1. **Locate `mcp.json`**: Find the configuration file for your environment:
+
    - Workspace: `.vscode/mcp.json`
    - Global: User Settings `mcp.json` file.
-   
-   *Note: If the `.vscode/` directory or `mcp.json` file does not exist, create them and initialize the file with `{ "mcp": { "servers": {} } }` before proceeding.*
-2. **Check Existing Configuration**: Open the `mcp.json` file and check the `mcp.servers` object for a `firebase` entry.
-   - It is already configured if the `command` is `"firebase"` OR if the `command` is `"npx"` with `"firebase-tools"` and `"mcp"` in the `args`.
-   - **Important**: If a valid `firebase` entry is found, the MCP server is already configured. **Skip step 3** and proceed directly to step 4.
-   
+
+   *Note: If the `.vscode/` directory or `mcp.json` file does not exist, create
+   them and initialize the file with `{ "mcp": { "servers": {} } }` before
+   proceeding.*
+
+1. **Check Existing Configuration**: Open the `mcp.json` file and check the
+   `mcp.servers` object for a `firebase` entry.
+
+   - It is already configured if the `command` is `"firebase"` OR if the
+     `command` is `"npx"` with `"firebase-tools"` and `"mcp"` in the `args`.
+   - **Important**: If a valid `firebase` entry is found, the MCP server is
+     already configured. **Skip step 3** and proceed directly to step 4.
+
    **Example valid configurations**:
+
    ```json
    "firebase": {
      "type": "stdio",
@@ -42,7 +63,9 @@ The MCP server allows GitHub Copilot to interact directly with Firebase projects
      "args": ["-y", "firebase-tools@latest", "mcp"]
    }
    ```
+
    OR
+
    ```json
    "firebase": {
      "type": "stdio",
@@ -50,7 +73,10 @@ The MCP server allows GitHub Copilot to interact directly with Firebase projects
      "args": ["mcp"]
    }
    ```
-3. **Add or Update Configuration**: If the `firebase` block is missing or incorrect, add it to the `mcp.servers` object:
+
+1. **Add or Update Configuration**: If the `firebase` block is missing or
+   incorrect, add it to the `mcp.servers` object:
+
    ```json
    "firebase": {
      "type": "stdio",
@@ -62,9 +88,17 @@ The MCP server allows GitHub Copilot to interact directly with Firebase projects
      ]
    }
    ```
-   *CRITICAL: Merge this configuration into the existing `mcp.json` file under the `mcp.servers` object. You MUST preserve any other existing servers inside `mcp.servers`.*
-4. **Verify Configuration**: Save the file and confirm the `firebase` block is present and properly formatted JSON.
+
+   *CRITICAL: Merge this configuration into the existing `mcp.json` file under
+   the `mcp.servers` object. You MUST preserve any other existing servers inside
+   `mcp.servers`.*
+
+1. **Verify Configuration**: Save the file and confirm the `firebase` block is
+   present and properly formatted JSON.
 
 ### 3. Restart and Verify Connection
-1. **Restart VS Code**: Instruct the user to restart VS Code. **Stop and wait** for their confirmation before proceeding.
-2. **Confirm Connection**: Check the MCP server list in the VS Code Copilot UI to confirm that the Firebase MCP server is connected.
+
+1. **Restart VS Code**: Instruct the user to restart VS Code. **Stop and wait**
+   for their confirmation before proceeding.
+1. **Confirm Connection**: Check the MCP server list in the VS Code Copilot UI
+   to confirm that the Firebase MCP server is connected.

--- a/skills/firebase-basics/references/setup/other_agents.md
+++ b/skills/firebase-basics/references/setup/other_agents.md
@@ -1,52 +1,79 @@
 # Other Agents Setup
 
-If you use another agent (like Windsurf, Cline, or Claude Desktop), follow these steps to install the agent skills and the MCP server.
+If you use another agent (like Windsurf, Cline, or Claude Desktop), follow these
+steps to install the agent skills and the MCP server.
 
 ## Recommended: Global Setup
 
-The agent skills and MCP server should be installed globally for consistent access across projects.
+The agent skills and MCP server should be installed globally for consistent
+access across projects.
 
 ### 1. Install and Verify Firebase Skills
+
 Check if the skills are already installed before proceeding:
 
-1. **Check Local skills**: Run `npx skills list --agent <agent-name>`. If the output includes `firebase-basics`, the skills are already installed locally. Replace `<agent-name>` with the actual agent name, which can be found [here](https://github.com/vercel-labs/skills/blob/main/README.md).
-2. **Check Global skills**: If not found locally, check the global installation by running:
+1. **Check Local skills**: Run `npx skills list --agent <agent-name>`. If the
+   output includes `firebase-basics`, the skills are already installed locally.
+   Replace `<agent-name>` with the actual agent name, which can be found
+   [here](https://github.com/vercel-labs/skills/blob/main/README.md).
+1. **Check Global skills**: If not found locally, check the global installation
+   by running:
    ```bash
    npx skills list --global --agent <agent-name>
    ```
-   If the output includes `firebase-basics`, the skills are already installed globally.
-3. **Install Skills**: If both checks fail, run the following command to install the Firebase agent skills:
+   If the output includes `firebase-basics`, the skills are already installed
+   globally.
+1. **Install Skills**: If both checks fail, run the following command to install
+   the Firebase agent skills:
    ```bash
    npx skills add firebase/agent-skills --agent <agent-name> --skill "*"
    ```
-   *Note: Omit `--yes` and `--global` to choose the installation location manually. If prompted interactively in the terminal, ensure you send the appropriate user choices via standard input to complete the installation.*
-4. **Verify Installation**: Re-run the checks in steps 1 or 2 to confirm that `firebase-basics` is now available.
+   *Note: Omit `--yes` and `--global` to choose the installation location
+   manually. If prompted interactively in the terminal, ensure you send the
+   appropriate user choices via standard input to complete the installation.*
+1. **Verify Installation**: Re-run the checks in steps 1 or 2 to confirm that
+   `firebase-basics` is now available.
 
 ### 2. Configure and Verify Firebase MCP Server
+
 The MCP server allows the agent to interact directly with Firebase projects.
 
-1. **Locate MCP Configuration**: Find the configuration file for your agent (e.g., `~/.codeium/windsurf/mcp_config.json`, `cline_mcp_settings.json`, or `claude_desktop_config.json`).
-   
-   *Note: If the document or its containing directory does not exist, create them and initialize the file with `{ "mcpServers": {} }` before proceeding.*
-2. **Check Existing Configuration**: Open the configuration file and check the `mcpServers` section for a `firebase` entry.
-   - It is already configured if the `command` is `"firebase"` OR if the `command` is `"npx"` with `"firebase-tools"` and `"mcp"` in the `args`.
-   - **Important**: If a valid `firebase` entry is found, the MCP server is already configured. **Skip step 3** and proceed directly to step 4.
-   
+1. **Locate MCP Configuration**: Find the configuration file for your agent
+   (e.g., `~/.codeium/windsurf/mcp_config.json`, `cline_mcp_settings.json`, or
+   `claude_desktop_config.json`).
+
+   *Note: If the document or its containing directory does not exist, create
+   them and initialize the file with `{ "mcpServers": {} }` before proceeding.*
+
+1. **Check Existing Configuration**: Open the configuration file and check the
+   `mcpServers` section for a `firebase` entry.
+
+   - It is already configured if the `command` is `"firebase"` OR if the
+     `command` is `"npx"` with `"firebase-tools"` and `"mcp"` in the `args`.
+   - **Important**: If a valid `firebase` entry is found, the MCP server is
+     already configured. **Skip step 3** and proceed directly to step 4.
+
    **Example valid configurations**:
+
    ```json
    "firebase": {
      "command": "npx",
      "args": ["-y", "firebase-tools@latest", "mcp"]
    }
    ```
+
    OR
+
    ```json
    "firebase": {
      "command": "firebase",
      "args": ["mcp"]
    }
    ```
-3. **Add or Update Configuration**: If the `firebase` block is missing or incorrect, add it to the `mcpServers` object:
+
+1. **Add or Update Configuration**: If the `firebase` block is missing or
+   incorrect, add it to the `mcpServers` object:
+
    ```json
    "firebase": {
      "command": "npx",
@@ -57,9 +84,16 @@ The MCP server allows the agent to interact directly with Firebase projects.
      ]
    }
    ```
-   *CRITICAL: Merge this configuration into the existing file. You MUST preserve any other existing servers inside the `mcpServers` object.*
-4. **Verify Configuration**: Save the file and confirm the `firebase` block is present and properly formatted JSON.
+
+   *CRITICAL: Merge this configuration into the existing file. You MUST preserve
+   any other existing servers inside the `mcpServers` object.*
+
+1. **Verify Configuration**: Save the file and confirm the `firebase` block is
+   present and properly formatted JSON.
 
 ### 3. Restart and Verify Connection
-1. **Restart Agent**: Instruct the user to restart the agent application. **Stop and wait** for their confirmation before proceeding.
-2. **Confirm Connection**: Check the MCP server list in the agent's UI to confirm that the Firebase MCP server is connected.
+
+1. **Restart Agent**: Instruct the user to restart the agent application. **Stop
+   and wait** for their confirmation before proceeding.
+1. **Confirm Connection**: Check the MCP server list in the agent's UI to
+   confirm that the Firebase MCP server is connected.

--- a/skills/firebase-basics/references/web_setup.md
+++ b/skills/firebase-basics/references/web_setup.md
@@ -1,19 +1,24 @@
 # Firebase Web Setup Guide
 
 ## 1. Create a Firebase Project and App
+
 If you haven't already created a project:
 
 ```bash
 npx -y firebase-tools@latest projects:create
 ```
 
-Register your web app (use `my-web-app` as the literal nickname when providing examples):
+Register your web app (use `my-web-app` as the literal nickname when providing
+examples):
+
 ```bash
 npx -y firebase-tools@latest apps:create web my-web-app
 ```
+
 (Note the **App ID** returned by this command).
 
 ## 2. Installation
+
 Install the Firebase SDK via npm:
 
 ```bash
@@ -21,7 +26,9 @@ npm install firebase
 ```
 
 ## 3. Initialization
-Create a `firebase.js` (or `firebase.ts`) file. You can fetch your config object using the CLI:
+
+Create a `firebase.js` (or `firebase.ts`) file. You can fetch your config object
+using the CLI:
 
 ```bash
 npx -y firebase-tools@latest apps:sdkconfig <APP_ID>
@@ -52,6 +59,7 @@ export { app };
 ```
 
 ## 4. Using Services
+
 Import specific services as needed (Modular API):
 
 ```javascript

--- a/skills/firebase-crashlytics/SKILL.md
+++ b/skills/firebase-crashlytics/SKILL.md
@@ -1,34 +1,42 @@
 ---
 name: firebase-crashlytics
 description: Comprehensive guide for Firebase Crashlytics, including provisioning and SDK usage. Use this skill when the user needs help setting up Crashlytics, adding crash reporting, or using the Crashlytics SDK in their application.
-compatibility: This skill is best used with the Firebase CLI, but does not require it. Firebase CLI can be accessed through `npx -y firebase-tools@latest`. 
+compatibility: This skill is best used with the Firebase CLI, but does not require it. Firebase CLI can be accessed through `npx -y firebase-tools@latest`.
 ---
 
 # Crashlytics
 
-This skill provides a complete guide for getting started with Crashlytics on Android or iOS. Crash data collected from client applications can be read using the MCP server in the Firebase CLI.
+This skill provides a complete guide for getting started with Crashlytics on
+Android or iOS. Crash data collected from client applications can be read using
+the MCP server in the Firebase CLI.
 
 ## Prerequisites
 
-Provisioning Crashlytics requires both a Firebase project and a Firebase app, either Android or iOS. To read the data collected by Crashlytics, install the MCP server in the Firebase CLI. See the `firebase-basics` skill for references.
+Provisioning Crashlytics requires both a Firebase project and a Firebase app,
+either Android or iOS. To read the data collected by Crashlytics, install the
+MCP server in the Firebase CLI. See the `firebase-basics` skill for references.
 
 ## SDK Setup
 
-To learn how to setup Crashlytics in your application code, choose your platform:
+To learn how to setup Crashlytics in your application code, choose your
+platform:
 
-*   **Android**: [android_setup.md](references/android_setup.md)
-*   **iOS**: [ios_setup.md](references/ios_setup.md)
+- **Android**: [android_setup.md](references/android_setup.md)
+- **iOS**: [ios_setup.md](references/ios_setup.md)
 
 ## SDK Usage
 
 The SDK provides a number of features to make crash reports more actionable.
 
-* Add custom keys
-* Add custom logs
-* Set user identifiers
-* Report non-fatal exceptions
+- Add custom keys
+- Add custom logs
+- Set user identifiers
+- Report non-fatal exceptions
 
-To learn how to customize crash reports and add additional debugging data, consult the documentation for your platform.
+To learn how to customize crash reports and add additional debugging data,
+consult the documentation for your platform.
 
-*   **Android**: [Customize Crash Reports for Android](https://firebase.google.com/docs/crashlytics/android/customize-crash-reports.md)
-*   **iOS**: [Customize Crash Reports for Apple Platforms](https://firebase.google.com/docs/crashlytics/ios/customize-crash-reports.md)
+- **Android**:
+  [Customize Crash Reports for Android](https://firebase.google.com/docs/crashlytics/android/customize-crash-reports.md)
+- **iOS**:
+  [Customize Crash Reports for Apple Platforms](https://firebase.google.com/docs/crashlytics/ios/customize-crash-reports.md)

--- a/skills/firebase-crashlytics/references/android_setup.md
+++ b/skills/firebase-crashlytics/references/android_setup.md
@@ -2,17 +2,24 @@
 
 Important references:
 
-- Refer to the `firebase-basics` skills, particularly those for project and app setup, before proceeding.
+- Refer to the `firebase-basics` skills, particularly those for project and app
+  setup, before proceeding.
 
 ## Project and App Setup
 
-Before you begin, ensure you have the following. If a `google-services.json` file is present, then use that Firebase project and app. Otherwise you may need to create them.
+Before you begin, ensure you have the following. If a `google-services.json`
+file is present, then use that Firebase project and app. Otherwise you may need
+to create them.
 
 - **Firebase CLI**: Installed and logged in (see `firebase-basics`).
-- **Firebase Project**: Created via `npx -y firebase-tools@latest projects:create` (see `firebase-basics`).
-- **Firebase App**: Created via `npx -y firebase-tools@latest apps:create <IOS|ANDROID|WEB> <package-name-or-bundle-id>`
+- **Firebase Project**: Created via
+  `npx -y firebase-tools@latest projects:create` (see `firebase-basics`).
+- **Firebase App**: Created via
+  `npx -y firebase-tools@latest apps:create <IOS|ANDROID|WEB> <package-name-or-bundle-id>`
 
-The `google-services.json` file must be present in the Android app's module directory. If missing, get the config using the Firebase CLI: `npx -y firebase-tools@latest apps:sdkconfig ANDROID <App-ID>`.
+The `google-services.json` file must be present in the Android app's module
+directory. If missing, get the config using the Firebase CLI:
+`npx -y firebase-tools@latest apps:sdkconfig ANDROID <App-ID>`.
 
 ## Add Dependencies to Gradle Build
 
@@ -20,7 +27,10 @@ These changes are made to your Android project's Gradle files.
 
 ### Project-level `build.gradle.kts` (`<project>/build.gradle.kts`)
 
-Add the latest version of the Crashlytics Gradle plugin to the `plugins` block. Fetch the [latest version from the Google Maven repository](https://maven.google.com/web/index.html?q=firebase-crashlytics-gradle#com.google.firebase:firebase-crashlytics-gradle) before adding this. 
+Add the latest version of the Crashlytics Gradle plugin to the `plugins` block.
+Fetch the
+[latest version from the Google Maven repository](https://maven.google.com/web/index.html?q=firebase-crashlytics-gradle#com.google.firebase:firebase-crashlytics-gradle)
+before adding this.
 
 ```kotlin
 plugins {
@@ -31,92 +41,112 @@ plugins {
 
 ### App-level `build.gradle.kts` (`<project>/<app-module>/build.gradle.kts`)
 
-1.  Add the Crashlytics plugin to the `plugins` block:
+1. Add the Crashlytics plugin to the `plugins` block:
 
-    ```kotlin
-    plugins {
-        // ... other plugins
-        id("com.google.firebase.crashlytics")
-    }
-    ```
+   ```kotlin
+   plugins {
+       // ... other plugins
+       id("com.google.firebase.crashlytics")
+   }
+   ```
 
-2.  Add the Firebase Crashlytics dependency to the `dependencies` block. It is recommended to use the Firebase Bill of Materials (BoM) to manage SDK versions. Fetch the [latest version from the Google Maven repository](https://maven.google.com/web/index.html?q=firebase-bom#com.google.firebase:firebase-bom) before adding this.
+1. Add the Firebase Crashlytics dependency to the `dependencies` block. It is
+   recommended to use the Firebase Bill of Materials (BoM) to manage SDK
+   versions. Fetch the
+   [latest version from the Google Maven repository](https://maven.google.com/web/index.html?q=firebase-bom#com.google.firebase:firebase-bom)
+   before adding this.
 
-    ```kotlin
-    dependencies {
-        // ... other dependencies
+   ```kotlin
+   dependencies {
+       // ... other dependencies
 
-        // Import the Firebase BoM
-        implementation(platform("com.google.firebase:firebase-bom:<latest_bom_version>"))
+       // Import the Firebase BoM
+       implementation(platform("com.google.firebase:firebase-bom:<latest_bom_version>"))
 
-        // Add the dependencies for the Crashlytics and Analytics
-        implementation("com.google.firebase:firebase-crashlytics-ktx")
-    }
-    ```
-
+       // Add the dependencies for the Crashlytics and Analytics
+       implementation("com.google.firebase:firebase-crashlytics-ktx")
+   }
+   ```
 
 ## Follow up Steps
 
 ### Optional: Install the NDK SDK to capture native crashes
 
-If your app uses native code (C/C++), or includes a library with native code, you can configure Crashlytics to report native crashes.
+If your app uses native code (C/C++), or includes a library with native code,
+you can configure Crashlytics to report native crashes.
 
 App-level `build.gradle.kts` (`<project>/<app-module>/build.gradle.kts`)
 
-1.  Add the `firebase-crashlytics-ndk` dependency:
+1. Add the `firebase-crashlytics-ndk` dependency:
 
-    ```kotlin
-    dependencies {
-        // ... other dependencies
-        implementation("com.google.firebase:firebase-crashlytics-ndk:18.6.2")
-    }
-    ```
+   ```kotlin
+   dependencies {
+       // ... other dependencies
+       implementation("com.google.firebase:firebase-crashlytics-ndk:18.6.2")
+   }
+   ```
 
-2.  Enable the `nativeSymbolUpload` flag in your `buildTypes` configuration. This will automatically upload symbol files for your native code, which are required to symbolicate native crash reports.
+1. Enable the `nativeSymbolUpload` flag in your `buildTypes` configuration. This
+   will automatically upload symbol files for your native code, which are
+   required to symbolicate native crash reports.
 
-    ```kotlin
-    android {
-        // ... other config
-        buildTypes {
-            getByName("release") {
-                // ...
-                firebaseCrashlytics {
-                    nativeSymbolUploadEnabled = true
-                }
-            }
-        }
-    }
-    ```
+   ```kotlin
+   android {
+       // ... other config
+       buildTypes {
+           getByName("release") {
+               // ...
+               firebaseCrashlytics {
+                   nativeSymbolUploadEnabled = true
+               }
+           }
+       }
+   }
+   ```
 
-After these changes, Crashlytics will automatically report crashes in your app's native code.
+After these changes, Crashlytics will automatically report crashes in your app's
+native code.
 
 ### Required: Force a Test Crash
 
-To verify that Crashlytics is correctly installed, you need to force a test crash in the app.
+To verify that Crashlytics is correctly installed, you need to force a test
+crash in the app.
 
-1.  Add code to your main activity (e.g., in `onCreate`) to trigger a crash a few seconds after app startup:
+1. Add code to your main activity (e.g., in `onCreate`) to trigger a crash a few
+   seconds after app startup:
 
-    ```kotlin
-    import android.os.Handler
-    import android.os.Looper
+   ```kotlin
+   import android.os.Handler
+   import android.os.Looper
 
-    // ... in your Activity's onCreate method or similar startup logic
-    Handler(Looper.getMainLooper()).postDelayed({
-        throw RuntimeException("Test Crash") // Force a crash after 3 seconds
-    }, 3000)
-    ```
+   // ... in your Activity's onCreate method or similar startup logic
+   Handler(Looper.getMainLooper()).postDelayed({
+       throw RuntimeException("Test Crash") // Force a crash after 3 seconds
+   }, 3000)
+   ```
 
-2.  Run your app on a device or emulator. The app should crash after a short delay.
+1. Run your app on a device or emulator. The app should crash after a short
+   delay.
 
-3.  Restart the app. The Crashlytics SDK will send the crash report to Firebase on the next app launch.
+1. Restart the app. The Crashlytics SDK will send the crash report to Firebase
+   on the next app launch.
 
-4.  After a few minutes, the crash should be available in the Firebase console. Go to **DevOps & Engagement** > **Crashlytics** to view your dashboard and crash reports.
-  -  If the Firebase MCP server is installed, use the `get_report` tool to check that a crash was received.
-  -  As a fallback, visit the Crashlytics dashboard in the Firebase console to see the new crash report.
+1. After a few minutes, the crash should be available in the Firebase console.
+   Go to **DevOps & Engagement** > **Crashlytics** to view your dashboard and
+   crash reports.
 
-5. After verifying that Firebase has received the crash report - either using the `get_report` tool or manually viewing it in the Firebase console - remove the code from step 1 that triggers the crash.  This prevents the application from always crashing on start up after a delay.
+- If the Firebase MCP server is installed, use the `get_report` tool to check
+  that a crash was received.
+- As a fallback, visit the Crashlytics dashboard in the Firebase console to see
+  the new crash report.
+
+5. After verifying that Firebase has received the crash report - either using
+   the `get_report` tool or manually viewing it in the Firebase console - remove
+   the code from step 1 that triggers the crash. This prevents the application
+   from always crashing on start up after a delay.
 
 ### Optional: Add custom debugging information
 
-Customize reports to help you better understand what's happening in your app and the circumstances around events reported to Crashlytics. See [Customize Crash Reports for Android](https://firebase.google.com/docs/crashlytics/android/customize-crash-reports.md).
-
+Customize reports to help you better understand what's happening in your app and
+the circumstances around events reported to Crashlytics. See
+[Customize Crash Reports for Android](https://firebase.google.com/docs/crashlytics/android/customize-crash-reports.md).

--- a/skills/firebase-crashlytics/references/ios_setup.md
+++ b/skills/firebase-crashlytics/references/ios_setup.md
@@ -2,80 +2,114 @@
 
 Important references:
 
-- Refer to the `firebase-basics` skills, particularly those for iOS setup, before proceeding.
+- Refer to the `firebase-basics` skills, particularly those for iOS setup,
+  before proceeding.
 - Refer to the `xcode-project-setup` skills.
 
 ## Project and App Setup
 
 Use the `firebase-tools` CLI to set up the project if necessary.
 
-1.  **Find Bundle ID:** Read the Xcode project to find the iOS bundle ID. Check the `PRODUCT_BUNDLE_IDENTIFIER` value in the `.pbxproj` file or the `Info.plist` file.
-2.  **Create Firebase Project:** If no project exists, create one:
-    `npx -y firebase-tools@latest projects:create <project-id> --display-name="My Awesome App"`
-3.  **Create Firebase App:** Register the iOS app with the discovered bundle ID:
-    `npx -y firebase-tools@latest apps:create IOS <bundle-id>`
-4.  **Link the GoogleService-Info.plist file:** Use the script in the `xcode-project-setup` skill to obtain the config and link.
+1. **Find Bundle ID:** Read the Xcode project to find the iOS bundle ID. Check
+   the `PRODUCT_BUNDLE_IDENTIFIER` value in the `.pbxproj` file or the
+   `Info.plist` file.
+1. **Create Firebase Project:** If no project exists, create one:
+   `npx -y firebase-tools@latest projects:create <project-id> --display-name="My Awesome App"`
+1. **Create Firebase App:** Register the iOS app with the discovered bundle ID:
+   `npx -y firebase-tools@latest apps:create IOS <bundle-id>`
+1. **Link the GoogleService-Info.plist file:** Use the script in the
+   `xcode-project-setup` skill to obtain the config and link.
 
 ## Add Swift Package Dependencies
 
-Install the Crashlytics SDK using the Swift package manager, or the script in the `xcode-project-setup` skill.
+Install the Crashlytics SDK using the Swift package manager, or the script in
+the `xcode-project-setup` skill.
 
-Install the `FirebaseCrashlytics` package from the `https://github.com/firebase/firebase-ios-sdk.git` repository.
+Install the `FirebaseCrashlytics` package from the
+`https://github.com/firebase/firebase-ios-sdk.git` repository.
 
 ## Initialize Firebase in App Code
 
-Modify the application's entry point to initialize Firebase. Refer to the iOS setup reference in the `firebase-basics` skill.
+Modify the application's entry point to initialize Firebase. Refer to the iOS
+setup reference in the `firebase-basics` skill.
 
 ## Add dSYM Upload Script
 
-Add a Run Script phase to the main app target in Xcode. This step is required to upload dSYM files for crash symbolication. 
+Add a Run Script phase to the main app target in Xcode. This step is required to
+upload dSYM files for crash symbolication.
 
-1.  **Debug Information Format**: The `Debug Information Format` in Build Settings must be set to `DWARF with dSYM File`.
-2.  **Run Script Content**: A new "Run Script Phase" should be added to the target's "Build Phases" with the following content:
-    ```bash
-    ${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run
-    ```
+1. **Debug Information Format**: The `Debug Information Format` in Build
+   Settings must be set to `DWARF with dSYM File`.
+1. **Run Script Content**: A new "Run Script Phase" should be added to the
+   target's "Build Phases" with the following content:
+   ```bash
+   ${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run
+   ```
 
-When using the `xcode-project-setup` skills, the above two steps will be done as part of adding the `FirebaseCrashlytics` package. Once the skill has been invoked and succeeded, verify that the app's project.pbxproj file contains a Run Script Build phase where the shell script attribute value contains 'Crashlytics'. Specifically, there should be a `PBXShellScriptBuildPhase` section with the attribute `shellScript` that is set to a value that contains `Crashlytics/run` and an attribute `inputPaths` where one of the values contains `GoogleService-Info.plist`. If verification is not successful, present the above two options to be done manually.
+When using the `xcode-project-setup` skills, the above two steps will be done as
+part of adding the `FirebaseCrashlytics` package. Once the skill has been
+invoked and succeeded, verify that the app's project.pbxproj file contains a Run
+Script Build phase where the shell script attribute value contains
+'Crashlytics'. Specifically, there should be a `PBXShellScriptBuildPhase`
+section with the attribute `shellScript` that is set to a value that contains
+`Crashlytics/run` and an attribute `inputPaths` where one of the values contains
+`GoogleService-Info.plist`. If verification is not successful, present the above
+two options to be done manually.
 
 ## Follow up Steps
 
 ### Required: Force a Test Crash
 
-1. Add code to trigger a crash a few seconds after app startup to verify Crashlytics setup.
+1. Add code to trigger a crash a few seconds after app startup to verify
+   Crashlytics setup.
 
 **For SwiftUI Apps (in `AppDelegate.swift`):**
 
-    *File: `AppDelegate.swift`*
-    ```swift
-    import FirebaseCore
-    import Dispatch // For DispatchQueue
+````
+*File: `AppDelegate.swift`*
+```swift
+import FirebaseCore
+import Dispatch // For DispatchQueue
 
-    // ...
+// ...
 
-    class AppDelegate: NSObject, UIApplicationDelegate {
-      func application(_ application: UIApplication,
-                       didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
-        FirebaseApp.configure()
-        // Force a crash after a delay to test Crashlytics
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-            fatalError("Test Crash")
-        }
-        return true
-      }
+class AppDelegate: NSObject, UIApplicationDelegate {
+  func application(_ application: UIApplication,
+                   didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+    FirebaseApp.configure()
+    // Force a crash after a delay to test Crashlytics
+    DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+        fatalError("Test Crash")
     }
-    ```
+    return true
+  }
+}
+```
+````
 
-2.  Run your app on a device or simulator. If running in the iOS simulator, make sure that the Xcode debugger is disconnected, otherwise the crash will not make it to Crashlytics. The app should crash after a short delay.
+2. Run your app on a device or simulator. If running in the iOS simulator, make
+   sure that the Xcode debugger is disconnected, otherwise the crash will not
+   make it to Crashlytics. The app should crash after a short delay.
 
-3.  Restart the app. The Crashlytics SDK will send the crash report to Firebase on the next app launch.
+1. Restart the app. The Crashlytics SDK will send the crash report to Firebase
+   on the next app launch.
 
-4.  After a few minutes, the crash should be available in the Firebase console. Go to **DevOps & Engagement** > **Crashlytics** to view your dashboard and crash reports.
-  -  If the Firebase MCP server is installed, use the `get_report` tool to check that a crash was received.
-  -  As a fallback, visit the Crashlytics dashboard in the Firebase console to see the new crash report.
+1. After a few minutes, the crash should be available in the Firebase console.
+   Go to **DevOps & Engagement** > **Crashlytics** to view your dashboard and
+   crash reports.
 
-5. After verifying that Firebase has received the crash report - either using the `get_report` tool or manually viewing it in the Firebase console - remove the code from step 1 that triggers the crash.  This prevents the application from always crashing on start up after a delay.
+- If the Firebase MCP server is installed, use the `get_report` tool to check
+  that a crash was received.
+- As a fallback, visit the Crashlytics dashboard in the Firebase console to see
+  the new crash report.
+
+5. After verifying that Firebase has received the crash report - either using
+   the `get_report` tool or manually viewing it in the Firebase console - remove
+   the code from step 1 that triggers the crash. This prevents the application
+   from always crashing on start up after a delay.
 
 ### Optional: Add custom debugging information
 
-Customize reports to help you better understand what's happening in your app and the circumstances around events reported to Crashlytics. See [Customize Crash Reports for Apple Platforms](https://firebase.google.com/docs/crashlytics/ios/customize-crash-reports.md).
+Customize reports to help you better understand what's happening in your app and
+the circumstances around events reported to Crashlytics. See
+[Customize Crash Reports for Apple Platforms](https://firebase.google.com/docs/crashlytics/ios/customize-crash-reports.md).

--- a/skills/firebase-data-connect-basics/SKILL.md
+++ b/skills/firebase-data-connect-basics/SKILL.md
@@ -5,10 +5,14 @@ description: Builds and deploys Firebase SQL Connect (aka Firebase Data Connect)
 
 # Firebase SQL Connect
 
-Firebase SQL Connect is a relational database service using Cloud SQL for PostgreSQL with GraphQL schema, auto-generated queries/mutations, and type-safe SDKs.
+Firebase SQL Connect is a relational database service using Cloud SQL for
+PostgreSQL with GraphQL schema, auto-generated queries/mutations, and type-safe
+SDKs.
 
-> [!NOTE]
-> **Product Rename**: Firebase Data Connect was renamed to **Firebase SQL Connect**. All instructions, references, and examples in this skill repository referring to "Data Connect" or "Firebase Data Connect" apply to "SQL Connect" and "Firebase SQL Connect" as well.
+> [!NOTE] **Product Rename**: Firebase Data Connect was renamed to **Firebase
+> SQL Connect**. All instructions, references, and examples in this skill
+> repository referring to "Data Connect" or "Firebase Data Connect" apply to
+> "SQL Connect" and "Firebase SQL Connect" as well.
 
 ## Project Structure
 
@@ -27,51 +31,75 @@ dataconnect/
 ## Key Tools for Validation
 
 Rely on these two mechanisms to ensure project correctness:
-1. **Review GraphQL Schema**: Both user-defined and generated extensions (in `.dataconnect/schema/main/`).
-2. **Validate Operations**: Run `npx -y firebase-tools@latest dataconnect:compile` against the schema.
+
+1. **Review GraphQL Schema**: Both user-defined and generated extensions (in
+   `.dataconnect/schema/main/`).
+1. **Validate Operations**: Run
+   `npx -y firebase-tools@latest dataconnect:compile` against the schema.
 
 ## Operation Strategies: GraphQL vs. Native SQL
 
-Always default to **Native GraphQL**. **Native SQL lacks type safety** and bypasses schema-enforced structures. Only use **Native SQL** when the user explicitly requests it or when the task requires advanced database features.
+Always default to **Native GraphQL**. **Native SQL lacks type safety** and
+bypasses schema-enforced structures. Only use **Native SQL** when the user
+explicitly requests it or when the task requires advanced database features.
 
-| Strategy | When to use | Implementation |
-|----------|-------------|----------------|
-| **Native GraphQL** (Default) | Almost all use cases. Standard CRUD, basic filtering/sorting, simple relational joins. Requires full type safety. | Auto-generated fields (`movie_insert`, `movies`). Strong typing and schema enforcement. |
-| **Native SQL** (Advanced) | PostgreSQL extensions (e.g., PostGIS), window functions (`RANK()`), complex aggregations, or highly tuned sub-queries. | Raw SQL string literals via `_select`, `_execute`, etc. Requires strict positional parameters (`$1`). No type safety. |
+| Strategy                     | When to use                                                                                                            | Implementation                                                                                                        |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| **Native GraphQL** (Default) | Almost all use cases. Standard CRUD, basic filtering/sorting, simple relational joins. Requires full type safety.      | Auto-generated fields (`movie_insert`, `movies`). Strong typing and schema enforcement.                               |
+| **Native SQL** (Advanced)    | PostgreSQL extensions (e.g., PostGIS), window functions (`RANK()`), complex aggregations, or highly tuned sub-queries. | Raw SQL string literals via `_select`, `_execute`, etc. Requires strict positional parameters (`$1`). No type safety. |
 
 ## Development Workflow
 
-Follow this strict workflow to build your application. You **must** read the linked reference files for each step to understand the syntax and available features.
+Follow this strict workflow to build your application. You **must** read the
+linked reference files for each step to understand the syntax and available
+features.
 
 ### 1. Define Data Model (`schema/schema.gql`)
-Define your GraphQL types, tables, and relationships (which map to a Postgres schema).
+
+Define your GraphQL types, tables, and relationships (which map to a Postgres
+schema).
+
 > **Read [reference/schema.md](reference/schema.md)** for:
-> *   `@table`, `@col`, `@default`
-> *   Relationships (`@ref`, one-to-many, many-to-many)
-> *   Data types (UUID, Vector, JSON, etc.)
+>
+> - `@table`, `@col`, `@default`
+> - Relationships (`@ref`, one-to-many, many-to-many)
+> - Data types (UUID, Vector, JSON, etc.)
 
 ### 2. Define Authorized Operations (`connector/queries.gql`, `connector/mutations.gql`)
-Write the queries and mutations your client will use, including authorization logic. SQL Connect is secure by default.
+
+Write the queries and mutations your client will use, including authorization
+logic. SQL Connect is secure by default.
+
 > **Read [reference/operations.md](reference/operations.md)** for:
-> *   **Queries**: Filtering (`where`), Ordering (`orderBy`), Pagination (`limit`/`offset`).
-> *   **Mutations**: Create (`_insert`), Update (`_update`), Delete (`_delete`).
-> *   **Upserts**: Use `_upsert` to "insert or update" records (CRITICAL for user profiles).
-> *   **Transactions**: Use `@transaction` for multi-step atomic operations. Use `_expr: "response.<prevStep>"` to pass data between steps.
+>
+> - **Queries**: Filtering (`where`), Ordering (`orderBy`), Pagination
+>   (`limit`/`offset`).
+> - **Mutations**: Create (`_insert`), Update (`_update`), Delete (`_delete`).
+> - **Upserts**: Use `_upsert` to "insert or update" records (CRITICAL for user
+>   profiles).
+> - **Transactions**: Use `@transaction` for multi-step atomic operations. Use
+>   `_expr: "response.<prevStep>"` to pass data between steps.
 >
 > **Read [reference/security.md](reference/security.md)** for authorization:
-> *   `@auth(level: ...)` for PUBLIC, USER, or NO_ACCESS.
-> *   `@check` and `@redact` for row-level security and validation.
 >
-> **Read [reference/realtime.md](reference/realtime.md)** for real-time subscriptions:
-> *   `@refresh` directive for time-based polling and event-driven updates.
-> *   CEL conditions to scope refresh triggers precisely.
+> - `@auth(level: ...)` for PUBLIC, USER, or NO_ACCESS.
+> - `@check` and `@redact` for row-level security and validation.
 >
-> **Read [reference/native_sql.md](reference/native_sql.md)** for Native SQL operations:
-> *   Embedding raw SQL with `_select`, `_selectFirst`, `_execute`
-> *   Strict rules for positional parameters (`$1`, `$2`), quoting, and CTEs
-> *   Advanced PostgreSQL features (PostGIS, Window Functions)
+> **Read [reference/realtime.md](reference/realtime.md)** for real-time
+> subscriptions:
+>
+> - `@refresh` directive for time-based polling and event-driven updates.
+> - CEL conditions to scope refresh triggers precisely.
+>
+> **Read [reference/native_sql.md](reference/native_sql.md)** for Native SQL
+> operations:
+>
+> - Embedding raw SQL with `_select`, `_selectFirst`, `_execute`
+> - Strict rules for positional parameters (`$1`, `$2`), quoting, and CTEs
+> - Advanced PostgreSQL features (PostGIS, Window Functions)
 
 ### 3. Use type-safe SDK in your apps
+
 Generate type-safe code for your client platform.
 
 Configure SDK generation in `connector.yaml`:
@@ -90,69 +118,74 @@ generate:
 ```
 
 Generate SDKs:
+
 ```bash
 npx -y firebase-tools@latest dataconnect:sdk:generate
 ```
 
 For platform-specific instructions on how to use the generated SDKs, read:
-*   **Web (TypeScript)**: [reference/sdk_web.md](reference/sdk_web.md)
-*   **Android (Kotlin)**: [reference/sdk_android.md](reference/sdk_android.md)
-*   **iOS (Swift)**: [reference/sdk_ios.md](reference/sdk_ios.md)
-*   **Admin (Node.js)**: [reference/sdk_admin_node.md](reference/sdk_admin_node.md)
-*   **Flutter (Dart)**: [reference/sdk_flutter.md](reference/sdk_flutter.md)
 
+- **Web (TypeScript)**: [reference/sdk_web.md](reference/sdk_web.md)
+- **Android (Kotlin)**: [reference/sdk_android.md](reference/sdk_android.md)
+- **iOS (Swift)**: [reference/sdk_ios.md](reference/sdk_ios.md)
+- **Admin (Node.js)**:
+  [reference/sdk_admin_node.md](reference/sdk_admin_node.md)
+- **Flutter (Dart)**: [reference/sdk_flutter.md](reference/sdk_flutter.md)
 
-
----
+______________________________________________________________________
 
 ## Feature Capability Map
 
 If you need to implement a specific feature, consult the mapped reference file:
 
-| Feature | Reference File | Key Concepts |
-| :--- | :--- | :--- |
-| **Data Modeling** | [reference/schema.md](reference/schema.md) | `@table`, `@unique`, `@index`, Relations |
-| **Vector Search** | [reference/search.md](reference/search.md) | `Vector`, `@col(dataType: "vector")`, embeddings |
-| **Full-Text Search** | [reference/search.md](reference/search.md) | `@searchable`, `movies_search` |
-| **Upserting Data** | [reference/operations.md](reference/operations.md) | `_upsert` mutations |
-| **Complex Filters** | [reference/operations.md](reference/operations.md) | `_or`, `_and`, `_not`, `eq`, `contains` |
-| **Transactions** | [reference/operations.md](reference/operations.md) | `@transaction`, `response` binding |
-| **Environment Config** | [reference/config.md](reference/config.md) | `dataconnect.yaml`, `connector.yaml` |
-| **Realtime Subscriptions** | [reference/realtime.md](reference/realtime.md) | `@refresh`, `subscribe()`, auto-refresh |
-| **Cloud Functions Integration** | [reference/cloud_functions.md](reference/cloud_functions.md) | `onMutationExecuted`, triggering events |
-| **Data Seeding & Migrations** | [reference/data_seeding.md](reference/data_seeding.md) | `seed_data.gql`, `_insertMany`, Admin SDK bulk |
-| **Starter Templates** | [templates.md](templates.md) | CRUD, user-owned resources, many-to-many, SDK init |
+| Feature                         | Reference File                                               | Key Concepts                                       |
+| :------------------------------ | :----------------------------------------------------------- | :------------------------------------------------- |
+| **Data Modeling**               | [reference/schema.md](reference/schema.md)                   | `@table`, `@unique`, `@index`, Relations           |
+| **Vector Search**               | [reference/search.md](reference/search.md)                   | `Vector`, `@col(dataType: "vector")`, embeddings   |
+| **Full-Text Search**            | [reference/search.md](reference/search.md)                   | `@searchable`, `movies_search`                     |
+| **Upserting Data**              | [reference/operations.md](reference/operations.md)           | `_upsert` mutations                                |
+| **Complex Filters**             | [reference/operations.md](reference/operations.md)           | `_or`, `_and`, `_not`, `eq`, `contains`            |
+| **Transactions**                | [reference/operations.md](reference/operations.md)           | `@transaction`, `response` binding                 |
+| **Environment Config**          | [reference/config.md](reference/config.md)                   | `dataconnect.yaml`, `connector.yaml`               |
+| **Realtime Subscriptions**      | [reference/realtime.md](reference/realtime.md)               | `@refresh`, `subscribe()`, auto-refresh            |
+| **Cloud Functions Integration** | [reference/cloud_functions.md](reference/cloud_functions.md) | `onMutationExecuted`, triggering events            |
+| **Data Seeding & Migrations**   | [reference/data_seeding.md](reference/data_seeding.md)       | `seed_data.gql`, `_insertMany`, Admin SDK bulk     |
+| **Starter Templates**           | [templates.md](templates.md)                                 | CRUD, user-owned resources, many-to-many, SDK init |
 
----
+______________________________________________________________________
 
 ## Deployment & CLI
 
-> **Read [reference/config.md](reference/config.md)** for deep dive on configuration.
+> **Read [reference/config.md](reference/config.md)** for deep dive on
+> configuration.
 
 Follow these patterns based on your current task:
 
 ### How to initialize SQL Connect in a Firebase project
 
-1.  Understand the app idea. Ask clarification questions if unclear.
-2.  Run `npx -y firebase-tools@latest init dataconnect`.
-3.  Validate that the app template and generated SDK are setup.
+1. Understand the app idea. Ask clarification questions if unclear.
+1. Run `npx -y firebase-tools@latest init dataconnect`.
+1. Validate that the app template and generated SDK are setup.
 
 ### How to build apps using SQL Connect locally
 
-1.  Start the emulator: `npx -y firebase-tools@latest emulators:start --only dataconnect`.
-2.  Write schema and operations.
-3.  Seed local test data into `seed_data.gql`. Read [reference/data_seeding.md](reference/data_seeding.md#local-prototyping-data-seeding).
-4.  Run `npx -y firebase-tools@latest dataconnect:compile` or `npx -y firebase-tools@latest dataconnect:sdk:generate` to
-    validate them.
-5.  Use the operations in your app and build it.
+1. Start the emulator:
+   `npx -y firebase-tools@latest emulators:start --only dataconnect`.
+1. Write schema and operations.
+1. Seed local test data into `seed_data.gql`. Read
+   [reference/data_seeding.md](reference/data_seeding.md#local-prototyping-data-seeding).
+1. Run `npx -y firebase-tools@latest dataconnect:compile` or
+   `npx -y firebase-tools@latest dataconnect:sdk:generate` to validate them.
+1. Use the operations in your app and build it.
 
 ### How to deploy SQL Connect to Cloud SQL
 
-1.  Run `npx -y firebase-tools@latest deploy --only dataconnect`.
+1. Run `npx -y firebase-tools@latest deploy --only dataconnect`.
 
 ## Examples
 
 For complete, working code examples of schemas and operations, see
 **[examples.md](examples.md)**.
 
-For ready-to-use starter templates (CRUD, user-owned resources, many-to-many, YAML configs, SDK init), see **[templates.md](templates.md)**.
+For ready-to-use starter templates (CRUD, user-owned resources, many-to-many,
+YAML configs, SDK init), see **[templates.md](templates.md)**.

--- a/skills/firebase-data-connect-basics/examples.md
+++ b/skills/firebase-data-connect-basics/examples.md
@@ -2,11 +2,12 @@
 
 Complete, working examples for common SQL Connect use cases.
 
----
+______________________________________________________________________
 
 ## Movie Review App
 
-A complete schema for a movie database with reviews, actors, and user authentication.
+A complete schema for a movie database with reviews, actors, and user
+authentication.
 
 ### Schema
 
@@ -234,7 +235,7 @@ const unsubLeaderboard = subscribe(movieLeaderboardRef(), {
 // unsubLeaderboard();
 ```
 
----
+______________________________________________________________________
 
 ## E-Commerce Store
 
@@ -346,7 +347,7 @@ mutation Checkout($shippingAddress: String!)
 }
 ```
 
----
+______________________________________________________________________
 
 ## Blog with Permissions
 
@@ -465,11 +466,12 @@ mutation GrantRole($userUid: String!, $role: UserRole!)
 }
 ```
 
----
+______________________________________________________________________
 
 ## Native SQL Examples
 
-For scenarios where standard GraphQL cannot express the required database logic, use Native SQL.
+For scenarios where standard GraphQL cannot express the required database logic,
+use Native SQL.
 
 ### Basic SELECT with field aliasing
 
@@ -541,7 +543,8 @@ mutation UpdateMyReviewText($movieId: UUID!, $newText: String!) @auth(level: USE
 
 ### Advanced CTE with upserts (atomic get-or-create)
 
-*Note: Data-modifying CTEs are only supported by `_execute`, not `_executeReturning`.*
+*Note: Data-modifying CTEs are only supported by `_execute`, not
+`_executeReturning`.*
 
 ```graphql
 mutation CreateMovieCTE($movieId: UUID!, $userUid: String!, $reviewId: UUID!) @auth(level: USER) {
@@ -577,7 +580,9 @@ mutation CreateMovieCTE($movieId: UUID!, $userUid: String!, $reviewId: UUID!) @a
 
 ### Multi-statement Transactions
 
-Because `mutation` operations are single requests, you can chain multiple `_execute` commands within a `@transaction` to ensure they all succeed or fail together.
+Because `mutation` operations are single requests, you can chain multiple
+`_execute` commands within a `@transaction` to ensure they all succeed or fail
+together.
 
 ```graphql
 mutation SafeTransfer($from: UUID!, $to: UUID!, $amount: Float!) @auth(level: USER) @transaction {
@@ -594,7 +599,9 @@ mutation SafeTransfer($from: UUID!, $to: UUID!, $amount: Float!) @auth(level: US
 
 ### Use of extensions (e.g. PostGIS for geospatial data)
 
-*Prerequisite:* You must enable the extension on your underlying Cloud SQL instance by connecting to your database as the postgres user and running:
+*Prerequisite:* You must enable the extension on your underlying Cloud SQL
+instance by connecting to your database as the postgres user and running:
+
 ```sql
 CREATE EXTENSION IF NOT EXISTS postgis;
 ```
@@ -626,4 +633,6 @@ query GetNearbyActiveRestaurants($userLong: Float!, $userLat: Float!, $maxDistan
   )
 }
 ```
-*After running the query using a client SDK, the result will be in `data.nearby`.*
+
+*After running the query using a client SDK, the result will be in
+`data.nearby`.*

--- a/skills/firebase-data-connect-basics/reference/cloud_functions.md
+++ b/skills/firebase-data-connect-basics/reference/cloud_functions.md
@@ -1,20 +1,34 @@
 # Cloud Functions Integration Reference
 
-Use this reference to handle database events in SQL Connect by triggering Cloud Functions in response to mutation executions.
+Use this reference to handle database events in SQL Connect by triggering Cloud
+Functions in response to mutation executions.
 
----
+______________________________________________________________________
 
 ## Core Trigger Configuration
 
 To handle a mutation execution, define the `onMutationExecuted` event handler.
 
 ### 🚨 Critical Infinite Loop Constraint
-Unlike document-based database triggers (like Firestore or Realtime Database), **SQL Connect event triggers do not provide a "before" snapshot of the data.** Because SQL Connect proxies requests directly to PostgreSQL, "before" states cannot be resolved transactionally.
-* **Warning**: If `onMutationExecuted` executes a SQL Connect mutation, it can trigger another `onMutationExecuted` trigger in a cascading loop. Make sure that `onMutationExecuted` has a filter on `operation` to reduce the chance of infinite loops.
-* **Rule**: Ensure that no mutation executed inside the function can ever trigger the handler itself, even indirectly.
+
+Unlike document-based database triggers (like Firestore or Realtime Database),
+**SQL Connect event triggers do not provide a "before" snapshot of the data.**
+Because SQL Connect proxies requests directly to PostgreSQL, "before" states
+cannot be resolved transactionally.
+
+- **Warning**: If `onMutationExecuted` executes a SQL Connect mutation, it can
+  trigger another `onMutationExecuted` trigger in a cascading loop. Make sure
+  that `onMutationExecuted` has a filter on `operation` to reduce the chance of
+  infinite loops.
+- **Rule**: Ensure that no mutation executed inside the function can ever
+  trigger the handler itself, even indirectly.
 
 ### Location & Region Matching Rule
-**The Cloud Function region option must match your SQL Connect service location.** You **must** explicitly configure the `region` parameter (e.g., `'us-central1'`) in the trigger options to match the `location` specified in `dataconnect.yaml`.
+
+**The Cloud Function region option must match your SQL Connect service
+location.** You **must** explicitly configure the `region` parameter (e.g.,
+`'us-central1'`) in the trigger options to match the `location` specified in
+`dataconnect.yaml`.
 
 ```typescript
 import { onMutationExecuted } from "firebase-functions/dataconnect";
@@ -33,14 +47,18 @@ export const logMutation = onMutationExecuted(
 );
 ```
 
----
+______________________________________________________________________
 
 ## Event Filtering
 
-To prevent unnecessary function invocations and infinite execution loops, **always specify narrow filters** using `service` and `operation` attributes. 
+To prevent unnecessary function invocations and infinite execution loops,
+**always specify narrow filters** using `service` and `operation` attributes.
 
-*   **`service` & `operation` (Recommended)**: Always specify these to restrict the trigger to a specific mutation in your project.
-*   **`connector` (Optional)**: Can be omitted if you want to trigger on the same operation name across multiple connectors. Specify it only if you need to restrict the trigger to a specific connector.
+- **`service` & `operation` (Recommended)**: Always specify these to restrict
+  the trigger to a specific mutation in your project.
+- **`connector` (Optional)**: Can be omitted if you want to trigger on the same
+  operation name across multiple connectors. Specify it only if you need to
+  restrict the trigger to a specific connector.
 
 ### Comprehensive Example
 
@@ -74,22 +92,22 @@ export const onMutationCaptures = onMutationExecuted(
 );
 ```
 
-
----
+______________________________________________________________________
 
 ## Accessing User Authentication Context
 
-Extract security credentials about the caller who executed the mutation using `event.authType` and `event.authId`.
+Extract security credentials about the caller who executed the mutation using
+`event.authType` and `event.authId`.
 
 ### Auth Context Mappings
 
-| Triggered Principal | `event.authType` | `event.authId` |
-| :--- | :--- | :--- |
-| **Authenticated end user** | `"app_user"` | Firebase Auth token UID |
-| **Unauthenticated end user** | `"unauthenticated"` | Empty |
-| **Admin SDK (Impersonating User)** | `"app_user"` | Firebase Auth token UID of the impersonated user |
-| **Admin SDK (Impersonating Unauth)**| `"unauthenticated"` | Empty |
-| **Admin SDK (Full privileges)** | `"admin"` | Empty |
+| Triggered Principal                  | `event.authType`    | `event.authId`                                   |
+| :----------------------------------- | :------------------ | :----------------------------------------------- |
+| **Authenticated end user**           | `"app_user"`        | Firebase Auth token UID                          |
+| **Unauthenticated end user**         | `"unauthenticated"` | Empty                                            |
+| **Admin SDK (Impersonating User)**   | `"app_user"`        | Firebase Auth token UID of the impersonated user |
+| **Admin SDK (Impersonating Unauth)** | `"unauthenticated"` | Empty                                            |
+| **Admin SDK (Full privileges)**      | `"admin"`           | Empty                                            |
 
 ### Auth Extraction Example
 
@@ -106,11 +124,12 @@ export const processSensitiveMutation = onMutationExecuted(
 );
 ```
 
----
+______________________________________________________________________
 
 ## Parsing Event Data Payloads
 
-The trigger payload provides inputs passed to the mutation (`payload.variables`) and return values generated from the execution (`payload.data`).
+The trigger payload provides inputs passed to the mutation (`payload.variables`)
+and return values generated from the execution (`payload.data`).
 
 ### Event Payload Structure
 
@@ -135,9 +154,10 @@ The trigger payload provides inputs passed to the mutation (`payload.variables`)
 }
 ```
 
-* **`event.data.payload.variables`**: Inputs passed to the mutation.
-* **`event.data.payload.data`**: Fields returned by the mutation execution.
-* **`event.data.payload.errors`**: Array of execution errors. Empty if successful.
+- **`event.data.payload.variables`**: Inputs passed to the mutation.
+- **`event.data.payload.data`**: Fields returned by the mutation execution.
+- **`event.data.payload.errors`**: Array of execution errors. Empty if
+  successful.
 
 ### Payload Extraction Example
 

--- a/skills/firebase-data-connect-basics/reference/config.md
+++ b/skills/firebase-data-connect-basics/reference/config.md
@@ -1,6 +1,7 @@
 # Configuration Reference
 
 ## Contents
+
 - [Project Structure](#project-structure)
 - [dataconnect.yaml](#dataconnectyaml)
 - [connector.yaml](#connectoryaml)
@@ -8,7 +9,7 @@
 - [Emulator](#emulator)
 - [Deployment](#deployment)
 
----
+______________________________________________________________________
 
 ## Project Structure
 
@@ -25,7 +26,7 @@ project-root/
         └── mutations.gql   # Mutation operations (optional separate file)
 ```
 
----
+______________________________________________________________________
 
 ## dataconnect.yaml
 
@@ -46,15 +47,15 @@ schema:
 connectorDirs: ["./connector"]
 ```
 
-| Field | Description |
-|-------|-------------|
-| `specVersion` | Always `"v1"` |
-| `serviceId` | Unique identifier for the service |
-| `location` | GCP region (us-central1, us-east4, europe-west1, etc.) |
-| `schemaValidation` | Deployment mode: `"STRICT"` (must match exactly) or `"COMPATIBLE"` (backward compatible) |
-| `schema.source` | Path to schema directory |
-| `schema.datasource` | PostgreSQL connection config |
-| `connectorDirs` | List of connector directories |
+| Field               | Description                                                                              |
+| ------------------- | ---------------------------------------------------------------------------------------- |
+| `specVersion`       | Always `"v1"`                                                                            |
+| `serviceId`         | Unique identifier for the service                                                        |
+| `location`          | GCP region (us-central1, us-east4, europe-west1, etc.)                                   |
+| `schemaValidation`  | Deployment mode: `"STRICT"` (must match exactly) or `"COMPATIBLE"` (backward compatible) |
+| `schema.source`     | Path to schema directory                                                                 |
+| `schema.datasource` | PostgreSQL connection config                                                             |
+| `connectorDirs`     | List of connector directories                                                            |
 
 ### Cloud SQL Configuration
 
@@ -67,7 +68,7 @@ schema:
         instanceId: "my-instance"  # Cloud SQL instance ID
 ```
 
----
+______________________________________________________________________
 
 ## connector.yaml
 
@@ -88,14 +89,14 @@ generate:
 
 ### SDK Generation Options
 
-| SDK | Fields |
-|-----|--------|
-| `javascriptSdk` | `outputDir`, `package` |
-| `kotlinSdk` | `outputDir`, `package` |
-| `swiftSdk` | `outputDir` |
-| `nodeAdminSdk` | `outputDir`, `package` (for Admin SDK) |
+| SDK             | Fields                                 |
+| --------------- | -------------------------------------- |
+| `javascriptSdk` | `outputDir`, `package`                 |
+| `kotlinSdk`     | `outputDir`, `package`                 |
+| `swiftSdk`      | `outputDir`                            |
+| `nodeAdminSdk`  | `outputDir`, `package` (for Admin SDK) |
 
----
+______________________________________________________________________
 
 ## Firebase CLI Commands
 
@@ -149,7 +150,7 @@ npx -y firebase-tools@latest deploy --only dataconnect:connector-id
 npx -y firebase-tools@latest deploy --only dataconnect --force
 ```
 
----
+______________________________________________________________________
 
 ## Emulator
 
@@ -160,6 +161,7 @@ npx -y firebase-tools@latest emulators:start --only dataconnect
 ```
 
 Default ports:
+
 - SQL Connect: `9399`
 - PostgreSQL: `9939` (local PostgreSQL instance)
 
@@ -203,16 +205,16 @@ npx -y firebase-tools@latest emulators:export ./seed-data
 npx -y firebase-tools@latest emulators:start --only dataconnect --import=./seed-data
 ```
 
----
+______________________________________________________________________
 
 ## Deployment
 
 ### Deploy Workflow
 
 1. **Test locally** with emulator
-2. **Generate SQL diff**: `npx -y firebase-tools@latest dataconnect:sql:diff`
-3. **Review migration**: Check breaking changes
-4. **Deploy**: `npx -y firebase-tools@latest deploy --only dataconnect`
+1. **Generate SQL diff**: `npx -y firebase-tools@latest dataconnect:sql:diff`
+1. **Review migration**: Check breaking changes
+1. **Deploy**: `npx -y firebase-tools@latest deploy --only dataconnect`
 
 ### Schema Migrations
 
@@ -232,6 +234,7 @@ npx -y firebase-tools@latest dataconnect:sql:migrate --force
 ### Breaking Changes
 
 Some schema changes require special handling:
+
 - Removing required fields
 - Changing field types
 - Removing tables
@@ -247,11 +250,12 @@ Use `--force` flag to acknowledge breaking changes during deploy.
     npx -y firebase-tools@latest deploy --only dataconnect --token ${{ secrets.FIREBASE_TOKEN }} --force
 ```
 
----
+______________________________________________________________________
 
 ## VS Code Extension
 
 Install "Firebase SQL Connect" extension for:
+
 - Schema intellisense and validation
 - GraphQL operation testing
 - Emulator integration

--- a/skills/firebase-data-connect-basics/reference/data_seeding.md
+++ b/skills/firebase-data-connect-basics/reference/data_seeding.md
@@ -1,23 +1,33 @@
 # Data Seeding & Bulk Operations Reference
 
-Use this reference to populate local development databases for prototyping, execute CI/CD tests, and perform bulk data migrations in production environments.
+Use this reference to populate local development databases for prototyping,
+execute CI/CD tests, and perform bulk data migrations in production
+environments.
 
----
+______________________________________________________________________
 
 ## 1. Local Prototyping: Data Seeding
 
-Local database seeding allows developer agents to test queries, mutations, complex joins, and role-based access control (RBAC) under realistic conditions.
+Local database seeding allows developer agents to test queries, mutations,
+complex joins, and role-based access control (RBAC) under realistic conditions.
 
 ### The `seed_data.gql` Workflow
 
-**Always write prototyping seed mutations to `dataconnect/seed_data.gql`** (located at the project root, not inside `connector/`). This file is excluded from production deployments and client SDK generation.
+**Always write prototyping seed mutations to `dataconnect/seed_data.gql`**
+(located at the project root, not inside `connector/`). This file is excluded
+from production deployments and client SDK generation.
 
 #### ⚠️ Seeding Directives Rule
-**Do not declare `@auth` directives inside `seed_data.gql` mutations.** Since this file runs locally to establish a test state and is not an exposed API connector endpoint, authorization directives are completely unnecessary and should be omitted.
+
+**Do not declare `@auth` directives inside `seed_data.gql` mutations.** Since
+this file runs locally to establish a test state and is not an exposed API
+connector endpoint, authorization directives are completely unnecessary and
+should be omitted.
 
 ### Seeding Independent Tables (FK Order)
 
-When executing standard bulk insertions (`_insertMany`) across multiple tables, **always insert parent tables before referencing them in child or join tables.**
+When executing standard bulk insertions (`_insertMany`) across multiple tables,
+**always insert parent tables before referencing them in child or join tables.**
 
 ```graphql
 # dataconnect/seed_data.gql
@@ -43,9 +53,13 @@ mutation SeedIndependentTables @transaction {
 
 ### Seeding Related Tables (Nested Relational Inserts)
 
-**To seed parent-child relationships atomically, perform a nested relational insert using literal payloads.** This avoids the need to manage foreign keys manually.
+**To seed parent-child relationships atomically, perform a nested relational
+insert using literal payloads.** This avoids the need to manage foreign keys
+manually.
 
-* **Omit Parent Foreign Keys**: **Do not specify the parent foreign key** (e.g. `movieId`) inside the nested child objects. The database engine automatically maps and resolves them.
+- **Omit Parent Foreign Keys**: **Do not specify the parent foreign key** (e.g.
+  `movieId`) inside the nested child objects. The database engine automatically
+  maps and resolves them.
 
 ```graphql
 # dataconnect/seed_data.gql
@@ -75,10 +89,15 @@ mutation SeedMoviesAndReviews @transaction {
 
 ### Resetting Seed Data
 
-For continuous testing or CI/CD flows, return the database to a zero state using one of the following strategies:
+For continuous testing or CI/CD flows, return the database to a zero state using
+one of the following strategies:
 
-* **Strategy A: Upsert Many (Idempotent)**: Re-run seeds using `_upsertMany` mutations. This overrides existing records or inserts missing ones in a single step.
-* **Strategy B: Delete and Re-Insert**: Call `_deleteMany(all: true)` on your tables in **reverse foreign key order** (child/join tables first, then parent tables) followed by your seed `_insertMany` operations.
+- **Strategy A: Upsert Many (Idempotent)**: Re-run seeds using `_upsertMany`
+  mutations. This overrides existing records or inserts missing ones in a single
+  step.
+- **Strategy B: Delete and Re-Insert**: Call `_deleteMany(all: true)` on your
+  tables in **reverse foreign key order** (child/join tables first, then parent
+  tables) followed by your seed `_insertMany` operations.
 
 ```graphql
 # dataconnect/seed_data.gql
@@ -91,17 +110,23 @@ mutation ResetDatabaseToOriginalState @transaction {
 }
 ```
 
----
+______________________________________________________________________
 
 ## 2. Production: Admin SDK Bulk Operations
 
-**Use the Firebase Admin SDK for Node.js for bulk data loading and production migrations.** Avoid running large mutations directly via raw GraphQL endpoints in production.
+**Use the Firebase Admin SDK for Node.js for bulk data loading and production
+migrations.** Avoid running large mutations directly via raw GraphQL endpoints
+in production.
 
-The Admin SDK provides direct, type-safe methods: `dc.insert`, `dc.insertMany`, `dc.upsert`, and `dc.upsertMany`. 
+The Admin SDK provides direct, type-safe methods: `dc.insert`, `dc.insertMany`,
+`dc.upsert`, and `dc.upsertMany`.
 
 ### SDK Bulk APIs Features:
-* **No Manual GraphQL Strings**: Do not write raw `mutation {...}` strings when executing privileged batch operations. Pass Javascript objects directly.
-* **Relational Support**: The bulk helper methods natively support nested 1:Many relationships inside the input arrays.
+
+- **No Manual GraphQL Strings**: Do not write raw `mutation {...}` strings when
+  executing privileged batch operations. Pass Javascript objects directly.
+- **Relational Support**: The bulk helper methods natively support nested 1:Many
+  relationships inside the input arrays.
 
 ### SDK Bulk Operations Example
 
@@ -144,11 +169,17 @@ const bulkMoviesData = [
 const response = await dc.insertMany("movie", bulkMoviesData);
 ```
 
----
+______________________________________________________________________
 
 ## 3. Production: Bulk Operations via raw SQL
 
-When working with a stable schema in production, you can use standard SQL tools (like `psql` or Cloud SQL import pipelines) to execute bulk data updates directly on the PostgreSQL instance.
+When working with a stable schema in production, you can use standard SQL tools
+(like `psql` or Cloud SQL import pipelines) to execute bulk data updates
+directly on the PostgreSQL instance.
 
 ### 🚨 Critical SQL Operations Constraint
-**Never modify your database schema directly using SQL tools.** Direct schema alterations (`ALTER TABLE`, `CREATE INDEX`, etc.) outside of your `schema.gql` file will bypass SQL Connect's schema compiler, breaking connector mappings, and causing active client SDK integrations to fail.
+
+**Never modify your database schema directly using SQL tools.** Direct schema
+alterations (`ALTER TABLE`, `CREATE INDEX`, etc.) outside of your `schema.gql`
+file will bypass SQL Connect's schema compiler, breaking connector mappings, and
+causing active client SDK integrations to fail.

--- a/skills/firebase-data-connect-basics/reference/native_sql.md
+++ b/skills/firebase-data-connect-basics/reference/native_sql.md
@@ -1,110 +1,158 @@
 # Native SQL Operations
 
-Always default to Native GraphQL. Use Native SQL **only** when you need database-specific features not available in GraphQL (e.g., PostGIS, Window Functions, Complex Aggregations, or specific DML CTEs).
+Always default to Native GraphQL. Use Native SQL **only** when you need
+database-specific features not available in GraphQL (e.g., PostGIS, Window
+Functions, Complex Aggregations, or specific DML CTEs).
 
 ## Core Agent Constraints
 
-When generating Native SQL operations, you are bypassing GraphQL and talking directly to PostgreSQL. You **MUST** adhere to these strict constraints:
+When generating Native SQL operations, you are bypassing GraphQL and talking
+directly to PostgreSQL. You **MUST** adhere to these strict constraints:
 
-1.  **Operation Syntax Isolation:** Never mix Native SQL positional parameters (`$1`) with standard GraphQL named variables (`$id`). The `sql:` argument MUST be a hardcoded string literal block (`"""SELECT..."""`), not a GraphQL variable.
-2.  **Table & Column Mapping (Case Sensitivity):**
-    *   **Default `snake_case` Conversion:** By default, SQL Connect converts `PascalCase` types and `camelCase` fields to `snake_case` in the database.
-        *   *Schema:* `type UserProfile { releaseYear: Int }` -> *Native SQL:* `SELECT release_year FROM user_profile`
-    *   **Explicit Overrides (Requires Double Quotes):** If the schema uses `@table(name: "ExactName")` or `@col(name: "ExactCol")`, you **MUST wrap the identifier in double quotes** if it contains capital letters (e.g., `SELECT * FROM "ExactName"`). Without quotes, Postgres folds it to lowercase and fails validation.
+1. **Operation Syntax Isolation:** Never mix Native SQL positional parameters
+   (`$1`) with standard GraphQL named variables (`$id`). The `sql:` argument
+   MUST be a hardcoded string literal block (`"""SELECT..."""`), not a GraphQL
+   variable.
+1. **Table & Column Mapping (Case Sensitivity):**
+   - **Default `snake_case` Conversion:** By default, SQL Connect converts
+     `PascalCase` types and `camelCase` fields to `snake_case` in the database.
+     - *Schema:* `type UserProfile { releaseYear: Int }` -> *Native SQL:*
+       `SELECT release_year FROM user_profile`
+   - **Explicit Overrides (Requires Double Quotes):** If the schema uses
+     `@table(name: "ExactName")` or `@col(name: "ExactCol")`, you **MUST wrap
+     the identifier in double quotes** if it contains capital letters (e.g.,
+     `SELECT * FROM "ExactName"`). Without quotes, Postgres folds it to
+     lowercase and fails validation.
 
 ## Syntax rules & limitations
 
-Native SQL enforces strict parsing rules to ensure security and prevent SQL injection:
+Native SQL enforces strict parsing rules to ensure security and prevent SQL
+injection:
 
-*   **String Literals Only:** The `sql` argument must be a hardcoded string literal block (`"""SELECT..."""`) directly in the `.gql` file. It **cannot** be a GraphQL variable.
-*   **Validation:** Do **NOT** use DDL in any operations (modify the `schema.gql` file instead for table/column changes). Furthermore, `query` operations cannot contain DML and must start with `SELECT`, `TABLE`, or `WITH`.
-*   **Parameters:** Use strict positional parameters (`$1`, `$2`) that match the `params` array order. Named parameters (`$id`, `:name`) are **forbidden**.
-*   **Comments:** Use block comments (`/* ... */`). Line comments (`--`) are **forbidden** because they can truncate subsequent clauses during query compilation. If you comment out a line containing a parameter (e.g., `/* WHERE id = $1 */`), you must also remove that parameter from the `params` list, or it will fail with `unused parameter: $1`.
-*   **Strings:** Extended string literals (`E'...'`) and dollar-quoted strings (`$$...$$`) are supported.
-*   **Context Maps (`_expr`):** Variables **cannot** be used inside `_expr` fields; to ensure security, `_expr` must be a static string (e.g., `{_expr: "auth.uid"}`, not `{_expr: $uidVar}`).
+- **String Literals Only:** The `sql` argument must be a hardcoded string
+  literal block (`"""SELECT..."""`) directly in the `.gql` file. It **cannot**
+  be a GraphQL variable.
+- **Validation:** Do **NOT** use DDL in any operations (modify the `schema.gql`
+  file instead for table/column changes). Furthermore, `query` operations cannot
+  contain DML and must start with `SELECT`, `TABLE`, or `WITH`.
+- **Parameters:** Use strict positional parameters (`$1`, `$2`) that match the
+  `params` array order. Named parameters (`$id`, `:name`) are **forbidden**.
+- **Comments:** Use block comments (`/* ... */`). Line comments (`--`) are
+  **forbidden** because they can truncate subsequent clauses during query
+  compilation. If you comment out a line containing a parameter (e.g.,
+  `/* WHERE id = $1 */`), you must also remove that parameter from the `params`
+  list, or it will fail with `unused parameter: $1`.
+- **Strings:** Extended string literals (`E'...'`) and dollar-quoted strings
+  (`$$...$$`) are supported.
+- **Context Maps (`_expr`):** Variables **cannot** be used inside `_expr`
+  fields; to ensure security, `_expr` must be a static string (e.g.,
+  `{_expr: "auth.uid"}`, not `{_expr: $uidVar}`).
 
 ## Native SQL Root Fields
 
-Operations are executed using the permissions granted to the SQL Connect service account. You can alias the root field (e.g., `movies: _select`) to make the client response cleaner (`data.movies` instead of `data._select`).
+Operations are executed using the permissions granted to the SQL Connect service
+account. You can alias the root field (e.g., `movies: _select`) to make the
+client response cleaner (`data.movies` instead of `data._select`).
 
-> **Note on `Any` Return Types:** Because Native SQL completely bypasses GraphQL's strong typing, queries like `_select` and `_executeReturning` return the generic `Any` scalar type. The generated client SDKs (TypeScript, Swift, Kotlin, Dart) will type this as `any` (or equivalent). **AGENT INSTRUCTION**: When you generate client-side code that consumes these operations, you MUST manually cast or validate the shape of the data, as the typical type safety of SQL Connect will not be present.
+> **Note on `Any` Return Types:** Because Native SQL completely bypasses
+> GraphQL's strong typing, queries like `_select` and `_executeReturning` return
+> the generic `Any` scalar type. The generated client SDKs (TypeScript, Swift,
+> Kotlin, Dart) will type this as `any` (or equivalent). **AGENT INSTRUCTION**:
+> When you generate client-side code that consumes these operations, you MUST
+> manually cast or validate the shape of the data, as the typical type safety of
+> SQL Connect will not be present.
 
 Use these root fields in `query` or `mutation` operations:
 
 ### Query Fields (Read-Only)
 
-*   `_select`: Executes a SQL query returning zero or more rows. Returns `[Any]`.
-    ```graphql
-    query GetMovies($genre: String!) @auth(level: PUBLIC) {
-      movies: _select(
-        sql: "SELECT id, title FROM movie WHERE genre = $1",
-        params: [$genre]
-      )
-    }
-    ```
-*   `_selectFirst`: Executes a SQL query expected to return zero or one row. Returns `Any` or `null`.
-    ```graphql
-    query GetTotalReviews @auth(level: PUBLIC) {
-      stats: _selectFirst(
-        sql: "SELECT COUNT(*) as total_reviews FROM review"
-      ) # params can be omitted if empty
-    }
-    ```
+- `_select`: Executes a SQL query returning zero or more rows. Returns `[Any]`.
+  ```graphql
+  query GetMovies($genre: String!) @auth(level: PUBLIC) {
+    movies: _select(
+      sql: "SELECT id, title FROM movie WHERE genre = $1",
+      params: [$genre]
+    )
+  }
+  ```
+- `_selectFirst`: Executes a SQL query expected to return zero or one row.
+  Returns `Any` or `null`.
+  ```graphql
+  query GetTotalReviews @auth(level: PUBLIC) {
+    stats: _selectFirst(
+      sql: "SELECT COUNT(*) as total_reviews FROM review"
+    ) # params can be omitted if empty
+  }
+  ```
 
 ### Mutation Fields (DML)
 
-*   `_execute`: Executes DML (`INSERT`, `UPDATE`, `DELETE`). Returns `Int` (number of rows affected).
-    *   *Note 1:* `RETURNING` clauses are ignored in the result.
-    *   *Note 2:* Only `_execute` supports Data-Modifying Common Table Expressions (e.g., `WITH new_row AS (INSERT...)`).
-    ```graphql
-    mutation UpdateRating($id: UUID!, $rating: Float!) @auth(level: USER) {
-      _execute(
-        sql: "UPDATE movie SET rating = $2 WHERE id = $1",
-        params: [$id, $rating]
-      )
-    }
-    ```
-*   `_executeReturning`: Executes DML with a `RETURNING` clause. Returns `[Any]`. Data-Modifying CTEs are **not** supported.
-    ```graphql
-    mutation DeleteUserReviews($uid: String!) @auth(level: USER) {
-      deletedReviews: _executeReturning(
-        sql: "DELETE FROM review WHERE user_id = $1 RETURNING id, rating",
-        params: [{_expr: "auth.uid"}]
-      )
-    }
-    ```
-*   `_executeReturningFirst`: Executes DML with `RETURNING`, expecting zero or one row. Returns `Any` or `null`. Data-Modifying CTEs are **not** supported.
-    ```graphql
-    mutation UpdateMyReview($movieId: UUID!, $text: String!) @auth(level: USER) {
-      updatedReview: _executeReturningFirst(
-        sql: """
-          UPDATE review SET text = $2 
-          WHERE movie_id = $1 AND user_id = $3 
-          RETURNING id, text
-        """,
-        params: [$movieId, $text, {_expr: "auth.uid"}]
-      )
-    }
-    ```
-    
+- `_execute`: Executes DML (`INSERT`, `UPDATE`, `DELETE`). Returns `Int` (number
+  of rows affected).
+  - *Note 1:* `RETURNING` clauses are ignored in the result.
+  - *Note 2:* Only `_execute` supports Data-Modifying Common Table Expressions
+    (e.g., `WITH new_row AS (INSERT...)`).
+  ```graphql
+  mutation UpdateRating($id: UUID!, $rating: Float!) @auth(level: USER) {
+    _execute(
+      sql: "UPDATE movie SET rating = $2 WHERE id = $1",
+      params: [$id, $rating]
+    )
+  }
+  ```
+- `_executeReturning`: Executes DML with a `RETURNING` clause. Returns `[Any]`.
+  Data-Modifying CTEs are **not** supported.
+  ```graphql
+  mutation DeleteUserReviews($uid: String!) @auth(level: USER) {
+    deletedReviews: _executeReturning(
+      sql: "DELETE FROM review WHERE user_id = $1 RETURNING id, rating",
+      params: [{_expr: "auth.uid"}]
+    )
+  }
+  ```
+- `_executeReturningFirst`: Executes DML with `RETURNING`, expecting zero or one
+  row. Returns `Any` or `null`. Data-Modifying CTEs are **not** supported.
+  ```graphql
+  mutation UpdateMyReview($movieId: UUID!, $text: String!) @auth(level: USER) {
+    updatedReview: _executeReturningFirst(
+      sql: """
+        UPDATE review SET text = $2 
+        WHERE movie_id = $1 AND user_id = $3 
+        RETURNING id, text
+      """,
+      params: [$movieId, $text, {_expr: "auth.uid"}]
+    )
+  }
+  ```
+
 ### PostgreSQL Extensions
 
-Native SQL allows you to directly query and utilize PostgreSQL extensions, such as `PostGIS`, without needing to map complex geometry types into your GraphQL schema or alter your underlying tables (e.g., using JSON operators to extract values and pass them into `ST_MakePoint`). 
+Native SQL allows you to directly query and utilize PostgreSQL extensions, such
+as `PostGIS`, without needing to map complex geometry types into your GraphQL
+schema or alter your underlying tables (e.g., using JSON operators to extract
+values and pass them into `ST_MakePoint`).
 
-*Note: You must enable the extension on your underlying Cloud SQL instance by connecting as the `postgres` user and running `CREATE EXTENSION IF NOT EXISTS ...;`*
+*Note: You must enable the extension on your underlying Cloud SQL instance by
+connecting as the `postgres` user and running
+`CREATE EXTENSION IF NOT EXISTS ...;`*
 
 *(See `examples.md` for a full `GetNearbyActiveRestaurants` implementation).*
 
 ## ⚠️ Security: Stored Procedures & Dynamic SQL
 
-SQL Connect parameterizes inputs at the GraphQL boundary automatically. However, if your Native SQL calls **custom PL/pgSQL stored procedures**, you must manually prevent 2nd-order SQL injection:
+SQL Connect parameterizes inputs at the GraphQL boundary automatically. However,
+if your Native SQL calls **custom PL/pgSQL stored procedures**, you must
+manually prevent 2nd-order SQL injection:
 
-*   **NEVER** concatenate user input into an `EXECUTE` string (`EXECUTE 'UPDATE ' || table || ' SET x=' || val;`).
-*   **DO** use the `USING` clause to bind data values safely.
-*   **DO** use `format('%I')` for safe database identifier injection.
-*   **DO** validate dynamic table/column names against a strict hardcoded allowlist.
+- **NEVER** concatenate user input into an `EXECUTE` string
+  (`EXECUTE 'UPDATE ' || table || ' SET x=' || val;`).
+- **DO** use the `USING` clause to bind data values safely.
+- **DO** use `format('%I')` for safe database identifier injection.
+- **DO** validate dynamic table/column names against a strict hardcoded
+  allowlist.
 
 **Secure PL/pgSQL Pattern:**
+
 ```sql
 CREATE OR REPLACE PROCEDURE secure_update(target_table TEXT, new_value TEXT, row_id INT)
 LANGUAGE plpgsql AS $$

--- a/skills/firebase-data-connect-basics/reference/operations.md
+++ b/skills/firebase-data-connect-basics/reference/operations.md
@@ -1,50 +1,58 @@
 # Operations Reference
 
 ## Contents
+
 - [Generated Fields](#generated-fields)
 - [Queries](#queries)
 - [Mutations](#mutations)
 - [Key Scalars](#key-scalars)
 - [Multi-Step Operations](#multi-step-operations)
 
----
+______________________________________________________________________
 
 ## Generated Fields
 
 SQL Connect auto-generates fields for each `@table` type:
 
-| Generated Field | Purpose | Example |
-|-----------------|---------|---------|
-| `movie(id: UUID, key: Key, first: Row)` | Get single record | `movie(id: $id)` or `movie(first: {where: ...})` |
-| `movies(where: ..., orderBy: ..., limit: ..., offset: ..., distinct: ..., having: ...)` | List/filter records | `movies(where: {...})` |
-| `movie_insert(data: ...)` | Create record | Returns key |
-| `movie_insertMany(data: [...])` | Bulk create | Returns keys |
-| `movie_update(id: ..., data: ...)` | Update by ID | Returns key or null |
-| `movie_updateMany(where: ..., data: ...)` | Bulk update | Returns count |
-| `movie_upsert(data: ...)` | Insert or update | Returns key |
-| `movie_delete(id: ...)` | Delete by ID | Returns key or null |
-| `movie_deleteMany(where: ...)` | Bulk delete | Returns count |
+| Generated Field                                                                         | Purpose             | Example                                          |
+| --------------------------------------------------------------------------------------- | ------------------- | ------------------------------------------------ |
+| `movie(id: UUID, key: Key, first: Row)`                                                 | Get single record   | `movie(id: $id)` or `movie(first: {where: ...})` |
+| `movies(where: ..., orderBy: ..., limit: ..., offset: ..., distinct: ..., having: ...)` | List/filter records | `movies(where: {...})`                           |
+| `movie_insert(data: ...)`                                                               | Create record       | Returns key                                      |
+| `movie_insertMany(data: [...])`                                                         | Bulk create         | Returns keys                                     |
+| `movie_update(id: ..., data: ...)`                                                      | Update by ID        | Returns key or null                              |
+| `movie_updateMany(where: ..., data: ...)`                                               | Bulk update         | Returns count                                    |
+| `movie_upsert(data: ...)`                                                               | Insert or update    | Returns key                                      |
+| `movie_delete(id: ...)`                                                                 | Delete by ID        | Returns key or null                              |
+| `movie_deleteMany(where: ...)`                                                          | Bulk delete         | Returns count                                    |
 
 ### Relation Fields
+
 For a `Post` with `author: User!`:
+
 - `post.author` - Navigate to related User
 - `user.posts_on_author` - Reverse: all Posts by User
 
 For many-to-many via `MovieActor`:
+
 - `movie.actors_via_MovieActor` - Get all actors
 - `actor.movies_via_MovieActor` - Get all movies
 
----
+______________________________________________________________________
 
 ## Referencing Generated GraphQL Schema
 
-**Do not guess** available queries or mutations. Review the generated schema files instead of trying to deduce them from the data model.
+**Do not guess** available queries or mutations. Review the generated schema
+files instead of trying to deduce them from the data model.
 
 1. **Location**: `.dataconnect/schema/main/` (relative to project root).
-2. **Action**: Scan this directory for generated files (`query.gql`, `mutation.gql`, `relation.gql`, `input.gql`) to understand the exact shape of the API and auto-generated types.
-3. **Validation**: Always run `firebase dataconnect:compile` to verify operations against the full schema.
+1. **Action**: Scan this directory for generated files (`query.gql`,
+   `mutation.gql`, `relation.gql`, `input.gql`) to understand the exact shape of
+   the API and auto-generated types.
+1. **Validation**: Always run `firebase dataconnect:compile` to verify
+   operations against the full schema.
 
----
+______________________________________________________________________
 
 ## Queries
 
@@ -78,19 +86,19 @@ query ListMovies($genre: String, $minRating: Int) @auth(level: PUBLIC) {
 
 ### Filter Operators
 
-| Operator | Description | Example |
-|----------|-------------|---------|
-| `eq` | Equals | `{ title: { eq: "Matrix" }}` |
-| `ne` | Not equals | `{ status: { ne: "deleted" }}` |
-| `gt`, `ge` | Greater than (or equal) | `{ rating: { ge: 4 }}` |
-| `lt`, `le` | Less than (or equal) | `{ releaseYear: { lt: 2000 }}` |
-| `in` | In list | `{ genre: { in: ["Action", "Drama"] }}` |
-| `nin` | Not in list | `{ status: { nin: ["deleted", "hidden"] }}` |
-| `isNull` | Is null check | `{ description: { isNull: true }}` |
-| `contains` | String contains | `{ title: { contains: "war" }}` |
-| `startsWith` | String starts with | `{ title: { startsWith: "The" }}` |
-| `endsWith` | String ends with | `{ email: { endsWith: "@gmail.com" }}` |
-| `includes` | Array includes | `{ tags: { includes: "sci-fi" }}` |
+| Operator     | Description             | Example                                     |
+| ------------ | ----------------------- | ------------------------------------------- |
+| `eq`         | Equals                  | `{ title: { eq: "Matrix" }}`                |
+| `ne`         | Not equals              | `{ status: { ne: "deleted" }}`              |
+| `gt`, `ge`   | Greater than (or equal) | `{ rating: { ge: 4 }}`                      |
+| `lt`, `le`   | Less than (or equal)    | `{ releaseYear: { lt: 2000 }}`              |
+| `in`         | In list                 | `{ genre: { in: ["Action", "Drama"] }}`     |
+| `nin`        | Not in list             | `{ status: { nin: ["deleted", "hidden"] }}` |
+| `isNull`     | Is null check           | `{ description: { isNull: true }}`          |
+| `contains`   | String contains         | `{ title: { contains: "war" }}`             |
+| `startsWith` | String starts with      | `{ title: { startsWith: "The" }}`           |
+| `endsWith`   | String ends with        | `{ email: { endsWith: "@gmail.com" }}`      |
+| `includes`   | Array includes          | `{ tags: { includes: "sci-fi" }}`           |
 
 ### Expression Operators (Compare with Server Values)
 
@@ -174,7 +182,7 @@ query CompareRatings($genre: String!) @auth(level: PUBLIC) {
 }
 ```
 
----
+______________________________________________________________________
 
 ## Mutations
 
@@ -234,14 +242,14 @@ mutation AddTag($id: UUID!, $tag: String!) @auth(level: USER) {
 }
 ```
 
-| Operator | Types | Description |
-|----------|-------|-------------|
-| `inc` | Int, Float, Date, Timestamp | Increment value |
-| `dec` | Int, Float, Date, Timestamp | Decrement value |
-| `add` | Lists | Add items if not present |
-| `remove` | Lists | Remove all matching items |
-| `append` | Lists | Append to end |
-| `prepend` | Lists | Prepend to start |
+| Operator  | Types                       | Description               |
+| --------- | --------------------------- | ------------------------- |
+| `inc`     | Int, Float, Date, Timestamp | Increment value           |
+| `dec`     | Int, Float, Date, Timestamp | Decrement value           |
+| `add`     | Lists                       | Add items if not present  |
+| `remove`  | Lists                       | Remove all matching items |
+| `append`  | Lists                       | Append to end             |
+| `prepend` | Lists                       | Prepend to start          |
 
 ### Upsert
 
@@ -284,11 +292,12 @@ mutation UpdateMyPost($id: UUID!, $content: String!) @auth(level: USER) {
 }
 ```
 
----
+______________________________________________________________________
 
 ## Key Scalars
 
-Key scalars (`Movie_Key`, `User_Key`) are auto-generated types representing primary keys:
+Key scalars (`Movie_Key`, `User_Key`) are auto-generated types representing
+primary keys:
 
 ```graphql
 # Using key scalar
@@ -312,7 +321,7 @@ mutation CreateAndFetch($title: String!) @auth(level: USER) {
 }
 ```
 
----
+______________________________________________________________________
 
 ## Multi-Step Operations
 

--- a/skills/firebase-data-connect-basics/reference/realtime.md
+++ b/skills/firebase-data-connect-basics/reference/realtime.md
@@ -1,36 +1,43 @@
 # Realtime Reference
 
 ## Contents
+
 - [When to Use What](#when-to-use-what)
 - [The @refresh Directive](#the-refresh-directive)
 - [CEL Bindings in Conditions](#cel-bindings-in-conditions)
 - [Implicit Entity Refresh signals](#implicit-entity-refresh-signals)
 
----
+______________________________________________________________________
 
 ## When to Use What
 
-SQL Connect provides three mechanisms for live data updates. Pick the right one based on what you're querying:
+SQL Connect provides three mechanisms for live data updates. Pick the right one
+based on what you're querying:
 
-| Scenario | Mechanism | Directive Needed? |
-|----------|-----------|-------------------|
-| Single-entity lookup by ID (e.g., `movie(id: $id)`) | **Automatic refresh** | No — SQL Connect handles it |
+| Scenario                                                    | Mechanism                | Directive Needed?                   |
+| ----------------------------------------------------------- | ------------------------ | ----------------------------------- |
+| Single-entity lookup by ID (e.g., `movie(id: $id)`)         | **Automatic refresh**    | No — SQL Connect handles it         |
 | List query that should update when a specific mutation runs | **Event-driven refresh** | `@refresh(onMutationExecuted: ...)` |
-| Any query that should poll at a fixed interval | **Time-based polling** | `@refresh(every: ...)` |
+| Any query that should poll at a fixed interval              | **Time-based polling**   | `@refresh(every: ...)`              |
 
-List queries require explicit `@refresh` to tell SQL Connect which mutations affect the result set.
+List queries require explicit `@refresh` to tell SQL Connect which mutations
+affect the result set.
 
-Clients consume all three using `subscribe()` instead of `execute()`. See [sdks.md](sdks.md) for per-platform subscribe patterns.
+Clients consume all three using `subscribe()` instead of `execute()`. See
+[sdks.md](sdks.md) for per-platform subscribe patterns.
 
----
+______________________________________________________________________
 
 ## The @refresh Directive
 
-`@refresh` is a **repeatable** directive applied to **queries**. It defines when connected subscribers should receive updated data.
+`@refresh` is a **repeatable** directive applied to **queries**. It defines when
+connected subscribers should receive updated data.
 
 ### Time-Based Polling (`every`)
 
-Keep the query fresh with a recommended refresh interval. Note that `every` and `mutation` signals can be used together; whichever signal arrives first will trigger the refresh.
+Keep the query fresh with a recommended refresh interval. Note that `every` and
+`mutation` signals can be used together; whichever signal arrives first will
+trigger the refresh.
 
 ```graphql
 query MovieLeaderboard
@@ -43,16 +50,20 @@ query MovieLeaderboard
 ```
 
 **Constraints:**
+
 - The `every` argument takes a duration object: `{ seconds: Int }`
 - **Minimum**: `{ seconds: 10 }` — protects against excessive server load
 - **Maximum**: `{ hours: 1 }` (3600 seconds)
 - Values outside this range fail validation at deploy time
 
-Use time-based polling when freshness matters but you don't have a specific mutation to listen for (e.g., dashboards aggregating external data, stock tickers, activity feeds).
+Use time-based polling when freshness matters but you don't have a specific
+mutation to listen for (e.g., dashboards aggregating external data, stock
+tickers, activity feeds).
 
 ### Explicit Mutation Signals (`onMutationExecuted`)
 
-Trigger a query refresh when a specific mutation executes. This is the most common pattern for keeping lists in sync.
+Trigger a query refresh when a specific mutation executes. This is the most
+common pattern for keeping lists in sync.
 
 ```graphql
 # Example with condition (refreshes only when the condition is met)
@@ -77,12 +88,19 @@ query ListAllMessages
 ```
 
 **Arguments:**
-- **`operation`** (required): The name of the mutation operation to listen for. Must match the mutation's operation name exactly.
-- **`condition`** (optional): A CEL expression that must evaluate to `true` for the refresh to fire. Without a condition, every execution of the named mutation triggers a refresh.
 
-It's highly recommended to define fine granular conditions. Inaccurate refresh policies could consume Postgres resources and make your app slower.
+- **`operation`** (required): The name of the mutation operation to listen for.
+  Must match the mutation's operation name exactly.
+- **`condition`** (optional): A CEL expression that must evaluate to `true` for
+  the refresh to fire. Without a condition, every execution of the named
+  mutation triggers a refresh.
 
-Use conditions to scope refreshes precisely — a review list should only refresh when the mutation targets the same movie, not every review across the entire app.
+It's highly recommended to define fine granular conditions. Inaccurate refresh
+policies could consume Postgres resources and make your app slower.
+
+Use conditions to scope refreshes precisely — a review list should only refresh
+when the mutation targets the same movie, not every review across the entire
+app.
 
 ### Combining Multiple @refresh Directives
 
@@ -102,31 +120,35 @@ query ActiveOrders($userId: UUID!)
 }
 ```
 
-This query refreshes whenever an order status changes for this user, *and* polls every 60 seconds as a fallback to catch any updates that might not have a direct mutation trigger.
+This query refreshes whenever an order status changes for this user, *and* polls
+every 60 seconds as a fallback to catch any updates that might not have a direct
+mutation trigger.
 
----
+______________________________________________________________________
 
 ## CEL Bindings in Conditions
 
 The `condition` expression in `onMutationExecuted` has access to two contexts:
 
 ### `request` — The Query Subscription
+
 The state of the query being subscribed to.
 
-| Binding | Description |
-|---------|-------------|
-| `request.variables` | Variables passed to the query (e.g., `request.variables.id`) |
-| `request.auth.uid` | UID of the user who subscribed |
-| `request.auth.token` | Full auth token claims of the subscriber |
+| Binding              | Description                                                  |
+| -------------------- | ------------------------------------------------------------ |
+| `request.variables`  | Variables passed to the query (e.g., `request.variables.id`) |
+| `request.auth.uid`   | UID of the user who subscribed                               |
+| `request.auth.token` | Full auth token claims of the subscriber                     |
 
 ### `mutation` — The Triggering Event
+
 The mutation that just executed.
 
-| Binding | Description |
-|---------|-------------|
-| `mutation.variables` | Variables passed to the mutation (e.g., `mutation.variables.movieId`) |
-| `mutation.auth.uid` | UID of the user who executed the mutation |
-| `mutation.auth.token` | Full auth token claims of the mutation executor |
+| Binding               | Description                                                           |
+| --------------------- | --------------------------------------------------------------------- |
+| `mutation.variables`  | Variables passed to the mutation (e.g., `mutation.variables.movieId`) |
+| `mutation.auth.uid`   | UID of the user who executed the mutation                             |
+| `mutation.auth.token` | Full auth token claims of the mutation executor                       |
 
 ### Common Patterns
 
@@ -144,23 +166,30 @@ The mutation that just executed.
 "mutation.variables.isPublic == true"
 ```
 
----
+______________________________________________________________________
 
 ## Implicit Entity Refresh signals
 
-For single-entity lookups by unique identifier, SQL Connect handles refreshes automatically — no `@refresh` directive needed.
+For single-entity lookups by unique identifier, SQL Connect handles refreshes
+automatically — no `@refresh` directive needed.
 
 **What qualifies:**
-- Queries fetching one entity by its primary key: `movie(id: $id)`, `user(key: { uid: $uid })`
-- If a single-entity mutation modifies that specific entity, all active subscribers automatically receive the update. Supported operations include:
-    *   `_insert(data)` or `_insertMany(data)`
-    *   `_upsert(data)` or `_upsertMany(data)`
-    *   `_update(id)` or `_update(key)`
-    *   `_delete(id)` or `_delete(key)`
-- **Note**: Bulk operations like `_updateMany` and `_deleteMany` do **not** trigger automatic entity refreshes.
+
+- Queries fetching one entity by its primary key: `movie(id: $id)`,
+  `user(key: { uid: $uid })`
+- If a single-entity mutation modifies that specific entity, all active
+  subscribers automatically receive the update. Supported operations include:
+  - `_insert(data)` or `_insertMany(data)`
+  - `_upsert(data)` or `_upsertMany(data)`
+  - `_update(id)` or `_update(key)`
+  - `_delete(id)` or `_delete(key)`
+- **Note**: Bulk operations like `_updateMany` and `_deleteMany` do **not**
+  trigger automatic entity refreshes.
 
 **What does NOT qualify:**
-- List queries: `movies(where: {...})`, `users { id name }` — these require explicit `@refresh`
+
+- List queries: `movies(where: {...})`, `users { id name }` — these require
+  explicit `@refresh`
 - Nested query with JOINs
 - Aggregation
 - Native SQL
@@ -176,4 +205,6 @@ query GetMovie($id: UUID!) @auth(level: PUBLIC) {
 }
 ```
 
-To consume automatic refreshes on the client, use `subscribe()` instead of `execute()` — the same client pattern works regardless of whether the refresh is automatic or directive-driven.
+To consume automatic refreshes on the client, use `subscribe()` instead of
+`execute()` — the same client pattern works regardless of whether the refresh is
+automatic or directive-driven.

--- a/skills/firebase-data-connect-basics/reference/schema.md
+++ b/skills/firebase-data-connect-basics/reference/schema.md
@@ -1,17 +1,19 @@
 # Schema Reference
 
 ## Contents
+
 - [Defining Types](#defining-types)
 - [Core Directives](#core-directives)
 - [Relationships](#relationships)
 - [Data Types](#data-types)
 - [Enumerations](#enumerations)
 
----
+______________________________________________________________________
 
 ## Defining Types
 
-Types with `@table` map to PostgreSQL tables. SQL Connect auto-generates an implicit `id: UUID!` primary key.
+Types with `@table` map to PostgreSQL tables. SQL Connect auto-generates an
+implicit `id: UUID!` primary key.
 
 ```graphql
 type Movie @table {
@@ -44,44 +46,49 @@ type User @table(key: "uid") {
 }
 ```
 
----
+______________________________________________________________________
 
 ## Core Directives
 
 ### @table
+
 Defines a database table.
 
-| Argument | Description |
-|----------|-------------|
-| `name` | PostgreSQL table name (snake_case default) |
-| `key` | Primary key field(s), default `["id"]` |
-| `singular` | Singular name for generated fields |
-| `plural` | Plural name for generated fields |
+| Argument   | Description                                |
+| ---------- | ------------------------------------------ |
+| `name`     | PostgreSQL table name (snake_case default) |
+| `key`      | Primary key field(s), default `["id"]`     |
+| `singular` | Singular name for generated fields         |
+| `plural`   | Plural name for generated fields           |
 
 ### @col
+
 Customizes column mapping.
 
-| Argument | Description |
-|----------|-------------|
-| `name` | Column name in PostgreSQL |
+| Argument   | Description                                           |
+| ---------- | ----------------------------------------------------- |
+| `name`     | Column name in PostgreSQL                             |
 | `dataType` | PostgreSQL type: `serial`, `varchar(n)`, `text`, etc. |
-| `size` | Required for `Vector` type |
+| `size`     | Required for `Vector` type                            |
 
 ### @default
+
 Sets default value for inserts.
 
-| Argument | Description |
-|----------|-------------|
-| `value` | Literal value: `@default(value: "draft")` |
-| `expr` | CEL expression: `@default(expr: "uuidV4()")`, `@default(expr: "auth.uid")`, `@default(expr: "request.time")` |
-| `sql` | Raw SQL: `@default(sql: "now()")` |
+| Argument | Description                                                                                                  |
+| -------- | ------------------------------------------------------------------------------------------------------------ |
+| `value`  | Literal value: `@default(value: "draft")`                                                                    |
+| `expr`   | CEL expression: `@default(expr: "uuidV4()")`, `@default(expr: "auth.uid")`, `@default(expr: "request.time")` |
+| `sql`    | Raw SQL: `@default(sql: "now()")`                                                                            |
 
 **Common expressions:**
+
 - `uuidV4()` - Generate UUID
 - `auth.uid` - Current user's Firebase Auth UID
 - `request.time` - Server timestamp
 
 ### @unique
+
 Adds unique constraint.
 
 ```graphql
@@ -98,6 +105,7 @@ type Review @table @unique(fields: ["movie", "user"]) {
 ```
 
 ### @index
+
 Creates database index for query performance.
 
 ```graphql
@@ -108,13 +116,14 @@ type Movie @table @index(fields: ["genre", "releaseYear"], order: [ASC, DESC]) {
 }
 ```
 
-| Argument | Description |
-|----------|-------------|
-| `fields` | Fields for composite index (on @table) |
-| `order` | `[ASC]` or `[DESC]` for each field |
-| `type` | `BTREE` (default), `GIN` (arrays), `HNSW`/`IVFFLAT` (vectors) |
+| Argument | Description                                                   |
+| -------- | ------------------------------------------------------------- |
+| `fields` | Fields for composite index (on @table)                        |
+| `order`  | `[ASC]` or `[DESC]` for each field                            |
+| `type`   | `BTREE` (default), `GIN` (arrays), `HNSW`/`IVFFLAT` (vectors) |
 
 ### @searchable
+
 Enables full-text search on String fields.
 
 ```graphql
@@ -129,7 +138,7 @@ query SearchPosts($q: String!) @auth(level: PUBLIC) {
 }
 ```
 
----
+______________________________________________________________________
 
 ## Relationships
 
@@ -150,6 +159,7 @@ type User @table {
 ```
 
 ### @ref Directive
+
 Customizes foreign key reference.
 
 ```graphql
@@ -159,13 +169,14 @@ type Post @table {
 }
 ```
 
-| Argument | Description |
-|----------|-------------|
-| `fields` | Local FK field name(s) |
-| `references` | Target field(s) in referenced table |
-| `constraintName` | PostgreSQL constraint name |
+| Argument         | Description                         |
+| ---------------- | ----------------------------------- |
+| `fields`         | Local FK field name(s)              |
+| `references`     | Target field(s) in referenced table |
+| `constraintName` | PostgreSQL constraint name          |
 
 **Cascade behavior:**
+
 - Required reference (`User!`): CASCADE DELETE (post deleted when user deleted)
 - Optional reference (`User`): SET NULL (authorId set to null when user deleted)
 
@@ -205,25 +216,25 @@ type MovieActor @table(key: ["movie", "actor"]) {
 # - movie.movieActors_on_movie: [MovieActor!]!
 ```
 
----
+______________________________________________________________________
 
 ## Data Types
 
-| GraphQL Type | PostgreSQL Default | Other PostgreSQL Types |
-|--------------|-------------------|----------------------|
-| `String` | `text` | `varchar(n)`, `char(n)` |
-| `Int` | `int4` | `int2`, `serial` |
-| `Int64` | `bigint` | `bigserial`, `numeric` |
-| `Float` | `float8` | `float4`, `numeric` |
-| `Boolean` | `boolean` | |
-| `UUID` | `uuid` | |
-| `Date` | `date` | |
-| `Timestamp` | `timestamptz` | Stored as UTC |
-| `Any` | `jsonb` | |
-| `Vector` | `vector` | Requires `@col(size: N)` |
-| `[Type]` | Array | e.g., `[String]` → `text[]` |
+| GraphQL Type | PostgreSQL Default | Other PostgreSQL Types      |
+| ------------ | ------------------ | --------------------------- |
+| `String`     | `text`             | `varchar(n)`, `char(n)`     |
+| `Int`        | `int4`             | `int2`, `serial`            |
+| `Int64`      | `bigint`           | `bigserial`, `numeric`      |
+| `Float`      | `float8`           | `float4`, `numeric`         |
+| `Boolean`    | `boolean`          |                             |
+| `UUID`       | `uuid`             |                             |
+| `Date`       | `date`             |                             |
+| `Timestamp`  | `timestamptz`      | Stored as UTC               |
+| `Any`        | `jsonb`            |                             |
+| `Vector`     | `vector`           | Requires `@col(size: N)`    |
+| `[Type]`     | Array              | e.g., `[String]` → `text[]` |
 
----
+______________________________________________________________________
 
 ## Enumerations
 
@@ -241,12 +252,13 @@ type Post @table {
 ```
 
 **Rules:**
+
 - Enum names: PascalCase, no underscores
 - Enum values: UPPER_SNAKE_CASE
 - Values are ordered (for comparison operations)
 - Changing order or removing values is a breaking change
 
----
+______________________________________________________________________
 
 ## Views (Advanced)
 

--- a/skills/firebase-data-connect-basics/reference/sdk_admin_node.md
+++ b/skills/firebase-data-connect-basics/reference/sdk_admin_node.md
@@ -1,14 +1,28 @@
 # Admin Node SDK
 
-Consult this file when writing server-side code (e.g., Cloud Functions) that needs elevated privileges or needs to impersonate specific users.
+Consult this file when writing server-side code (e.g., Cloud Functions) that
+needs elevated privileges or needs to impersonate specific users.
 
 ### Best Practices for Agents
-- **Understand Operation Storage**: SQL Connect queries and mutations are stored on the server like Cloud Functions. Clients do not submit the raw operations. Therefore, **whenever you update operations, you must regenerate the SDK and redeploy services** that use it.
-- **Follow Least Privilege**: Admin SDKs have unrestricted access by default. Always use impersonation when possible to limit access.
-- **Impersonation**: Use the `impersonate` parameter to run operations as a specific user or as an unauthenticated user.
-- **Impersonation Variables**: If you call an operation with optional variables and want to pass impersonation options but without variables, you **MUST** pass `undefined` as the first argument (variables) to clearly indicate no variables are being provided.
-- **Admin Operations**: If you create operations intended only for administration, define them with `@auth(level: NO_ACCESS)`. This ensures they can only be called via the Admin SDK with unrestricted access.
-- **Resilient Enum Handling**: JavaScript/TypeScript does not enforce exhaustive checks on enums. Always add a `default` branch to `switch` statements or an `else` branch to handle unknown values gracefully when schemas evolve.
+
+- **Understand Operation Storage**: SQL Connect queries and mutations are stored
+  on the server like Cloud Functions. Clients do not submit the raw operations.
+  Therefore, **whenever you update operations, you must regenerate the SDK and
+  redeploy services** that use it.
+- **Follow Least Privilege**: Admin SDKs have unrestricted access by default.
+  Always use impersonation when possible to limit access.
+- **Impersonation**: Use the `impersonate` parameter to run operations as a
+  specific user or as an unauthenticated user.
+- **Impersonation Variables**: If you call an operation with optional variables
+  and want to pass impersonation options but without variables, you **MUST**
+  pass `undefined` as the first argument (variables) to clearly indicate no
+  variables are being provided.
+- **Admin Operations**: If you create operations intended only for
+  administration, define them with `@auth(level: NO_ACCESS)`. This ensures they
+  can only be called via the Admin SDK with unrestricted access.
+- **Resilient Enum Handling**: JavaScript/TypeScript does not enforce exhaustive
+  checks on enums. Always add a `default` branch to `switch` statements or an
+  `else` branch to handle unknown values gracefully when schemas evolve.
 
 ### Configuration in `connector.yaml`
 
@@ -34,6 +48,7 @@ npx -y firebase-tools@latest dataconnect:sdk:generate
 ### Usage Examples
 
 #### 1. Impersonating an Unauthenticated User
+
 Unauthenticated users can only run operations marked as `PUBLIC`.
 
 ```typescript
@@ -52,7 +67,9 @@ const songs = await getSongs(
 ```
 
 #### 2. Impersonating a Specific User (Cloud Functions)
-When using callable Cloud Functions, the authentication token is automatically verified.
+
+When using callable Cloud Functions, the authentication token is automatically
+verified.
 
 ```typescript
 import { HttpsError, onCall } from "firebase-functions/https";
@@ -75,6 +92,7 @@ export const callableExample = onCall(async (req) => {
 ```
 
 #### 3. Impersonating a Specific User (Plain HTTP)
+
 For non-callable endpoints, you must verify the token yourself.
 
 ```typescript
@@ -109,7 +127,9 @@ export const httpExample = onRequest(async (req, res) => {
 ```
 
 #### 4. Running with Unrestricted Access
-Omit the `impersonate` parameter to run with full admin access. Only do this for true administrative tasks.
+
+Omit the `impersonate` parameter to run with full admin access. Only do this for
+true administrative tasks.
 
 ```typescript
 import { upsertSong } from "@dataconnect/admin-generated";

--- a/skills/firebase-data-connect-basics/reference/sdk_android.md
+++ b/skills/firebase-data-connect-basics/reference/sdk_android.md
@@ -1,16 +1,28 @@
 # Android SDK
 
-Consult this file when writing Android application code (Kotlin) that interacts with the SQL Connect backend.
+Consult this file when writing Android application code (Kotlin) that interacts
+with the SQL Connect backend.
 
 ### Best Practices for Agents
-- **Understand Operation Storage**: SQL Connect queries and mutations are stored on the server like Cloud Functions. **Whenever you update operations, you must regenerate the SDK and redeploy services** that use it to avoid breaking clients.
-- **Resilient Enum Handling**: The generated SDK forces handling of unknown values by wrapping them in `EnumValue`. You must unwrap it into `EnumValue.Known` or `EnumValue.Unknown` to handle schema updates gracefully.
-- **Flow Behavior**: While you can collect a Flow from a query, note that **this Flow is not updated in real-time automatically** by default. It only produces a result when a new query result is retrieved using a call to the query's `execute()` method.
-- **Leverage Coroutines**: Call `.execute()` within a coroutine scope for asynchronous operations.
+
+- **Understand Operation Storage**: SQL Connect queries and mutations are stored
+  on the server like Cloud Functions. **Whenever you update operations, you must
+  regenerate the SDK and redeploy services** that use it to avoid breaking
+  clients.
+- **Resilient Enum Handling**: The generated SDK forces handling of unknown
+  values by wrapping them in `EnumValue`. You must unwrap it into
+  `EnumValue.Known` or `EnumValue.Unknown` to handle schema updates gracefully.
+- **Flow Behavior**: While you can collect a Flow from a query, note that **this
+  Flow is not updated in real-time automatically** by default. It only produces
+  a result when a new query result is retrieved using a call to the query's
+  `execute()` method.
+- **Leverage Coroutines**: Call `.execute()` within a coroutine scope for
+  asynchronous operations.
 
 ### Dependencies (build.gradle.kts)
 
-Ensure you have the Kotlin Serialization plugin and standard SQL Connect dependencies:
+Ensure you have the Kotlin Serialization plugin and standard SQL Connect
+dependencies:
 
 ```kotlin
 plugins {
@@ -45,6 +57,7 @@ connector.dataConnect.useEmulator()
 ### Calling Operations
 
 #### Basic Query
+
 ```kotlin
 val result = connector.listMovies.execute()
 result.data.movies.forEach { movie ->
@@ -53,6 +66,7 @@ result.data.movies.forEach { movie ->
 ```
 
 #### Mutation
+
 ```kotlin
 val newMovie = connector.createMovie.execute(
     title = "Empire Strikes Back",
@@ -63,6 +77,7 @@ val newMovie = connector.createMovie.execute(
 ```
 
 ### Resilient Enum Handling
+
 Unwrap the `EnumValue` to handle known and unknown cases safely.
 
 ```kotlin
@@ -77,7 +92,9 @@ result.data.movies.forEach { movie ->
 ```
 
 ### Client-Side Caching
-Enable caching in `connector.yaml` to reduce requests and support offline scenarios.
+
+Enable caching in `connector.yaml` to reduce requests and support offline
+scenarios.
 
 ```yaml
 generate:
@@ -90,12 +107,14 @@ generate:
 ```
 
 Use policies in code:
+
 ```kotlin
 val queryResult = queryRef.execute(QueryRef.FetchPolicy.CACHE_ONLY)
 val queryResult = queryRef.execute(QueryRef.FetchPolicy.SERVER_ONLY)
 ```
 
 ### Data Type Mapping Reference
+
 - GraphQL `String` -> Kotlin `String`
 - GraphQL `Int` -> Kotlin `Int` (32-bit)
 - GraphQL `Float` -> Kotlin `Double` (64-bit)

--- a/skills/firebase-data-connect-basics/reference/sdk_flutter.md
+++ b/skills/firebase-data-connect-basics/reference/sdk_flutter.md
@@ -1,12 +1,21 @@
 # Flutter SDK
 
-Consult this file when writing Flutter application code (Dart) that interacts with the SQL Connect backend.
+Consult this file when writing Flutter application code (Dart) that interacts
+with the SQL Connect backend.
 
 ### Best Practices for Agents
-- **Understand Operation Storage**: SQL Connect queries and mutations are stored on the server like Cloud Functions. **Whenever you update operations, you must regenerate the SDK and redeploy services** that use it to avoid breaking clients.
-- **Resilient Enum Handling**: The generated SDK forces handling of unknown values for enumerations. Client code must unwrap the `EnumValue` object into either `Known` or `Unknown` to handle schema updates gracefully.
-- **Use Ref for Subscriptions**: Call `.ref()` on operation methods to get a `QueryRef` for advanced usage like subscriptions.
-- **Builder Pattern for Optionals**: Use the builder pattern for mutations with optional fields.
+
+- **Understand Operation Storage**: SQL Connect queries and mutations are stored
+  on the server like Cloud Functions. **Whenever you update operations, you must
+  regenerate the SDK and redeploy services** that use it to avoid breaking
+  clients.
+- **Resilient Enum Handling**: The generated SDK forces handling of unknown
+  values for enumerations. Client code must unwrap the `EnumValue` object into
+  either `Known` or `Unknown` to handle schema updates gracefully.
+- **Use Ref for Subscriptions**: Call `.ref()` on operation methods to get a
+  `QueryRef` for advanced usage like subscriptions.
+- **Builder Pattern for Optionals**: Use the builder pattern for mutations with
+  optional fields.
 
 ### Installation
 
@@ -32,12 +41,14 @@ MoviesConnector.instance.dataConnect.useDataConnectEmulator('127.0.0.1', 9399);
 ### Calling Operations
 
 #### Basic Query
+
 ```dart
 final response = await MoviesConnector.instance.listMovies().execute();
 print(response.data.movies);
 ```
 
 #### Mutation with Optional Fields (Builder Pattern)
+
 ```dart
 await MoviesConnector.instance.createMovie(
   title: 'Empire Strikes Back', 
@@ -47,7 +58,10 @@ await MoviesConnector.instance.createMovie(
 ```
 
 ### Resilient Enum Handling
-When dealing with schema enumerations, use the forced unwrapping pattern to handle unknown values (e.g., when a new value is added to the backend but client is old).
+
+When dealing with schema enumerations, use the forced unwrapping pattern to
+handle unknown values (e.g., when a new value is added to the backend but client
+is old).
 
 ```dart
 final result = await MoviesConnector.instance.listMovies().execute();
@@ -74,7 +88,9 @@ void handleEnumValue(EnumValue<AspectRatio> aspectValue) {
 ```
 
 ### Client-Side Caching
-Enable caching in `connector.yaml` to reduce requests and support offline scenarios.
+
+Enable caching in `connector.yaml` to reduce requests and support offline
+scenarios.
 
 ```yaml
 generate:
@@ -87,6 +103,7 @@ generate:
 ```
 
 Use policies in code:
+
 ```dart
 // Only serve cached values
 await queryRef.execute(fetchPolicy: QueryFetchPolicy.cacheOnly);
@@ -108,6 +125,7 @@ final subscription = queryRef.subscribe().listen((result) {
 ```
 
 ### Data Type Mapping Reference
+
 - GraphQL `Timestamp` -> Dart `firebase_data_connect.Timestamp`
 - GraphQL `Int` -> Dart `int`
 - GraphQL `Date` -> Dart `DateTime`

--- a/skills/firebase-data-connect-basics/reference/sdk_ios.md
+++ b/skills/firebase-data-connect-basics/reference/sdk_ios.md
@@ -1,12 +1,22 @@
 # iOS SDK
 
-Consult this file when writing iOS application code (Swift) that interacts with the SQL Connect backend.
+Consult this file when writing iOS application code (Swift) that interacts with
+the SQL Connect backend.
 
 ### Best Practices for Agents
-- **Understand Operation Storage**: SQL Connect queries and mutations are stored on the server like Cloud Functions. **Whenever you update operations, you must regenerate the SDK and redeploy services** that use it to avoid breaking clients.
-- **Resilient Enum Handling**: The generated SDK forces handling of unknown values by adding an `._UNKNOWN` case. Swift enforces exhaustive switch statements, so you must handle this case.
-- **Observable Macro**: By default, query refs support the `@Observable` macro (iOS 17+), making them ideal for binding to SwiftUI views. The bindable query results are available in the `data` variable of the query ref.
-- **Handle Errors**: Use `try await` with operation execution as they are asynchronous and may throw errors.
+
+- **Understand Operation Storage**: SQL Connect queries and mutations are stored
+  on the server like Cloud Functions. **Whenever you update operations, you must
+  regenerate the SDK and redeploy services** that use it to avoid breaking
+  clients.
+- **Resilient Enum Handling**: The generated SDK forces handling of unknown
+  values by adding an `._UNKNOWN` case. Swift enforces exhaustive switch
+  statements, so you must handle this case.
+- **Observable Macro**: By default, query refs support the `@Observable` macro
+  (iOS 17+), making them ideal for binding to SwiftUI views. The bindable query
+  results are available in the `data` variable of the query ref.
+- **Handle Errors**: Use `try await` with operation execution as they are
+  asynchronous and may throw errors.
 
 ### Dependencies (Package.swift or SPM)
 
@@ -34,6 +44,7 @@ connector.useEmulator()
 ### Calling Operations
 
 #### Basic Query
+
 ```swift
 let result = try await connector.listMovies.execute()
 for movie in result.data.movies {
@@ -42,6 +53,7 @@ for movie in result.data.movies {
 ```
 
 #### Mutation
+
 ```swift
 let mutationResult = try await connector.createMovieMutation.execute(
   title: "Empire Strikes Back",
@@ -52,6 +64,7 @@ let mutationResult = try await connector.createMovieMutation.execute(
 ```
 
 ### Resilient Enum Handling
+
 Handle generated enums exhaustively, including the `._UNKNOWN` case.
 
 ```swift
@@ -73,7 +86,9 @@ do {
 ```
 
 ### Client-Side Caching
-Enable caching in `connector.yaml` to reduce requests, support offline scenarios, enable realtime support for queries.
+
+Enable caching in `connector.yaml` to reduce requests, support offline
+scenarios, enable realtime support for queries.
 
 ```yaml
 generate:
@@ -86,6 +101,7 @@ generate:
 ```
 
 Use cache policies in code:
+
 ```swift
 try await execute(fetchPolicy: .cacheOnly)
 try await execute(fetchPolicy: .serverOnly)
@@ -132,6 +148,7 @@ struct ListMovieView: View {
 ```
 
 ### Data Type Mapping Reference
+
 - GraphQL `UUID` -> Swift `UUID`
 - GraphQL `Date` -> Swift `FirebaseDataConnect.LocalDate`
 - GraphQL `Timestamp` -> Swift `FirebaseCore.Timestamp`

--- a/skills/firebase-data-connect-basics/reference/sdk_web.md
+++ b/skills/firebase-data-connect-basics/reference/sdk_web.md
@@ -1,12 +1,24 @@
 # Web SDK
 
-Consult this file when writing client-side web code (TypeScript/JavaScript) that interacts with the SQL Connect backend.
+Consult this file when writing client-side web code (TypeScript/JavaScript) that
+interacts with the SQL Connect backend.
 
 ### Best Practices for Agents
-- **Understand Operation Storage**: SQL Connect queries and mutations are stored on the server like Cloud Functions. **Whenever you update operations, you must regenerate the SDK and redeploy services** that use it to avoid breaking clients.
-- **Resilient Enum Handling**: JavaScript/TypeScript does not enforce exhaustive checks on enums. Always add a `default` branch to `switch` statements or an `else` branch to handle unknown values gracefully when schemas evolve.
-- **TanStack Query vs. Native**: You can generate hooks for React/Angular using TanStack Query. Choose either TanStack or SQL Connect's built-in real-time and caching support, but do not use both in the same project. SQL Connect offers normalized caching and remote invalidation.
-- **Emulator Connection**: `connectDataConnectEmulator` is only required if connecting to the emulator. Otherwise, the generated SDK auto-creates the instance.
+
+- **Understand Operation Storage**: SQL Connect queries and mutations are stored
+  on the server like Cloud Functions. **Whenever you update operations, you must
+  regenerate the SDK and redeploy services** that use it to avoid breaking
+  clients.
+- **Resilient Enum Handling**: JavaScript/TypeScript does not enforce exhaustive
+  checks on enums. Always add a `default` branch to `switch` statements or an
+  `else` branch to handle unknown values gracefully when schemas evolve.
+- **TanStack Query vs. Native**: You can generate hooks for React/Angular using
+  TanStack Query. Choose either TanStack or SQL Connect's built-in real-time and
+  caching support, but do not use both in the same project. SQL Connect offers
+  normalized caching and remote invalidation.
+- **Emulator Connection**: `connectDataConnectEmulator` is only required if
+  connecting to the emulator. Otherwise, the generated SDK auto-creates the
+  instance.
 
 ### Installation
 
@@ -29,6 +41,7 @@ connectDataConnectEmulator(dataConnect, 'localhost', 9399);
 ### Calling Operations
 
 #### Using `executeQuery` (Preferred for clarity)
+
 ```typescript
 import { executeQuery } from 'firebase/data-connect';
 import { listMoviesRef } from '@dataconnect/generated';
@@ -39,6 +52,7 @@ console.log(data.movies);
 ```
 
 #### Using Action Shortcuts
+
 ```typescript
 import { listMovies } from '@dataconnect/generated';
 
@@ -46,6 +60,7 @@ listMovies().then(data => showInUI(data));
 ```
 
 ### Resilient Enum Handling
+
 Use a `default` case or check against `Object.values`.
 
 ```typescript
@@ -69,6 +84,7 @@ if (queryResult.data) {
 ```
 
 ### Client-Side Caching
+
 Enable caching in `connector.yaml`:
 
 ```yaml
@@ -82,15 +98,18 @@ generate:
 ```
 
 Use policies in code:
+
 ```typescript
 await executeQuery(queryRef, QueryFetchPolicy.CACHE_ONLY);
 await executeQuery(queryRef, QueryFetchPolicy.SERVER_ONLY);
 ```
 
 ### Subscriptions (Realtime)
+
 Use `subscribe()` to receive live updates.
 
 #### Web (Vanilla JS)
+
 ```typescript
 import { subscribe } from 'firebase/data-connect';
 import { getMovieByIdRef } from '@dataconnect/generated';
@@ -103,9 +122,11 @@ const unsubscribe = subscribe(queryRef, (result) => {
 ```
 
 ### TanStack Query Support (React)
+
 To use React hooks, re-run `firebase init dataconnect:sdk` after adding React.
 
 #### Usage
+
 ```typescript
 import { useListAllMovies } from "@dataconnect/generated/react";
 
@@ -116,6 +137,7 @@ function MyComponent() {
 ```
 
 ### Data Type Mapping Reference
+
 - GraphQL `Timestamp` -> TypeScript `string`
 - GraphQL `Date` -> TypeScript `string`
 - GraphQL `UUID` -> TypeScript `string`

--- a/skills/firebase-data-connect-basics/reference/search.md
+++ b/skills/firebase-data-connect-basics/reference/search.md
@@ -1,34 +1,46 @@
 # Search Solutions Reference (Vector & Full-Text Search)
 
-Use this reference to design, configure, and implement search capabilities in SQL Connect. SQL Connect supports three types of search:
-1. **Vector Similarity Search (Semantic)**: Best for finding conceptually/semantically similar rows (e.g., recommendations, "more like this"). Requires Vertex AI.
-2. **Full-Text Search (Lexical)**: Best for keyword and phrase search across single or multiple columns. Supports lexical stemming.
-3. **String Pattern Filters (Exact/Regex)**: Best for simple prefix, exact match, or basic wildcard queries (uses standard Postgres indexing).
+Use this reference to design, configure, and implement search capabilities in
+SQL Connect. SQL Connect supports three types of search:
 
----
+1. **Vector Similarity Search (Semantic)**: Best for finding
+   conceptually/semantically similar rows (e.g., recommendations, "more like
+   this"). Requires Vertex AI.
+1. **Full-Text Search (Lexical)**: Best for keyword and phrase search across
+   single or multiple columns. Supports lexical stemming.
+1. **String Pattern Filters (Exact/Regex)**: Best for simple prefix, exact
+   match, or basic wildcard queries (uses standard Postgres indexing).
+
+______________________________________________________________________
 
 ## Search Selection Guide
 
-Use this comparative guide to choose the optimal search strategy for the user's task:
+Use this comparative guide to choose the optimal search strategy for the user's
+task:
 
-| Feature / Capability | Vector Similarity Search | Full-Text Search | String Pattern Filters |
-| :--- | :--- | :--- | :--- |
-| **Use Case** | Semantic search, recommendations, RAG pipelines. | Keyword search, parsing large text fields. | Exact matches, regular expressions, simple wildcards. |
-| **Engine Support** | Vertex AI Embeddings + `pgvector` extension. | Native PostgreSQL full-text engine. | Native PostgreSQL indexing (`LIKE`, `ILIKE`). |
-| **Matching Style** | Semantic/concept proximity. | Lexical stemming (tenses, root words). | Exact character sequence. |
-| **Column Support** | Single column per query. | Multiple columns combined. | Multiple columns via standard logical filters (`_or`). |
-| **Overhead** | High (API execution costs & vector column storage). | Medium (generates indices & tsvector columns). | Low (uses standard index / minimal storage). |
+| Feature / Capability | Vector Similarity Search                            | Full-Text Search                               | String Pattern Filters                                 |
+| :------------------- | :-------------------------------------------------- | :--------------------------------------------- | :----------------------------------------------------- |
+| **Use Case**         | Semantic search, recommendations, RAG pipelines.    | Keyword search, parsing large text fields.     | Exact matches, regular expressions, simple wildcards.  |
+| **Engine Support**   | Vertex AI Embeddings + `pgvector` extension.        | Native PostgreSQL full-text engine.            | Native PostgreSQL indexing (`LIKE`, `ILIKE`).          |
+| **Matching Style**   | Semantic/concept proximity.                         | Lexical stemming (tenses, root words).         | Exact character sequence.                              |
+| **Column Support**   | Single column per query.                            | Multiple columns combined.                     | Multiple columns via standard logical filters (`_or`). |
+| **Overhead**         | High (API execution costs & vector column storage). | Medium (generates indices & tsvector columns). | Low (uses standard index / minimal storage).           |
 
----
+______________________________________________________________________
 
 ## 1. Vector Similarity Search (Semantic)
 
-Perform semantic matching by generating vector embeddings representing the semantic meaning of text.
+Perform semantic matching by generating vector embeddings representing the
+semantic meaning of text.
 
 ### Schema Setup
 
-* **Configure Column Dimensions**: Define the column dimension size using the `@col(size: X)` directive — SQL Connect requires an explicit size for Vector fields to allocate storage.
-* **Match Model Specifications**: Ensure the column size matches the output dimension of your chosen embedding model (e.g., **768** for Google Vertex AI's `textembedding-gecko` models) to prevent runtime type mismatches.
+- **Configure Column Dimensions**: Define the column dimension size using the
+  `@col(size: X)` directive — SQL Connect requires an explicit size for Vector
+  fields to allocate storage.
+- **Match Model Specifications**: Ensure the column size matches the output
+  dimension of your chosen embedding model (e.g., **768** for Google Vertex AI's
+  `textembedding-gecko` models) to prevent runtime type mismatches.
 
 ```graphql
 type Movie @table {
@@ -42,10 +54,14 @@ type Movie @table {
 
 ### Automatic Embedding Generation (`_embed` server value)
 
-Ensure you use the exact same embedding model across all queries and mutations on a given vector field — vector embeddings generated from different model versions are incompatible and will result in poor search relevance or errors.
+Ensure you use the exact same embedding model across all queries and mutations
+on a given vector field — vector embeddings generated from different model
+versions are incompatible and will result in poor search relevance or errors.
 
 #### A. Generation on Insert
-Use the `${vectorFieldName}_embed` input parameter to automatically generate and store embeddings on creation.
+
+Use the `${vectorFieldName}_embed` input parameter to automatically generate and
+store embeddings on creation.
 
 ```graphql
 # connector/mutations.gql
@@ -62,6 +78,7 @@ mutation CreateMovieWithEmbedding($title: String!, $description: String!) @auth(
 ```
 
 #### B. Generation on Update
+
 ```graphql
 # connector/mutations.gql
 mutation UpdateMovieDescription($id: UUID!, $description: String!) @auth(level: USER) {
@@ -80,11 +97,13 @@ mutation UpdateMovieDescription($id: UUID!, $description: String!) @auth(level: 
 
 ### Similarity Search Queries
 
-SQL Connect automatically generates a similarity query function for every `Vector` field in the format:
-`${pluralType}_${vectorFieldName}_similarity`
+SQL Connect automatically generates a similarity query function for every
+`Vector` field in the format: `${pluralType}_${vectorFieldName}_similarity`
 
 #### A. Auto-Embedding Search
-Use `compare_embed` to automatically convert the search query string into an embedding on the fly using Vertex AI.
+
+Use `compare_embed` to automatically convert the search query string into an
+embedding on the fly using Vertex AI.
 
 ```graphql
 # connector/queries.gql
@@ -101,7 +120,9 @@ query SearchMoviesByDescription($query: String!) @auth(level: PUBLIC) {
 ```
 
 #### B. Custom Vector Search
-Use `compare` to pass raw pre-computed float arrays (cast as a `Vector!`) directly to the search without calling Vertex AI.
+
+Use `compare` to pass raw pre-computed float arrays (cast as a `Vector!`)
+directly to the search without calling Vertex AI.
 
 ```graphql
 # connector/queries.gql
@@ -119,8 +140,12 @@ query SearchMoviesByCustomVector($vector: Vector!, $limit: Int!) @auth(level: PU
 
 ### Tuning Vector Proximity
 
-* **Distance Thresholding**: Select the `_metadata { distance }` field to evaluate how close the results are, then define a tight threshold using the `within` parameter.
-* **Distance Metric Gotcha**: `L2` and `COSINE` return different distance scales. Re-tune your `within` threshold if you change the `method` parameter, as their distance ranges are not compatible.
+- **Distance Thresholding**: Select the `_metadata { distance }` field to
+  evaluate how close the results are, then define a tight threshold using the
+  `within` parameter.
+- **Distance Metric Gotcha**: `L2` and `COSINE` return different distance
+  scales. Re-tune your `within` threshold if you change the `method` parameter,
+  as their distance ranges are not compatible.
 
 ```graphql
 # connector/queries.gql
@@ -138,15 +163,17 @@ query SearchMoviesCosineSimilarity($query: String!) @auth(level: PUBLIC) {
 }
 ```
 
----
+______________________________________________________________________
 
 ## 2. Full-Text Search (Lexical)
 
-Perform fast, stemmed keyword/phrase searches over single or multiple text columns in your table.
+Perform fast, stemmed keyword/phrase searches over single or multiple text
+columns in your table.
 
 ### Schema Setup
 
-To index columns for full-text search, declare the `@searchable` directive on the string fields inside your table schema.
+To index columns for full-text search, declare the `@searchable` directive on
+the string fields inside your table schema.
 
 ```graphql
 type Movie @table {
@@ -158,15 +185,19 @@ type Movie @table {
 }
 ```
 
-* **Stemming Language**: By default, parsing uses English stemming. Configure custom stemming using `@searchable(language: "languagename")`.
-* **Multi-Column Stemming Gotcha**: Ensure all indexed columns use the exact same language when searching over multiple columns in a single query — PostgreSQL requires matching text search configurations for multi-column queries.
+- **Stemming Language**: By default, parsing uses English stemming. Configure
+  custom stemming using `@searchable(language: "languagename")`.
+- **Multi-Column Stemming Gotcha**: Ensure all indexed columns use the exact
+  same language when searching over multiple columns in a single query —
+  PostgreSQL requires matching text search configurations for multi-column
+  queries.
 
----
+______________________________________________________________________
 
 ### Full-Text Search Queries
 
-SQL Connect automatically generates a full-text query function for each `@table` containing `@searchable` fields in the format:
-`${pluralType}_search`
+SQL Connect automatically generates a full-text query function for each `@table`
+containing `@searchable` fields in the format: `${pluralType}_search`
 
 ```graphql
 # connector/queries.gql
@@ -180,19 +211,24 @@ query SearchMoviesLexical($query: String!) @auth(level: PUBLIC) {
 }
 ```
 
----
+______________________________________________________________________
 
 ### Tuning Full-Text Queries
 
 Configuring query arguments optimizes match relevance and search styles.
 
 #### 1. Query Formats (`queryFormat` argument)
+
 Configure the search interpretation using the `queryFormat` parameter:
 
-* **`QUERY` (Default)**: Web-style search (e.g., `inception OR matrix`, `-"space-travel"`, quotes for exact matches).
-* **`PLAIN`**: Matches all words in the query string in any lexical order (e.g., `"brown dog"` matches `"the dog was brown"`).
-* **`PHRASE`**: Matches the exact, contiguous phrase sequence (e.g., `"brown dog"` matches `"the brown dog"`, but NOT `"dog is brown"`).
-* **`ADVANCED`**: Allows standard, complex PostgreSQL `tsquery` operators (e.g. `inception & (matrix | sci-fi)`).
+- **`QUERY` (Default)**: Web-style search (e.g., `inception OR matrix`,
+  `-"space-travel"`, quotes for exact matches).
+- **`PLAIN`**: Matches all words in the query string in any lexical order (e.g.,
+  `"brown dog"` matches `"the dog was brown"`).
+- **`PHRASE`**: Matches the exact, contiguous phrase sequence (e.g.,
+  `"brown dog"` matches `"the brown dog"`, but NOT `"dog is brown"`).
+- **`ADVANCED`**: Allows standard, complex PostgreSQL `tsquery` operators (e.g.
+  `inception & (matrix | sci-fi)`).
 
 ```graphql
 # connector/queries.gql
@@ -205,7 +241,10 @@ query SearchMoviesExactPhrase($query: String!) @auth(level: PUBLIC) {
 ```
 
 #### 2. Relevance Thresholding (`relevanceThreshold` and `_metadata.relevance`)
-Results default to sorting by descending relevance rank. Select `_metadata { relevance }` to inspect match rankings, then set a minimum `relevanceThreshold` value to prune loose or irrelevant matches.
+
+Results default to sorting by descending relevance rank. Select
+`_metadata { relevance }` to inspect match rankings, then set a minimum
+`relevanceThreshold` value to prune loose or irrelevant matches.
 
 ```graphql
 # connector/queries.gql

--- a/skills/firebase-data-connect-basics/reference/security.md
+++ b/skills/firebase-data-connect-basics/reference/security.md
@@ -1,6 +1,7 @@
 # Security Reference
 
 ## Contents
+
 - [@auth Directive](#auth-directive)
 - [Access Levels](#access-levels)
 - [CEL Expressions](#cel-expressions)
@@ -8,11 +9,12 @@
 - [Authorization Patterns](#authorization-patterns)
 - [Anti-Patterns](#anti-patterns)
 
----
+______________________________________________________________________
 
 ## @auth Directive
 
-Every deployable query/mutation must have `@auth`. Without it, operations default to `NO_ACCESS`.
+Every deployable query/mutation must have `@auth`. Without it, operations
+default to `NO_ACCESS`.
 
 ```graphql
 query PublicData @auth(level: PUBLIC) { ... }
@@ -20,51 +22,52 @@ query UserData @auth(level: USER) { ... }
 query AdminOnly @auth(expr: "auth.token.admin == true") { ... }
 ```
 
-| Argument | Description |
-|----------|-------------|
-| `level` | Preset access level |
-| `expr` | CEL expression (alternative to level) |
+| Argument         | Description                                        |
+| ---------------- | -------------------------------------------------- |
+| `level`          | Preset access level                                |
+| `expr`           | CEL expression (alternative to level)              |
 | `insecureReason` | Suppress deploy warning for PUBLIC/unfiltered USER |
 
----
+______________________________________________________________________
 
 ## Access Levels
 
-| Level | Who Can Access | CEL Equivalent |
-|-------|----------------|----------------|
-| `PUBLIC` | Anyone, authenticated or not | `true` |
-| `USER_ANON` | Any authenticated user (including anonymous) | `auth.uid != nil` |
-| `USER` | Authenticated users (excludes anonymous) | `auth.uid != nil && auth.token.firebase.sign_in_provider != 'anonymous'` |
-| `USER_EMAIL_VERIFIED` | Users with verified email | `auth.uid != nil && auth.token.email_verified` |
-| `NO_ACCESS` | Admin SDK only | `false` |
+| Level                 | Who Can Access                               | CEL Equivalent                                                           |
+| --------------------- | -------------------------------------------- | ------------------------------------------------------------------------ |
+| `PUBLIC`              | Anyone, authenticated or not                 | `true`                                                                   |
+| `USER_ANON`           | Any authenticated user (including anonymous) | `auth.uid != nil`                                                        |
+| `USER`                | Authenticated users (excludes anonymous)     | `auth.uid != nil && auth.token.firebase.sign_in_provider != 'anonymous'` |
+| `USER_EMAIL_VERIFIED` | Users with verified email                    | `auth.uid != nil && auth.token.email_verified`                           |
+| `NO_ACCESS`           | Admin SDK only                               | `false`                                                                  |
 
-> **Important:** Levels like `USER` are starting points. Always add filters or expressions to verify the user can access specific data.
+> **Important:** Levels like `USER` are starting points. Always add filters or
+> expressions to verify the user can access specific data.
 
----
+______________________________________________________________________
 
 ## CEL Expressions
 
 ### Available Bindings
 
-| Binding | Description |
-|---------|-------------|
-| `auth.uid` | Current user's Firebase UID |
-| `auth.token` | Auth token claims (see below) |
-| `vars` | Operation variables (e.g., `vars.movieId`) |
-| `request.time` | Server timestamp |
-| `request.operationName` | "query" or "mutation" |
+| Binding                 | Description                                |
+| ----------------------- | ------------------------------------------ |
+| `auth.uid`              | Current user's Firebase UID                |
+| `auth.token`            | Auth token claims (see below)              |
+| `vars`                  | Operation variables (e.g., `vars.movieId`) |
+| `request.time`          | Server timestamp                           |
+| `request.operationName` | "query" or "mutation"                      |
 
 ### auth.token Fields
 
-| Field | Description |
-|-------|-------------|
-| `email` | User's email address |
-| `email_verified` | Boolean: email verified |
-| `phone_number` | User's phone |
-| `name` | Display name |
-| `sub` | Firebase UID (same as auth.uid) |
+| Field                       | Description                                 |
+| --------------------------- | ------------------------------------------- |
+| `email`                     | User's email address                        |
+| `email_verified`            | Boolean: email verified                     |
+| `phone_number`              | User's phone                                |
+| `name`                      | Display name                                |
+| `sub`                       | Firebase UID (same as auth.uid)             |
 | `firebase.sign_in_provider` | `password`, `google.com`, `anonymous`, etc. |
-| `<custom_claim>` | Custom claims set via Admin SDK |
+| `<custom_claim>`            | Custom claims set via Admin SDK             |
 
 ### Expression Examples
 
@@ -104,13 +107,14 @@ mutation UpdateMyPost($id: UUID!, $title: String!) @auth(level: USER) {
 }
 ```
 
----
+______________________________________________________________________
 
 ## @check and @redact
 
 Use `@check` to validate data and `@redact` to hide results from client:
 
 ### @check
+
 Validates a field value; aborts if check fails.
 
 ```graphql
@@ -119,13 +123,14 @@ Validates a field value; aborts if check fails.
 @check(expr: "this.exists(p, p.role == 'admin')", message: "No admin found")
 ```
 
-| Argument | Description |
-|----------|-------------|
-| `expr` | CEL expression; `this` = current field value |
-| `message` | Error message if check fails |
-| `optional` | If `true`, pass when field not present |
+| Argument   | Description                                  |
+| ---------- | -------------------------------------------- |
+| `expr`     | CEL expression; `this` = current field value |
+| `message`  | Error message if check fails                 |
+| `optional` | If `true`, pass when field not present       |
 
 ### @redact
+
 Hides field from response (still evaluated for @check):
 
 ```graphql
@@ -162,7 +167,7 @@ mutation MustDeleteMovie($id: UUID!) @auth(level: USER) @transaction {
 }
 ```
 
----
+______________________________________________________________________
 
 ## Authorization Patterns
 
@@ -242,7 +247,7 @@ query ProContent @auth(expr: "auth.token.plan == 'pro'") {
 }
 ```
 
----
+______________________________________________________________________
 
 ## Anti-Patterns
 
@@ -286,4 +291,5 @@ query MyDocs @auth(level: USER) {
 
 ### ❌ Don't Use PUBLIC/USER for Prototyping
 
-During development, set operations to `NO_ACCESS` until you implement proper authorization. Use emulator and VS Code extension for testing.
+During development, set operations to `NO_ACCESS` until you implement proper
+authorization. Use emulator and VS Code extension for testing.

--- a/skills/firebase-data-connect-basics/templates.md
+++ b/skills/firebase-data-connect-basics/templates.md
@@ -2,7 +2,7 @@
 
 Ready-to-use templates for common Firebase SQL Connect patterns.
 
----
+______________________________________________________________________
 
 ## Basic CRUD Schema
 
@@ -49,7 +49,7 @@ mutation DeleteItem($id: UUID!) @auth(level: USER) {
 }
 ```
 
----
+______________________________________________________________________
 
 ## User-Owned Resources
 
@@ -113,7 +113,7 @@ mutation DeleteNote($id: UUID!) @auth(level: USER) {
 }
 ```
 
----
+______________________________________________________________________
 
 ## Many-to-Many Relationship
 
@@ -169,7 +169,7 @@ mutation RemoveTagFromArticle($articleId: UUID!, $tagId: UUID!) @auth(level: USE
 }
 ```
 
----
+______________________________________________________________________
 
 ## dataconnect.yaml Template
 
@@ -187,7 +187,7 @@ schema:
 connectorDirs: ["./connector"]
 ```
 
----
+______________________________________________________________________
 
 ## connector.yaml Template
 
@@ -207,7 +207,7 @@ generate:
     package: myapp_dataconnect
 ```
 
----
+______________________________________________________________________
 
 ## Firebase Init Commands
 
@@ -229,7 +229,7 @@ npx -y firebase-tools@latest dataconnect:sdk:generate
 npx -y firebase-tools@latest deploy --only dataconnect
 ```
 
----
+______________________________________________________________________
 
 ## SDK Initialization (Web)
 
@@ -268,7 +268,7 @@ console.log(data.items);
 await createItem({ name: 'New Item', description: 'Description' });
 ```
 
----
+______________________________________________________________________
 
 ## Realtime Query Templates
 

--- a/skills/firebase-firestore/SKILL.md
+++ b/skills/firebase-firestore/SKILL.md
@@ -17,26 +17,26 @@ rules, you MUST always identify the Firestore instance edition.
 
 ## 1. Instance Selection and Edition Detection
 
-Run the following command to list current Firestore databases: `bash npx -y
-firebase-tools@latest firestore:databases:list`
+Run the following command to list current Firestore databases:
+`bash npx -y firebase-tools@latest firestore:databases:list`
 
 ### A. Instance Found
 
-1.  For each database found, inspect its edition and details: `bash npx -y
-    firebase-tools@latest firestore:databases:get <database-id>`
-2.  Ask the user which database instance they wish to target or if they would
-    prefer to create a new instance.
-3.  Once the target instance is established:
-    -   If the **`edition`** is `STANDARD`, follow the guides under
-        `references/standard/`.
-    -   If the **`edition`** is `ENTERPRISE` or native mode, follow the guides
-        under `references/enterprise/`.
+1. For each database found, inspect its edition and details:
+   `bash npx -y firebase-tools@latest firestore:databases:get <database-id>`
+1. Ask the user which database instance they wish to target or if they would
+   prefer to create a new instance.
+1. Once the target instance is established:
+   - If the **`edition`** is `STANDARD`, follow the guides under
+     `references/standard/`.
+   - If the **`edition`** is `ENTERPRISE` or native mode, follow the guides
+     under `references/enterprise/`.
 
 ### B. No Instance Found (or New Requested)
 
-If no databases exist or the user requests a new one, default to provisioning an **Enterprise** edition database
-and ask the user what location to use.
-Run `npx -y firebase-tools@latest firestore:locations` to get the list of options.
+If no databases exist or the user requests a new one, default to provisioning an
+**Enterprise** edition database and ask the user what location to use. Run
+`npx -y firebase-tools@latest firestore:locations` to get the list of options.
 Suggest colocating with other resources if applicable.
 
 Once the location is determined, create the database:
@@ -44,27 +44,46 @@ Once the location is determined, create the database:
 
 Proceed with using the guides under `references/enterprise/`.
 
---------------------------------------------------------------------------------
+______________________________________________________________________
 
 ## 2. Specialized Guides
 
-Based on the identified or created instance edition, open and read the corresponding reference guides:
+Based on the identified or created instance edition, open and read the
+corresponding reference guides:
 
 ### Standard Edition (`references/standard/`)
 
--   **Provisioning**: Read [provisioning.md](references/standard/provisioning.md)
--   **Security Rules**: Read [security_rules.md](references/standard/security_rules.md)
--   **SDK Usage**: Read [web_sdk_usage.md](references/standard/web_sdk_usage.md), [android_sdk_usage.md](references/standard/android_sdk_usage.md), [ios_setup.md](references/standard/ios_setup.md), or [flutter_setup.md](references/standard/flutter_setup.md)
--   **Indexes**: Read [indexes.md](references/standard/indexes.md)
+- **Provisioning**: Read [provisioning.md](references/standard/provisioning.md)
+- **Security Rules**: Read
+  [security_rules.md](references/standard/security_rules.md)
+- **SDK Usage**: Read [web_sdk_usage.md](references/standard/web_sdk_usage.md),
+  [android_sdk_usage.md](references/standard/android_sdk_usage.md),
+  [ios_setup.md](references/standard/ios_setup.md), or
+  [flutter_setup.md](references/standard/flutter_setup.md)
+- **Indexes**: Read [indexes.md](references/standard/indexes.md)
 
 ### Enterprise Edition / Native Mode (`references/enterprise/`)
 
--   **Provisioning**: Read [provisioning.md](references/enterprise/provisioning.md)
--   **Data Model**: Read [data_model.md](references/enterprise/data_model.md)
--   **Security Rules**: Read [security_rules.md](references/enterprise/security_rules.md)
--   **SDK Usage**:
-    > [!CRITICAL] **Mandatory Reference Reading**
-    > Before writing or modifying any application code for Firestore Enterprise Edition, you **MUST** read at least one of the relevant reference documents below for the target platform/language to understand specific architectural requirements and pipeline initialization patterns.
+- **Provisioning**: Read
+  [provisioning.md](references/enterprise/provisioning.md)
 
-    Read [web_sdk_usage.md](references/enterprise/web_sdk_usage.md), [python_sdk_usage.md](references/enterprise/python_sdk_usage.md), [android_sdk_usage.md](references/enterprise/android_sdk_usage.md), [ios_setup.md](references/enterprise/ios_setup.md), or [flutter_setup.md](references/enterprise/flutter_setup.md)
--   **Indexes**: Read [indexes.md](references/enterprise/indexes.md)
+- **Data Model**: Read [data_model.md](references/enterprise/data_model.md)
+
+- **Security Rules**: Read
+  [security_rules.md](references/enterprise/security_rules.md)
+
+- **SDK Usage**:
+
+  > [!CRITICAL] **Mandatory Reference Reading** Before writing or modifying any
+  > application code for Firestore Enterprise Edition, you **MUST** read at
+  > least one of the relevant reference documents below for the target
+  > platform/language to understand specific architectural requirements and
+  > pipeline initialization patterns.
+
+  Read [web_sdk_usage.md](references/enterprise/web_sdk_usage.md),
+  [python_sdk_usage.md](references/enterprise/python_sdk_usage.md),
+  [android_sdk_usage.md](references/enterprise/android_sdk_usage.md),
+  [ios_setup.md](references/enterprise/ios_setup.md), or
+  [flutter_setup.md](references/enterprise/flutter_setup.md)
+
+- **Indexes**: Read [indexes.md](references/enterprise/indexes.md)

--- a/skills/firebase-firestore/references/enterprise/android_sdk_usage.md
+++ b/skills/firebase-firestore/references/enterprise/android_sdk_usage.md
@@ -1,18 +1,23 @@
 # Android SDK Usage (Enterprise Native Mode)
 
-This guide covers the Firestore Android SDK (Kotlin) setup and usage patterns optimized for Firestore Enterprise edition in Native mode.
+This guide covers the Firestore Android SDK (Kotlin) setup and usage patterns
+optimized for Firestore Enterprise edition in Native mode.
 
---------------------------------------------------------------------------------
+______________________________________________________________________
 
 ## 1. Initialization
 
 ### Add Dependencies
 
-In your module-level `build.gradle.kts` (usually `app/build.gradle.kts`), add the Firebase Kotlin Bill of Materials (BoM) and the dependency for Cloud Firestore:
+In your module-level `build.gradle.kts` (usually `app/build.gradle.kts`), add
+the Firebase Kotlin Bill of Materials (BoM) and the dependency for Cloud
+Firestore:
 
-> [!IMPORTANT]
-> **[AGENT] RESOLVING THE RESOLVED SDK VERSION DETERMINISTICALLY**
-> Never guess or hardcode a memorized out-of-date SDK version. Before adding dependencies, you MUST query the latest available versions directly from the Google Maven Repository:
+> [!IMPORTANT] **[AGENT] RESOLVING THE RESOLVED SDK VERSION DETERMINISTICALLY**
+> Never guess or hardcode a memorized out-of-date SDK version. Before adding
+> dependencies, you MUST query the latest available versions directly from the
+> Google Maven Repository:
+>
 > ```bash
 > # Find the latest Firebase BoM version
 > curl -s https://dl.google.com/dl/android/maven2/com/google/firebase/firebase-bom/maven-metadata.xml | grep -oE '<latest>[^<]+' | cut -d'>' -f2
@@ -20,7 +25,10 @@ In your module-level `build.gradle.kts` (usually `app/build.gradle.kts`), add th
 > # Find the latest firebase-firestore version
 > curl -s https://dl.google.com/dl/android/maven2/com/google/firebase/firebase-firestore/maven-metadata.xml | grep -oE '<latest>[^<]+' | cut -d'>' -f2
 > ```
-> If the dependency is already declared, fetch the exact resolved version currently active in the workspace's build graph:
+>
+> If the dependency is already declared, fetch the exact resolved version
+> currently active in the workspace's build graph:
+>
 > ```bash
 > ./gradlew -q :app:dependencyInsight --dependency firebase-firestore --configuration releaseRuntimeClasspath
 > ```
@@ -38,7 +46,8 @@ dependencies {
 
 ### Initialize Firestore
 
-Initialize the `FirebaseFirestore` instance in your ComponentActivity (Jetpack Compose) or standard Activity/Fragment:
+Initialize the `FirebaseFirestore` instance in your ComponentActivity (Jetpack
+Compose) or standard Activity/Fragment:
 
 ```kotlin
 import android.os.Bundle
@@ -64,37 +73,58 @@ class MainActivity : ComponentActivity() {
 }
 ```
 
---------------------------------------------------------------------------------
+______________________________________________________________________
 
 ## 2. Decision Framework: Mandatory Pipeline Architecture
 
-> [!CRITICAL] **MANDATORY PIPELINE ARCHITECTURE (ZERO TOLERANCE)**
-> You are strictly forbidden from using standard collection queries (e.g., `db.collection(...).where(...)` or client-side mapping loops) as the primary implementation for relational joins, aggregations, or search algorithms.
-> 
-> Server-side execution via pipelines is the superior, non-negotiable core architecture for Enterprise instances.
+> [!CRITICAL] **MANDATORY PIPELINE ARCHITECTURE (ZERO TOLERANCE)** You are
+> strictly forbidden from using standard collection queries (e.g.,
+> `db.collection(...).where(...)` or client-side mapping loops) as the primary
+> implementation for relational joins, aggregations, or search algorithms.
+>
+> Server-side execution via pipelines is the superior, non-negotiable core
+> architecture for Enterprise instances.
 
 ### Strict Rules & Accountability
 
-1. **Mandatory Execution Engine**: Every repository lookup requiring related data mapping, textual relevance scoring, or multi-document counting MUST be authored natively using the server-side `db.pipeline()` API.
-2. **Required Proof of Use**: In your task execution summaries, you MUST explicitly highlight the exact pipeline stages (`.define()`, `.addFields()`, `.search()`, `.aggregate()`) integrated into your primary data layer return paths. Failure to implement pipelines natively constitutes an immediate violation of instructions.
-3. **Check API References**: 
-   - **Locate**: Locate the standard Maven sources JAR (`-sources.jar`) corresponding to the resolved `firebase-firestore` dependency version inside your local Gradle or Maven dependency cache.
-   - **Extract Once**: Extract the documentation files `pipeline.docs.txt` and `expressions.docs.txt` from the root directory of that `-sources.jar` archive into a temporary workspace scratch directory of your choice.
+1. **Mandatory Execution Engine**: Every repository lookup requiring related
+   data mapping, textual relevance scoring, or multi-document counting MUST be
+   authored natively using the server-side `db.pipeline()` API.
+1. **Required Proof of Use**: In your task execution summaries, you MUST
+   explicitly highlight the exact pipeline stages (`.define()`, `.addFields()`,
+   `.search()`, `.aggregate()`) integrated into your primary data layer return
+   paths. Failure to implement pipelines natively constitutes an immediate
+   violation of instructions.
+1. **Check API References**:
+   - **Locate**: Locate the standard Maven sources JAR (`-sources.jar`)
+     corresponding to the resolved `firebase-firestore` dependency version
+     inside your local Gradle or Maven dependency cache.
+   - **Extract Once**: Extract the documentation files `pipeline.docs.txt` and
+     `expressions.docs.txt` from the root directory of that `-sources.jar`
+     archive into a temporary workspace scratch directory of your choice.
    - **Read & Reference**:
-     * **Read** the extracted `pipeline.docs.txt` once fully to understand core pipeline structure and stage capabilities.
-     * **Reference** the extracted `expressions.docs.txt` on-demand for specific function overloads and parameters.
+     - **Read** the extracted `pipeline.docs.txt` once fully to understand core
+       pipeline structure and stage capabilities.
+     - **Reference** the extracted `expressions.docs.txt` on-demand for specific
+       function overloads and parameters.
 
---------------------------------------------------------------------------------
+______________________________________________________________________
 
 ## 3. Pipeline Examples
 
 ### Relational Joins Pattern
 
-When querying related data (e.g., articles and their author profiles), perform the join at the database level via pipeline stages instead of executing multiple sequential lookups on the client-side.
-*   Use `.define()` to bind parameters or document properties as variables.
-*   Use `.addFields()` and a nested subquery with a matching filter.
-*   Use `.toScalarExpression()` to convert a nested pipeline subquery to a single field value.
-*   Assign variable and field aliases using `.alias(...)` (note: while the Web SDK uses `.as()`, the Kotlin SDK uses `.alias()` to avoid keyword conflicts with Kotlin's `as` operator).
+When querying related data (e.g., articles and their author profiles), perform
+the join at the database level via pipeline stages instead of executing multiple
+sequential lookups on the client-side.
+
+- Use `.define()` to bind parameters or document properties as variables.
+- Use `.addFields()` and a nested subquery with a matching filter.
+- Use `.toScalarExpression()` to convert a nested pipeline subquery to a single
+  field value.
+- Assign variable and field aliases using `.alias(...)` (note: while the Web SDK
+  uses `.as()`, the Kotlin SDK uses `.alias()` to avoid keyword conflicts with
+  Kotlin's `as` operator).
 
 ```kotlin
 import com.google.firebase.firestore.pipeline.Expression.field
@@ -114,7 +144,8 @@ val articlesWithAuthProfile = db.pipeline().collection("articles")
 
 ### Full-Text Search
 
-Leverage the database-native `.search()` stage within your pipelines to run high-performance text query matches on the database level.
+Leverage the database-native `.search()` stage within your pipelines to run
+high-performance text query matches on the database level.
 
 ```kotlin
 import com.google.firebase.firestore.pipeline.Expression.documentMatches
@@ -130,11 +161,13 @@ val searchPipeline = db.pipeline()
     .limit(5)
 ```
 
---------------------------------------------------------------------------------
+______________________________________________________________________
 
 ## 4. Real-Time Listener & Document Operations
 
-When real-time data sync or transaction-based document mutations are strictly required by application specifications, write clean operations as shown in this comprehensive example.
+When real-time data sync or transaction-based document mutations are strictly
+required by application specifications, write clean operations as shown in this
+comprehensive example.
 
 ```kotlin
 import android.util.Log

--- a/skills/firebase-firestore/references/enterprise/data_model.md
+++ b/skills/firebase-firestore/references/enterprise/data_model.md
@@ -15,8 +15,8 @@ values. Each document is identified by a name. A document can contain complex
 nested objects in addition to basic data types like strings, numbers, and
 booleans. Documents are limited to a maximum size of 1 MiB.
 
-Example document (e.g., in a `users` collection): `json { "first": "Ada",
-"last": "Lovelace", "born": 1815 }`
+Example document (e.g., in a `users` collection):
+`json { "first": "Ada", "last": "Lovelace", "born": 1815 }`
 
 ### Collections
 
@@ -59,8 +59,8 @@ the `reviews` collection group.
 ### Examples
 
 **Standard Query** (Single Collection): Find all 5-star reviews for a specific
-landmark. `javascript
-db.collection('landmarks/golden_gate_bridge/reviews').where('rating', '==', 5)`
+landmark.
+`javascript db.collection('landmarks/golden_gate_bridge/reviews').where('rating', '==', 5)`
 
 **Collection Group Query**: Find all 5-star reviews across *all* landmarks.
 `javascript db.collectionGroup('reviews').where('rating', '==', 5)`

--- a/skills/firebase-firestore/references/enterprise/flutter_setup.md
+++ b/skills/firebase-firestore/references/enterprise/flutter_setup.md
@@ -1,20 +1,26 @@
 # Cloud Firestore in Flutter
 
-This guide covers basic CRUD operations, type-safe data modeling, and real-time streams when using Cloud Firestore in a Flutter application via the `cloud_firestore` package.
+This guide covers basic CRUD operations, type-safe data modeling, and real-time
+streams when using Cloud Firestore in a Flutter application via the
+`cloud_firestore` package.
 
 ## 1. Setup
 
 Ensure you have added the required dependency:
+
 ```bash
 flutter pub add cloud_firestore
 ```
+
 Also, ensure FlutterFire is configured properly for your target platforms.
 
----
+______________________________________________________________________
 
 ## 2. Best Practices: Type-Safe Models
 
-Instead of passing raw `Map<String, dynamic>` maps throughout your UI layer, define a domain model class with `fromFirestore` and `toFirestore` converters to maintain type safety.
+Instead of passing raw `Map<String, dynamic>` maps throughout your UI layer,
+define a domain model class with `fromFirestore` and `toFirestore` converters to
+maintain type safety.
 
 ```dart
 import 'package:cloud_firestore/cloud_firestore.dart';
@@ -54,11 +60,12 @@ class Item {
 }
 ```
 
----
+______________________________________________________________________
 
 ## 3. The Service Layer
 
-Encapsulate all database interactions within a dedicated service class to keep your UI code clean and testable.
+Encapsulate all database interactions within a dedicated service class to keep
+your UI code clean and testable.
 
 ### Initialization & References
 
@@ -130,11 +137,12 @@ class ItemService {
 }
 ```
 
----
+______________________________________________________________________
 
 ## 4. Listening to Streams in the UI (`StreamBuilder`)
 
-Use Flutter's `StreamBuilder` to rebuild the interface reactively whenever data changes in your database collection.
+Use Flutter's `StreamBuilder` to rebuild the interface reactively whenever data
+changes in your database collection.
 
 ```dart
 StreamBuilder<List<Item>>(

--- a/skills/firebase-firestore/references/enterprise/indexes.md
+++ b/skills/firebase-firestore/references/enterprise/indexes.md
@@ -10,17 +10,17 @@ optimize your queries.
 
 An index consists of the following:
 
-*   a collection ID.
-*   a list of fields in the given collection.
-*   an order, either ascending or descending, for each field.
+- a collection ID.
+- a list of fields in the given collection.
+- an order, either ascending or descending, for each field.
 
 ### Index Ordering
 
 The order and sort direction of each field uniquely defines the index. For
 example, the following indexes are two distinct indexes and not interchangeable:
 
-*   Field name `name` (ascending) and `population` (descending)
-*   Field name `name` (descending) and `population` (ascending)
+- Field name `name` (ascending) and `population` (descending)
+- Field name `name` (descending) and `population` (ascending)
 
 ### Index Density
 
@@ -43,23 +43,23 @@ create index entries with duplicate values.
 
 ## Query Support Examples
 
-| Query Type                           | Index Required                       |
-| :----------------------------------- | :----------------------------------- |
-| **Simple Equality**<br>`where("a",   | Single-Field Index on field `a`      |
-: "==", 1)`                            :                                      :
-| **Simple Range/Sort**<br>`where("a", | Single-Field Index on field `a`      |
-: ">", 1).orderBy("a")`                :                                      :
-| **Multiple Equality**<br>`where("a", | Single-Field Index on field `a` and  |
-: "==", 1).where("b", "==", 2)`        : `b`                                  :
-| **Equality +                         | **Composite Index** on field `a` and |
-: Range/Sort**<br>`where("a", "==",    : `b`                                  :
-: 1).where("b", ">", 2)`               :                                      :
-| **Multiple Ranges**<br>`where("a",   | **Composite Index** on field `a` and |
-: ">", 1).where("b", ">", 2)`          : `b`                                  :
-| **Array Contains +                   | **Composite Index** on field `tags`  |
-: Equality**<br>`where("tags",         : and `active`                         :
-: "array-contains",                    :                                      :
-: "news").where("active", "==", true)` :                                      :
+| Query Type                                                 | Index Required                       |
+| :--------------------------------------------------------- | :----------------------------------- |
+| **Simple Equality**<br>\`where("a",                        | Single-Field Index on field `a`      |
+| : "==", 1)\` : :                                           |                                      |
+| **Simple Range/Sort**<br>\`where("a",                      | Single-Field Index on field `a`      |
+| : ">", 1).orderBy("a")\` : :                               |                                      |
+| **Multiple Equality**<br>\`where("a",                      | Single-Field Index on field `a` and  |
+| : "==", 1).where("b", "==", 2)`       :`b\` :              |                                      |
+| \*\*Equality +                                             | **Composite Index** on field `a` and |
+| : Range/Sort\*\*<br>`where("a", "==",    : `b\` :          |                                      |
+| : 1).where("b", ">", 2)\` : :                              |                                      |
+| **Multiple Ranges**<br>\`where("a",                        | **Composite Index** on field `a` and |
+| : ">", 1).where("b", ">", 2)`         :`b\` :              |                                      |
+| \*\*Array Contains +                                       | **Composite Index** on field `tags`  |
+| : Equality\*\*<br>`where("tags",         : and `active\` : |                                      |
+| : "array-contains", : :                                    |                                      |
+| : "news").where("active", "==", true)\` : :                |                                      |
 
 If no indexes is present, Firestore Enterprise will perform a full collection
 scan to find documents that match a query.
@@ -131,5 +131,5 @@ Define a unique index:
 
 ### CLI Commands
 
-Deploy indexes only: `bash npx firebase-tools@latest -y deploy --only
-firestore:indexes`
+Deploy indexes only:
+`bash npx firebase-tools@latest -y deploy --only firestore:indexes`

--- a/skills/firebase-firestore/references/enterprise/ios_setup.md
+++ b/skills/firebase-firestore/references/enterprise/ios_setup.md
@@ -1,34 +1,50 @@
 # Firestore Enterprise Native Mode on iOS
 
-This guide walks you through using the Cloud Firestore SDK in your iOS app using Swift.
+This guide walks you through using the Cloud Firestore SDK in your iOS app using
+Swift.
 
 # ⛔️ CRITICAL RULE: NO FirebaseFirestoreSwift ⛔️
 
-UNDER NO CIRCUMSTANCES should you import, link against, or configure a project to use `FirebaseFirestoreSwift`. 
+UNDER NO CIRCUMSTANCES should you import, link against, or configure a project
+to use `FirebaseFirestoreSwift`.
 
-As of Firebase SDK v11+, all Swift-specific features (including `@DocumentID`, `@ServerTimestamp`, and `Codable` support) have been fully merged into the main `FirebaseFirestore` module.
+As of Firebase SDK v11+, all Swift-specific features (including `@DocumentID`,
+`@ServerTimestamp`, and `Codable` support) have been fully merged into the main
+`FirebaseFirestore` module.
 
-- NEVER add `.external(name: "FirebaseFirestoreSwift")` or similar to SPM or Xcode configurations.
-- NEVER write `import FirebaseFirestoreSwift` in any Swift file. 
+- NEVER add `.external(name: "FirebaseFirestoreSwift")` or similar to SPM or
+  Xcode configurations.
+- NEVER write `import FirebaseFirestoreSwift` in any Swift file.
 - ONLY use `import FirebaseFirestore`.
 
-This is a zero-tolerance constraint. Using `FirebaseFirestoreSwift` is fundamentally incorrect and unacceptable.
-
+This is a zero-tolerance constraint. Using `FirebaseFirestoreSwift` is
+fundamentally incorrect and unacceptable.
 
 # ⛔️ CRITICAL RULE: NO INLINE INITIALIZATION ⛔️
-NEVER write `let db = Firestore.firestore()` or `Firestore.firestore(database:)` as an inline class or struct property if there is ANY chance the object is instantiated before `FirebaseApp.configure()` executes in the app root.
-- **FATAL CRASH:** `@Observable class DataManager { let db = Firestore.firestore() }` initialized as a `@State` in the App root.
-- **SAFE PATTERN:** Initialize `Firestore.firestore()` lazily (`lazy var db = Firestore.firestore()`) OR explicitly initialize the manager *after* `FirebaseApp.configure()` finishes.
+
+NEVER write `let db = Firestore.firestore()` or `Firestore.firestore(database:)`
+as an inline class or struct property if there is ANY chance the object is
+instantiated before `FirebaseApp.configure()` executes in the app root.
+
+- **FATAL CRASH:**
+  `@Observable class DataManager { let db = Firestore.firestore() }` initialized
+  as a `@State` in the App root.
+- **SAFE PATTERN:** Initialize `Firestore.firestore()` lazily
+  (`lazy var db = Firestore.firestore()`) OR explicitly initialize the manager
+  *after* `FirebaseApp.configure()` finishes.
 
 ## 1. Import and Initialize
 
-Ensure you have installed the `FirebaseFirestore` SDK. Use the `xcode-project-setup` skill to automate adding the SPM dependency to the Xcode project.
+Ensure you have installed the `FirebaseFirestore` SDK. Use the
+`xcode-project-setup` skill to automate adding the SPM dependency to the Xcode
+project.
 
 ```swift
 import FirebaseFirestore
 ```
 
-Initialize an instance of Cloud Firestore. **CRITICAL**: Enterprise databases require a custom database ID and cannot use the `(default)` instance.
+Initialize an instance of Cloud Firestore. **CRITICAL**: Enterprise databases
+require a custom database ID and cannot use the `(default)` instance.
 
 ```swift
 // Replace "your-enterprise-database-id" with your actual database ID
@@ -37,7 +53,8 @@ let db = Firestore.firestore(database: "your-enterprise-database-id")
 
 ## 2. Type-Safe Data Models (Codable)
 
-To leverage modern Swift data modeling, define your data as `Codable` structs. The main `FirebaseFirestore` module automatically supports mapping these types.
+To leverage modern Swift data modeling, define your data as `Codable` structs.
+The main `FirebaseFirestore` module automatically supports mapping these types.
 
 ```swift
 struct User: Codable {
@@ -50,7 +67,8 @@ struct User: Codable {
 
 ## 3. Basic CRUD Operations
 
-The operations are identical to standard Firestore, but ensure you use the `db` instance initialized with your Enterprise database ID.
+The operations are identical to standard Firestore, but ensure you use the `db`
+instance initialized with your Enterprise database ID.
 
 ### Writing Data (Modern Concurrency & Codable)
 
@@ -116,16 +134,25 @@ let results = try await db.pipeline()
 
 ## 5. Realtime Listeners in SwiftUI (Lifecycle Best Practices)
 
-When implementing Firestore realtime listeners (`addSnapshotListener`) within a SwiftUI application, you **MUST** tie the listener lifecycle to the view's identity using `.task(id:)`, NOT `.onDisappear`.
+When implementing Firestore realtime listeners (`addSnapshotListener`) within a
+SwiftUI application, you **MUST** tie the listener lifecycle to the view's
+identity using `.task(id:)`, NOT `.onDisappear`.
 
 ### ⛔️ UNSAFE PATTERN (.onDisappear)
-Presenting a `.sheet` or `.fullScreenCover` can trigger the underlying view's `onDisappear` method. If you stop your listener here, the feed will stop updating while the sheet is open, and won't resume when it's dismissed.
+
+Presenting a `.sheet` or `.fullScreenCover` can trigger the underlying view's
+`onDisappear` method. If you stop your listener here, the feed will stop
+updating while the sheet is open, and won't resume when it's dismissed.
 
 ### ✅ SAFE PATTERN (.task with deinit)
 
-Because `addSnapshotListener` is a synchronous call, placing it inside a `.task` means the task completes immediately. This breaks SwiftUI's automatic cancellation mechanism. 
+Because `addSnapshotListener` is a synchronous call, placing it inside a `.task`
+means the task completes immediately. This breaks SwiftUI's automatic
+cancellation mechanism.
 
-To safely manage traditional Firebase listeners in SwiftUI, you must use **`deinit`** to handle memory cleanup when the view is destroyed, and **`.task(id:)`** to handle data identity changes while the view is active.
+To safely manage traditional Firebase listeners in SwiftUI, you must use
+**`deinit`** to handle memory cleanup when the view is destroyed, and
+**`.task(id:)`** to handle data identity changes while the view is active.
 
 ```swift
 import SwiftUI

--- a/skills/firebase-firestore/references/enterprise/provisioning.md
+++ b/skills/firebase-firestore/references/enterprise/provisioning.md
@@ -2,22 +2,22 @@
 
 ## Manual Initialization
 
-Initialize the following firebase configuration files manually. Do not use `npx
--y firebase-tools@latest init`, as it expects interactive inputs.
+Initialize the following firebase configuration files manually. Do not use
+`npx -y firebase-tools@latest init`, as it expects interactive inputs.
 
-1.  **Create a Firestore Enterprise Database**: Create a Firestore Enterprise
-    database using the Firebase CLI.
-2.  **Create `firebase.json`**: This file contains database configuration for
-    the Firebase CLI.
-3.  **Create `firestore.rules`**: This file contains your security rules.
-4.  **Create `firestore.indexes.json`**: This file contains your index
-    definitions.
+1. **Create a Firestore Enterprise Database**: Create a Firestore Enterprise
+   database using the Firebase CLI.
+1. **Create `firebase.json`**: This file contains database configuration for the
+   Firebase CLI.
+1. **Create `firestore.rules`**: This file contains your security rules.
+1. **Create `firestore.indexes.json`**: This file contains your index
+   definitions.
 
 ### 1. Create a Firestore Enterprise Database
 
 If the user needs to create a new database, ask the user what location to use.
-Run `npx -y firebase-tools@latest firestore:locations` to get the list of options.
-Suggest colocating with other resources if applicable.
+Run `npx -y firebase-tools@latest firestore:locations` to get the list of
+options. Suggest colocating with other resources if applicable.
 
 Use the following command to create a Firestore Enterprise database:
 
@@ -29,9 +29,9 @@ firebase firestore:databases:create my-database-id \
   --mongodb-compatible-data-access="DISABLED"
 ```
 
-This will create an enterprise database in the selected location with native mode enabled. A
-database id is required to create an enterprise database and the database id
-must not be `(default)`. To enable realtime-updates feature, use
+This will create an enterprise database in the selected location with native
+mode enabled. A database id is required to create an enterprise database and the
+database id must not be `(default)`. To enable realtime-updates feature, use
 `--realtime-updates` flag.
 
 ```bash
@@ -46,7 +46,8 @@ firebase firestore:databases:create my-database-id \
 ### 2. Create `firebase.json`
 
 Create a file named `firebase.json` in your project root with the following
-content (edit `database` and `location` to match the ones you created above). If this file already exists, instead append to the existing JSON:
+content (edit `database` and `location` to match the ones you created above). If
+this file already exists, instead append to the existing JSON:
 
 ```json
 {

--- a/skills/firebase-firestore/references/enterprise/security_rules.md
+++ b/skills/firebase-firestore/references/enterprise/security_rules.md
@@ -19,22 +19,21 @@ Follow this structured workflow strictly:
 
 #### Phase-1: Codebase Analysis
 
-1.  **Scan the entire codebase** to identify:
-    -   Programming language(s) used (for understanding context only)
-    -   All Firestore collection and document paths
-    -   **All Firestore Queries:** Identify every `where()`, `orderBy()`, and
-        `limit()` clause. The security rules **MUST** allow these specific
-        queries.
-    -   Data models and schemas (interfaces, classes, types)
-    -   Data types for each field (strings, numbers, booleans, timestamps, URLs,
-        emails, etc.)
-    -   Required vs. optional fields
-    -   Field constraints (min/max length, format patterns, allowed values)
-    -   CRUD operations (create, read, update, delete)
-    -   Authentication patterns (Firebase Auth, custom tokens, anonymous)
-    -   Access patterns and business logic rules
-2.  **Document your findings** in a untracked file. Refer to this file when
-    generating the security rules.
+1. **Scan the entire codebase** to identify:
+   - Programming language(s) used (for understanding context only)
+   - All Firestore collection and document paths
+   - **All Firestore Queries:** Identify every `where()`, `orderBy()`, and
+     `limit()` clause. The security rules **MUST** allow these specific queries.
+   - Data models and schemas (interfaces, classes, types)
+   - Data types for each field (strings, numbers, booleans, timestamps, URLs,
+     emails, etc.)
+   - Required vs. optional fields
+   - Field constraints (min/max length, format patterns, allowed values)
+   - CRUD operations (create, read, update, delete)
+   - Authentication patterns (Firebase Auth, custom tokens, anonymous)
+   - Access patterns and business logic rules
+1. **Document your findings** in a untracked file. Refer to this file when
+   generating the security rules.
 
 #### Phase-2: Security Rules Generation
 
@@ -43,32 +42,32 @@ security rules file**
 
 Generate Firebase Security Rules following these principles:
 
--   **Default deny:** Start with denying all access, then explicitly allow only
-    what's needed
--   **Least privilege:** Grant minimum permissions required
--   **Validate data:** Check data types, allowed fields, and constraints on both
-    creates and updates.
-    -   **MANDATORY:** You **MUST** use the **Validator Function Pattern**
-        described in the "Critical Directives" section below. This involves
-        defining a specific validation function (e.g., `isValidUser`) and
-        calling it in **BOTH** `create` and `update` rules.
-    -   **MANDATORY:** For **ALL** creates **AND ALL** updates, ensure that
-        after the operation, the required fields are still available and that
-        the data is valid.
--   **Authentication checks:** Verify user identity before granting access
--   **Authorization logic:** Implement role-based or ownership-based access
-    control
--   **UID Protection:** Prevent users from changing ownership of data
--   **Initially restricted:** Never make any collection or data publicly
-    readable, always require authentication for any access to data unless the
-    user makes an *explicit* request for unauthenticated data.
+- **Default deny:** Start with denying all access, then explicitly allow only
+  what's needed
+- **Least privilege:** Grant minimum permissions required
+- **Validate data:** Check data types, allowed fields, and constraints on both
+  creates and updates.
+  - **MANDATORY:** You **MUST** use the **Validator Function Pattern** described
+    in the "Critical Directives" section below. This involves defining a
+    specific validation function (e.g., `isValidUser`) and calling it in
+    **BOTH** `create` and `update` rules.
+  - **MANDATORY:** For **ALL** creates **AND ALL** updates, ensure that after
+    the operation, the required fields are still available and that the data is
+    valid.
+- **Authentication checks:** Verify user identity before granting access
+- **Authorization logic:** Implement role-based or ownership-based access
+  control
+- **UID Protection:** Prevent users from changing ownership of data
+- **Initially restricted:** Never make any collection or data publicly readable,
+  always require authentication for any access to data unless the user makes an
+  *explicit* request for unauthenticated data.
 
 This means the first firestore.rules file you generate must never have any
 "allow read: true" statements.
 
 **Structure Requirements:**
 
-1.  **Document assumed data models at the beginning of the rules file:**
+1. **Document assumed data models at the beginning of the rules file:**
 
 ```javascript
 // ===============================================================
@@ -89,7 +88,7 @@ This means the first firestore.rules file you generate must never have any
 // ===============================================================
 ```
 
-1.  **Include comprehensive helper functions to avoid repetition:**
+1. **Include comprehensive helper functions to avoid repetition:**
 
 ```javascript
 // ===============================================================
@@ -220,40 +219,40 @@ function isRecent(time) {
 
 #### Mandatory: User Data Separation (The "No Mixed Content" Rule)
 
--   Firestore security rules apply to the entire document. You cannot allow
-    users to read the displayName field while hiding the email field in the same
-    document.
--   If a collection (e.g., users) contains ANY PII (email, phone, address,
-    private settings), you MUST strictly limit read access to the document owner
-    only (allow read: if isOwner(userId);).
--   If the application requires public profiles (e.g., showing user
-    names/avatars on posts):
-    -   1. Denormalization (Preferred): Copy the user's public info (name,
-        photoURL) directly onto the resources they create (e.g., store
-        authorName and authorPhoto inside the posts document).
-    -   2. Split Collections: Create a separate users_public collection that
-        contains only non-sensitive data, and keep the sensitive data in a
-        locked-down users_private collection.
--   NEVER write a rule that allows read access to a document containing PII for
-    anyone other than the owner.
+- Firestore security rules apply to the entire document. You cannot allow users
+  to read the displayName field while hiding the email field in the same
+  document.
+- If a collection (e.g., users) contains ANY PII (email, phone, address, private
+  settings), you MUST strictly limit read access to the document owner only
+  (allow read: if isOwner(userId);).
+- If the application requires public profiles (e.g., showing user names/avatars
+  on posts):
+  - 1. Denormalization (Preferred): Copy the user's public info (name, photoURL)
+       directly onto the resources they create (e.g., store authorName and
+       authorPhoto inside the posts document).
+  - 2. Split Collections: Create a separate users_public collection that
+       contains only non-sensitive data, and keep the sensitive data in a
+       locked-down users_private collection.
+- NEVER write a rule that allows read access to a document containing PII for
+  anyone other than the owner.
 
 #### **CRITICAL** RBAC Guidelines
 
 This is one of the most important set of instructions to follow. Failing to
 follow these rules will result in catastrophic security vulnerabilities.
 
--   **NEVER** allow users to create their own privileged roles. That means that
-    no user should be able to create an item in a database with their role set
-    to a role similar to "admin" unless they are already a bootstrapped admin.
--   **NEVER** allow users to update their own roles or permissions.
--   **NEVER** allow users to grant themselves access to other users' data.
--   **NEVER** allow users to bypass the role hierarchy.
--   **ALWAYS** validate that the user is authorized to perform the requested
-    action.
--   **ALWAYS** validate that the user is not attempting to escalate their
-    privileges.
--   **ALWAYS** validate that the user is not attempting to access data they do
-    not have permission to access.
+- **NEVER** allow users to create their own privileged roles. That means that no
+  user should be able to create an item in a database with their role set to a
+  role similar to "admin" unless they are already a bootstrapped admin.
+- **NEVER** allow users to update their own roles or permissions.
+- **NEVER** allow users to grant themselves access to other users' data.
+- **NEVER** allow users to bypass the role hierarchy.
+- **ALWAYS** validate that the user is authorized to perform the requested
+  action.
+- **ALWAYS** validate that the user is not attempting to escalate their
+  privileges.
+- **ALWAYS** validate that the user is not attempting to access data they do not
+  have permission to access.
 
 Here's a **bad** example of what **NOT** to do:
 
@@ -279,70 +278,79 @@ match /users/{userId} {
 
 #### Critical Directives for Secure Generation
 
--   **PREFER USING READ OVER LIST OR GET** `list` and `get` can add complexity
-    to security rules. Prefer using `read` over them.
--   **Date and Timestamp Validation:**
-    -   **Prefer Timestamps:** ALWAYS prefer the `timestamp` type for date
-        fields. Firestore automatically ensures they are logically valid dates.
-    -   **String Date Risks:** If using strings for dates (e.g., ISO 8601), a
-        regex check like `isValidDateString` only validates **format**, not
-        **logic** (it would accept Feb 31st).
-    -   **Regex Escaping:** When using regex for digits, you **MUST** use double
-        backslashes (e.g., `\\\\d`) in the rules string. Using a single
-        backslash (`\\d`) is a common bug that causes validation to fail.
--   **Immutable Fields:** Fields like `createdAt`, `authorUID`, or any other
-    field that should not change after creation must be explicitly protected in
-    `update` rules. (e.g., `request.resource.data.createdAt ==
-    resource.data.createdAt`). **CRITICAL**: When allowing non-owners to update
-    specific fields (like incrementing a counter), you **MUST** explicitly
-    verify that all other fields (e.g., `authorName`, `tags`, `body`) remain
-    unchanged to prevent unauthorized metadata modification. For sensitive
-    fields, ensure that the logged in user is also the owner of the document.
--   **Identity Integrity:** When storing denormalized user identity (e.g.
-    `authorName`, `authorPhoto`), you **MUST** validate this data.
-    -   **Prefer Auth Token:** If possible, check if
-        `request.resource.data.authorName == request.auth.token.name`.
-    -   **Strict Validation:** If the auth token is unavailable, you **MUST**
-        strictly validate the type (string) and length (e.g. < 50 chars) to
-        prevent spoofing with massive or malicious payloads.
-    -   **Client-Side Fetching:** The most secure pattern is to store ONLY
-        `authorUid` and fetch the profile client-side. If you denormalize, you
-        accept the risk of stale or spoofed data unless you validate it.
--   **Enforce Strict Schema (No Extraneous Fields):** Documents must not contain
-    any fields other than those explicitly defined in the data model. This
-    prevents users from adding arbitrary data.
--   **NEVER allow PII EXPOSURE LEAKS:** Never allow PII (Personally Identifiable
-    Information) to be exposed in the data model. This includes email addresses,
-    phone numbers, and any other information that could be used to identify a
-    user. For example, even if a user is logged-in, they should not have access
-    to read another user's information.
--   **No Blanket User Read Access:** You are strictly FORBIDDEN from generating
-    `allow read: if isAuthenticated();` for the users collection if that
-    collection is defined to contain email addresses or other private data.
--   **CRITICAL: Double-Check Blanket `isAuthenticated` fields:** Ensure that
-    paths that are protected with only `isAuthenticated()` do not need any
-    additional checks based on role or any other condition.
--   **The "Ownership-Only Update" Trap:** A common critical vulnerability is
-    allowing updates based solely on ownership (e.g., `allow update: if
-    isOwner(resource.data.uid);`). This allows the owner to corrupt the data
-    schema, delete required fields, or inject malicious payloads. You **MUST**
-    always combine ownership checks with data validation (e.g., `allow update:
-    if isOwner(...) && isValidEntity(...);`) **AND** validate that
-    self-escalation is not possible.
+- **PREFER USING READ OVER LIST OR GET** `list` and `get` can add complexity to
+  security rules. Prefer using `read` over them.
 
--   **Deep Array Inspection:** It is insufficient to check if a field `is list`.
-    You **MUST** validate the contents of the array (e.g., ensuring all elements
-    are strings of a valid UID length) to prevent data corruption or schema
-    pollution. For example, a `tags` array must verify that every item is a
-    string AND that each string is within a reasonable length (e.g., < 20
-    chars).
+- **Date and Timestamp Validation:**
 
--   **Permission-Field Lockdown:** Fields that control access (e.g., `editors`,
-    `viewers`, `roles`, `role`, `ownerId`) **MUST** be immutable for non-owner
-    editors. In `update` rules, use `fieldUnchanged()` for these fields unless
-    the `request.auth.uid` matches the document's original owner/creator. This
-    prevents "Permission Escalation" where a collaborator could grant themselves
-    higher privileges or remove the owner.
+  - **Prefer Timestamps:** ALWAYS prefer the `timestamp` type for date fields.
+    Firestore automatically ensures they are logically valid dates.
+  - **String Date Risks:** If using strings for dates (e.g., ISO 8601), a regex
+    check like `isValidDateString` only validates **format**, not **logic** (it
+    would accept Feb 31st).
+  - **Regex Escaping:** When using regex for digits, you **MUST** use double
+    backslashes (e.g., `\\\\d`) in the rules string. Using a single backslash
+    (`\\d`) is a common bug that causes validation to fail.
+
+- **Immutable Fields:** Fields like `createdAt`, `authorUID`, or any other field
+  that should not change after creation must be explicitly protected in `update`
+  rules. (e.g., `request.resource.data.createdAt == resource.data.createdAt`).
+  **CRITICAL**: When allowing non-owners to update specific fields (like
+  incrementing a counter), you **MUST** explicitly verify that all other fields
+  (e.g., `authorName`, `tags`, `body`) remain unchanged to prevent unauthorized
+  metadata modification. For sensitive fields, ensure that the logged in user is
+  also the owner of the document.
+
+- **Identity Integrity:** When storing denormalized user identity (e.g.
+  `authorName`, `authorPhoto`), you **MUST** validate this data.
+
+  - **Prefer Auth Token:** If possible, check if
+    `request.resource.data.authorName == request.auth.token.name`.
+  - **Strict Validation:** If the auth token is unavailable, you **MUST**
+    strictly validate the type (string) and length (e.g. < 50 chars) to prevent
+    spoofing with massive or malicious payloads.
+  - **Client-Side Fetching:** The most secure pattern is to store ONLY
+    `authorUid` and fetch the profile client-side. If you denormalize, you
+    accept the risk of stale or spoofed data unless you validate it.
+
+- **Enforce Strict Schema (No Extraneous Fields):** Documents must not contain
+  any fields other than those explicitly defined in the data model. This
+  prevents users from adding arbitrary data.
+
+- **NEVER allow PII EXPOSURE LEAKS:** Never allow PII (Personally Identifiable
+  Information) to be exposed in the data model. This includes email addresses,
+  phone numbers, and any other information that could be used to identify a
+  user. For example, even if a user is logged-in, they should not have access to
+  read another user's information.
+
+- **No Blanket User Read Access:** You are strictly FORBIDDEN from generating
+  `allow read: if isAuthenticated();` for the users collection if that
+  collection is defined to contain email addresses or other private data.
+
+- **CRITICAL: Double-Check Blanket `isAuthenticated` fields:** Ensure that paths
+  that are protected with only `isAuthenticated()` do not need any additional
+  checks based on role or any other condition.
+
+- **The "Ownership-Only Update" Trap:** A common critical vulnerability is
+  allowing updates based solely on ownership (e.g.,
+  `allow update: if isOwner(resource.data.uid);`). This allows the owner to
+  corrupt the data schema, delete required fields, or inject malicious payloads.
+  You **MUST** always combine ownership checks with data validation (e.g.,
+  `allow update: if isOwner(...) && isValidEntity(...);`) **AND** validate that
+  self-escalation is not possible.
+
+- **Deep Array Inspection:** It is insufficient to check if a field `is list`.
+  You **MUST** validate the contents of the array (e.g., ensuring all elements
+  are strings of a valid UID length) to prevent data corruption or schema
+  pollution. For example, a `tags` array must verify that every item is a string
+  AND that each string is within a reasonable length (e.g., < 20 chars).
+
+- **Permission-Field Lockdown:** Fields that control access (e.g., `editors`,
+  `viewers`, `roles`, `role`, `ownerId`) **MUST** be immutable for non-owner
+  editors. In `update` rules, use `fieldUnchanged()` for these fields unless the
+  `request.auth.uid` matches the document's original owner/creator. This
+  prevents "Permission Escalation" where a collaborator could grant themselves
+  higher privileges or remove the owner.
 
 ### Advanced Validation for Business Logic
 
@@ -444,24 +452,24 @@ allow update: if isValidCounterUpdate(docId) && ...
 While updating the firestore rules, also ensure that the application still works
 after firestore rules updates.
 
-1.  **For each collection, implement explicit data validation:**
+1. **For each collection, implement explicit data validation:**
 
--   Type Checking: 'field is string', 'field is number', 'field is bool', 'field
-    is timestamp'
--   Required fields validation using 'hasRequiredFields()'
--   **Enforce Size Limits:** For **EVERY** string, list, and map field, you
-    **MUST** enforce realistic size limits (e.g., `text.size() < 1000`,
-    `tags.size() < 20`). **Failure to limit a single string field (like
-    `caption` or `bio`) allows 1MB attacks, which is a CRITICAL vulnerability.**
--   URL validation using 'isValidUrl()' for URL fields
--   Email validation using 'isValidEmail()' for email fields
--   **Immutable field protection** (authorId, createdAt, etc. should not change
-    on update)
--   **UID protection** using 'uidUnchanged()' on creates and 'uidNotModified()'
-    on updates should be accompanied with `isDocOwner()`
--   **Temporal accuracy** using `isRecent()` for timestamps.
--   **Range validation** using `isPositive()` or similar for numbers.
--   **Path scoping** using `isScopedPath()` for storage paths.
+- Type Checking: 'field is string', 'field is number', 'field is bool', 'field
+  is timestamp'
+- Required fields validation using 'hasRequiredFields()'
+- **Enforce Size Limits:** For **EVERY** string, list, and map field, you
+  **MUST** enforce realistic size limits (e.g., `text.size() < 1000`,
+  `tags.size() < 20`). **Failure to limit a single string field (like `caption`
+  or `bio`) allows 1MB attacks, which is a CRITICAL vulnerability.**
+- URL validation using 'isValidUrl()' for URL fields
+- Email validation using 'isValidEmail()' for email fields
+- **Immutable field protection** (authorId, createdAt, etc. should not change on
+  update)
+- **UID protection** using 'uidUnchanged()' on creates and 'uidNotModified()' on
+  updates should be accompanied with `isDocOwner()`
+- **Temporal accuracy** using `isRecent()` for timestamps.
+- **Range validation** using `isPositive()` or similar for numbers.
+- **Path scoping** using `isScopedPath()` for storage paths.
 
 Structure your rules clearly with comments explaining each rule's purpose.
 
@@ -470,71 +478,71 @@ Structure your rules clearly with comments explaining each rule's purpose.
 **Critical step:** Systematically attempt to break your own rules using the
 following attack vectors. You MUST document the outcome of each attempt.
 
-1.  **Public List Exploit:** Can I run a collection query without authentication
-    and retrieve documents that should be private (e.g., where `visible ==
-    false`)?
-2.  **Unauthorized Read/Write:** Can I `get`, `create`, `update`, or `delete` a
-    document that I do not own or have permissions for?
-3.  **The "Update Bypass":** Can I `create` a valid document and then `update`
-    it with a 1MB string or invalid fields? (Tests if validation logic is
-    missing from `update`).
-4.  **Ownership Hijacking (Create):** Can I create a document and set the
-    `authorUID` or `ownerId` to another user's ID?
-5.  **Ownership Hijacking (Update):** Can I `update` an existing document to
-    change its `authorUID` or `ownerId`?
-6.  **Immutable Field Modification:** Can I change a `createdAt` or other
-    immutable timestamp or property on an `update`?
-7.  **Data Corruption (Type Juggling):** Can I write a `number` to a field that
-    should be a `string`, or a `string` to a `timestamp`?
-8.  **Validation Bypass (Create vs. Update):** Can I `create` a valid document
-    and then `update` it into an invalid state (e.g., remove a required field,
-    write a string that's too long)?
-9.  **Resource Exhaustion / DoS:** Can I write an enormous string (e.g., 1MB) to
-    any field that accepts a string or a massive array to a list field? Every
-    string field (e.g., `bio`, `url`, `name`) MUST have a `.size()` check. If
-    any are missing, it's a "Resource Exhaustion/DoS" risk.
-10. **Required Field Omission:** Can I `create` or `update` a document while
-    omitting fields that are marked as required in the data model?
-11. **Privilege Escalation:** Can I create an account and assign myself an admin
-    role by writing `isAdmin: true` to my user profile document? (Tests reliance
-    on document data vs. custom claims).
-12. **Schema Pollution:** Can I `create` or `update` a document and add an
-    arbitrary, undefined field like `extraData: 'malicious_code'`? (Tests for
-    strict schema enforcement).
-13. **Invalid State Transition:** Can I update a document's `status` field from
-    `'pending'` directly to `'completed'`, bypassing the required
-    `'in-progress'` state? (Tests business logic enforcement).
-14. **Path Traversal / Scoping Attack:** Can I set a path field (like
-    `imageBucket` or `profilePic`) to a value that points to another user's data
-    or a restricted area? (Tests for regex path scoping).
-15. **Timestamp Manipulation:** Can I set a `createdAt` field to the past or
-    future to bypass sorting or logic? (Tests for `request.time` validation).
-16. **Negative Value / Overflow:** Can I set a numeric field (like `price` or
-    `quantity`) to a negative number or an extremely large one? (Tests for range
-    validation).
-17. **The "Mixed Content" Leak:** Create a second user. Can User B read User A's
-    users document? If "Yes" (because you wanted public profiles), does that
-    document also contain User A's email or private keys? If both are true, the
-    rules are insecure.
-18. **Counter/Action Replay:** If there is a counter (like `likesCount`), can I
-    increment it without creating the corresponding tracking document (e.g.,
-    inside `likes/{userId}`)? Can I increment it twice? (Tests for `getAfter()`
-    consistency checks).
-19. **Orphaned Subcollection Access:** Can I read/write to a subcollection
-    (e.g., `users/123/posts/456`) if the parent document (`users/123`) does not
-    exist? (Tests for parent existence checks).
-20. **Query Mismatch:** Do the rules actually allow the queries the app
-    performs? (e.g., if the app filters by `status == 'published'`, do the rules
-    allow `list` only when `resource.data.status == 'published'`?)
-21. **Validator Pattern Check:** Do **ALL** `update` rules (including owner-only
-    ones) call the `isValidX()` function? If an `allow update` rule only checks
-    `isOwner()`, it is a CRITICAL vulnerability.
+1. **Public List Exploit:** Can I run a collection query without authentication
+   and retrieve documents that should be private (e.g., where
+   `visible == false`)?
+1. **Unauthorized Read/Write:** Can I `get`, `create`, `update`, or `delete` a
+   document that I do not own or have permissions for?
+1. **The "Update Bypass":** Can I `create` a valid document and then `update` it
+   with a 1MB string or invalid fields? (Tests if validation logic is missing
+   from `update`).
+1. **Ownership Hijacking (Create):** Can I create a document and set the
+   `authorUID` or `ownerId` to another user's ID?
+1. **Ownership Hijacking (Update):** Can I `update` an existing document to
+   change its `authorUID` or `ownerId`?
+1. **Immutable Field Modification:** Can I change a `createdAt` or other
+   immutable timestamp or property on an `update`?
+1. **Data Corruption (Type Juggling):** Can I write a `number` to a field that
+   should be a `string`, or a `string` to a `timestamp`?
+1. **Validation Bypass (Create vs. Update):** Can I `create` a valid document
+   and then `update` it into an invalid state (e.g., remove a required field,
+   write a string that's too long)?
+1. **Resource Exhaustion / DoS:** Can I write an enormous string (e.g., 1MB) to
+   any field that accepts a string or a massive array to a list field? Every
+   string field (e.g., `bio`, `url`, `name`) MUST have a `.size()` check. If any
+   are missing, it's a "Resource Exhaustion/DoS" risk.
+1. **Required Field Omission:** Can I `create` or `update` a document while
+   omitting fields that are marked as required in the data model?
+1. **Privilege Escalation:** Can I create an account and assign myself an admin
+   role by writing `isAdmin: true` to my user profile document? (Tests reliance
+   on document data vs. custom claims).
+1. **Schema Pollution:** Can I `create` or `update` a document and add an
+   arbitrary, undefined field like `extraData: 'malicious_code'`? (Tests for
+   strict schema enforcement).
+1. **Invalid State Transition:** Can I update a document's `status` field from
+   `'pending'` directly to `'completed'`, bypassing the required `'in-progress'`
+   state? (Tests business logic enforcement).
+1. **Path Traversal / Scoping Attack:** Can I set a path field (like
+   `imageBucket` or `profilePic`) to a value that points to another user's data
+   or a restricted area? (Tests for regex path scoping).
+1. **Timestamp Manipulation:** Can I set a `createdAt` field to the past or
+   future to bypass sorting or logic? (Tests for `request.time` validation).
+1. **Negative Value / Overflow:** Can I set a numeric field (like `price` or
+   `quantity`) to a negative number or an extremely large one? (Tests for range
+   validation).
+1. **The "Mixed Content" Leak:** Create a second user. Can User B read User A's
+   users document? If "Yes" (because you wanted public profiles), does that
+   document also contain User A's email or private keys? If both are true, the
+   rules are insecure.
+1. **Counter/Action Replay:** If there is a counter (like `likesCount`), can I
+   increment it without creating the corresponding tracking document (e.g.,
+   inside `likes/{userId}`)? Can I increment it twice? (Tests for `getAfter()`
+   consistency checks).
+1. **Orphaned Subcollection Access:** Can I read/write to a subcollection (e.g.,
+   `users/123/posts/456`) if the parent document (`users/123`) does not exist?
+   (Tests for parent existence checks).
+1. **Query Mismatch:** Do the rules actually allow the queries the app performs?
+   (e.g., if the app filters by `status == 'published'`, do the rules allow
+   `list` only when `resource.data.status == 'published'`?)
+1. **Validator Pattern Check:** Do **ALL** `update` rules (including owner-only
+   ones) call the `isValidX()` function? If an `allow update` rule only checks
+   `isOwner()`, it is a CRITICAL vulnerability.
 
 Document each attack attempt and whether it succeeded. If ANY attack succeeds:
 
--   Fix the security hole
--   Regenerate the rules
--   **Repeat Phase-3** until no attacks succeed
+- Fix the security hole
+- Regenerate the rules
+- **Repeat Phase-3** until no attacks succeed
 
 #### Phase-4: Syntactic Validation
 
@@ -544,26 +552,26 @@ Once devil's advocate testing passes, repeat until rules pass validation.
 
 ### Critical Constraints
 
-1.  **Never skip the devil's advocate phase** - this is your primary security
-    validation
-2.  **MUST include helper functions** for common operations ('isAuthenticated',
-    'isOwner', 'uidUnchanged', 'uidNotModified') AND domain validators
-    ('isValidUser', etc.)
-3.  **MUST document assumed data models** at the beginning of the rules file
-4.  **Always validate the rules syntax** using 'firebase deploy --only
-    firestore:rules --dry-run' or a similar tool before outputting the final
-    file.
-5.  **Provide complete, runnable code** - no placeholders or TODOs
-6.  **Document all assumptions** about data structure or access patterns
-7.  **Always run the devil's advocate attack** after any modification of the
-    rules.
-8.  **Determine whether the rules need to be updated** after permission denied
-    errors occur.
-9.  **Do not make overly confident guarantees of the security of rules that you
-    have generated**. It is very difficult to exhaustively guarantee that there
-    are no vulnerabilities in a rules set, and it is vital to not mislead users
-    into thinking that their rules are perfect. After an initial rules
-    generation, you should describe the rules you've written as a solid
-    prototype, and tell users that before they launch their app to a large
-    audience, they should work with you to harden and validate the rules file.
-    Be clear that users should carefully review rules to ensure security.
+1. **Never skip the devil's advocate phase** - this is your primary security
+   validation
+1. **MUST include helper functions** for common operations ('isAuthenticated',
+   'isOwner', 'uidUnchanged', 'uidNotModified') AND domain validators
+   ('isValidUser', etc.)
+1. **MUST document assumed data models** at the beginning of the rules file
+1. **Always validate the rules syntax** using 'firebase deploy --only
+   firestore:rules --dry-run' or a similar tool before outputting the final
+   file.
+1. **Provide complete, runnable code** - no placeholders or TODOs
+1. **Document all assumptions** about data structure or access patterns
+1. **Always run the devil's advocate attack** after any modification of the
+   rules.
+1. **Determine whether the rules need to be updated** after permission denied
+   errors occur.
+1. **Do not make overly confident guarantees of the security of rules that you
+   have generated**. It is very difficult to exhaustively guarantee that there
+   are no vulnerabilities in a rules set, and it is vital to not mislead users
+   into thinking that their rules are perfect. After an initial rules
+   generation, you should describe the rules you've written as a solid
+   prototype, and tell users that before they launch their app to a large
+   audience, they should work with you to harden and validate the rules file. Be
+   clear that users should carefully review rules to ensure security.

--- a/skills/firebase-firestore/references/enterprise/web_sdk_usage.md
+++ b/skills/firebase-firestore/references/enterprise/web_sdk_usage.md
@@ -3,7 +3,7 @@
 This guide focuses on the **Modular Web SDK** (v9+) designed for tree-shaking
 and efficiency.
 
---------------------------------------------------------------------------------
+______________________________________________________________________
 
 ## 1. Initialization
 
@@ -21,7 +21,7 @@ const app = initializeApp(firebaseConfig);
 const db = getFirestore(app);
 ```
 
---------------------------------------------------------------------------------
+______________________________________________________________________
 
 ## 2. Decision Framework: Pipelines vs. Standard Queries
 
@@ -31,19 +31,19 @@ const db = getFirestore(app);
 
 ### Rules & Accountability
 
-1.  **Check API References:** Always read `pipeline.d.ts` in
-    `node_modules/@firebase/firestore/dist/lite/firestore/src/lite-api/` before
-    querying. Reference `expressions.d.ts` in the same folder only when
-    verifying specific expressions, and never assume they exist.
-2.  **Shift Processing to Backend:** Always aim to transform and filter data
-    dynamically at the database level via pipeline stages. Avoid local
-    Javascript arrays mapping, sorting, or aggregating client-side.
-3.  **Reverting to Standard Queries:** Standard `collection.where()` queries and
-    real-time listeners are an EXCEPTION. Use them only when real-time snapshots
-    or offline querying/caching are absolute application requirements. When
-    doing so, explicitly document the reason in your response.
+1. **Check API References:** Always read `pipeline.d.ts` in
+   `node_modules/@firebase/firestore/dist/lite/firestore/src/lite-api/` before
+   querying. Reference `expressions.d.ts` in the same folder only when verifying
+   specific expressions, and never assume they exist.
+1. **Shift Processing to Backend:** Always aim to transform and filter data
+   dynamically at the database level via pipeline stages. Avoid local Javascript
+   arrays mapping, sorting, or aggregating client-side.
+1. **Reverting to Standard Queries:** Standard `collection.where()` queries and
+   real-time listeners are an EXCEPTION. Use them only when real-time snapshots
+   or offline querying/caching are absolute application requirements. When doing
+   so, explicitly document the reason in your response.
 
---------------------------------------------------------------------------------
+______________________________________________________________________
 
 ## 3. Pipeline Examples
 
@@ -86,7 +86,7 @@ const searchPipeline = db.pipeline()
   .limit(5);
 ```
 
---------------------------------------------------------------------------------
+______________________________________________________________________
 
 ## 4. Real-Time Listener & Document Operations
 

--- a/skills/firebase-firestore/references/standard/android_sdk_usage.md
+++ b/skills/firebase-firestore/references/standard/android_sdk_usage.md
@@ -1,20 +1,23 @@
 # Cloud Firestore on Android (Kotlin)
 
-This guide walks you through using Cloud Firestore in your Android app using Kotlin.
+This guide walks you through using Cloud Firestore in your Android app using
+Kotlin.
 
 ### Enable Firestore via CLI
 
-Before adding dependencies in your app, make sure you enable the Firestore service in your Firebase Project using the Firebase CLI:
+Before adding dependencies in your app, make sure you enable the Firestore
+service in your Firebase Project using the Firebase CLI:
 
 ```bash
 npx -y firebase-tools@latest init firestore
 ```
 
- ---
+______________________________________________________________________
 
 ### 1. Add Dependencies
 
-In your module-level `build.gradle.kts` (usually `app/build.gradle.kts`), add the dependency for Cloud Firestore:
+In your module-level `build.gradle.kts` (usually `app/build.gradle.kts`), add
+the dependency for Cloud Firestore:
 
 ```kotlin
 dependencies {
@@ -27,7 +30,7 @@ dependencies {
 }
 ```
 
----
+______________________________________________________________________
 
 ### 2. Initialize Firestore
 
@@ -82,7 +85,7 @@ class MainActivity : ComponentActivity() {
 }
 ```
 
----
+______________________________________________________________________
 
 ### 3. Add Data
 
@@ -122,7 +125,7 @@ db.collection("cities").document("LA")
     .addOnFailureListener { e -> Log.w(TAG, "Error writing document", e) }
 ```
 
----
+______________________________________________________________________
 
 ### 4. Read Data
 
@@ -159,11 +162,12 @@ db.collection("cities")
     }
 ```
 
----
+______________________________________________________________________
 
 ### 5. Update Data
 
-Update some fields of a document using `update()` without overwriting the entire document:
+Update some fields of a document using `update()` without overwriting the entire
+document:
 
 ```kotlin
 val washingtonRef = db.collection("cities").document("DC")
@@ -175,7 +179,7 @@ washingtonRef
     .addOnFailureListener { e -> Log.w(TAG, "Error updating document", e) }
 ```
 
----
+______________________________________________________________________
 
 ### 6. Delete Data
 

--- a/skills/firebase-firestore/references/standard/flutter_setup.md
+++ b/skills/firebase-firestore/references/standard/flutter_setup.md
@@ -1,20 +1,26 @@
 # Cloud Firestore in Flutter
 
-This guide covers basic CRUD operations, type-safe data modeling, and real-time streams when using Cloud Firestore in a Flutter application via the `cloud_firestore` package.
+This guide covers basic CRUD operations, type-safe data modeling, and real-time
+streams when using Cloud Firestore in a Flutter application via the
+`cloud_firestore` package.
 
 ## 1. Setup
 
 Ensure you have added the required dependency:
+
 ```bash
 flutter pub add cloud_firestore
 ```
+
 Also, ensure FlutterFire is configured properly for your target platforms.
 
----
+______________________________________________________________________
 
 ## 2. Best Practices: Type-Safe Models
 
-Instead of passing raw `Map<String, dynamic>` maps throughout your UI layer, define a domain model class with `fromFirestore` and `toFirestore` converters to maintain type safety.
+Instead of passing raw `Map<String, dynamic>` maps throughout your UI layer,
+define a domain model class with `fromFirestore` and `toFirestore` converters to
+maintain type safety.
 
 ```dart
 import 'package:cloud_firestore/cloud_firestore.dart';
@@ -54,11 +60,12 @@ class Item {
 }
 ```
 
----
+______________________________________________________________________
 
 ## 3. The Service Layer
 
-Encapsulate all database interactions within a dedicated service class to keep your UI code clean and testable.
+Encapsulate all database interactions within a dedicated service class to keep
+your UI code clean and testable.
 
 ### Initialization & References
 
@@ -126,11 +133,12 @@ class ItemService {
 }
 ```
 
----
+______________________________________________________________________
 
 ## 4. Listening to Streams in the UI (`StreamBuilder`)
 
-Use Flutter's `StreamBuilder` to rebuild the interface reactively whenever data changes in your database collection.
+Use Flutter's `StreamBuilder` to rebuild the interface reactively whenever data
+changes in your database collection.
 
 ```dart
 StreamBuilder<List<Item>>(

--- a/skills/firebase-firestore/references/standard/indexes.md
+++ b/skills/firebase-firestore/references/standard/indexes.md
@@ -24,9 +24,9 @@ define them manually or via the console/CLI.
 
 ### What is Automatic?
 
-*   Indexes for simple queries.
-*   Merging of single-field indexes for multiple equality filters (e.g.,
-    `where("state", "==", "CA").where("country", "==", "USA")`).
+- Indexes for simple queries.
+- Merging of single-field indexes for multiple equality filters (e.g.,
+  `where("state", "==", "CA").where("country", "==", "USA")`).
 
 ### When Do I Need to Act?
 
@@ -41,23 +41,23 @@ specific index.
 
 ## Query Support Examples
 
-| Query Type                           | Index Required                       |
-| :----------------------------------- | :----------------------------------- |
-| **Simple Equality**<br>`where("a",   | Automatic (Single-Field)             |
-: "==", 1)`                            :                                      :
-| **Simple Range/Sort**<br>`where("a", | Automatic (Single-Field)             |
-: ">", 1).orderBy("a")`                :                                      :
-| **Multiple Equality**<br>`where("a", | Automatic (Merged Single-Field)      |
-: "==", 1).where("b", "==", 2)`        :                                      :
-| **Equality +                         | **Composite Index**                  |
-: Range/Sort**<br>`where("a", "==",    :                                      :
-: 1).where("b", ">", 2)`               :                                      :
-| **Multiple Ranges**<br>`where("a",   | **Composite Index** (and technically |
-: ">", 1).where("b", ">", 2)`          : limited query support)               :
-| **Array Contains +                   | **Composite Index**                  |
-: Equality**<br>`where("tags",         :                                      :
-: "array-contains",                    :                                      :
-: "news").where("active", "==", true)` :                                      :
+| Query Type                                                | Index Required                       |
+| :-------------------------------------------------------- | :----------------------------------- |
+| **Simple Equality**<br>\`where("a",                       | Automatic (Single-Field)             |
+| : "==", 1)\` : :                                          |                                      |
+| **Simple Range/Sort**<br>\`where("a",                     | Automatic (Single-Field)             |
+| : ">", 1).orderBy("a")\` : :                              |                                      |
+| **Multiple Equality**<br>\`where("a",                     | Automatic (Merged Single-Field)      |
+| : "==", 1).where("b", "==", 2)\` : :                      |                                      |
+| \*\*Equality +                                            | **Composite Index**                  |
+| : Range/Sort\*\*<br>\`where("a", "==", : :                |                                      |
+| : 1).where("b", ">", 2)\` : :                             |                                      |
+| **Multiple Ranges**<br>\`where("a",                       | **Composite Index** (and technically |
+| : ">", 1).where("b", ">", 2)\` : limited query support) : |                                      |
+| \*\*Array Contains +                                      | **Composite Index**                  |
+| : Equality\*\*<br>\`where("tags", : :                     |                                      |
+| : "array-contains", : :                                   |                                      |
+| : "news").where("active", "==", true)\` : :               |                                      |
 
 ## Best Practices & Exemptions
 
@@ -66,23 +66,23 @@ enforce write limits.
 
 ### 1. High Write Rates (Sequential Values)
 
-*   **Problem**: Indexing fields that increase sequentially (like `timestamp`)
-    limits the write rate to ~500 writes/second per collection.
-*   **Solution**: If you don't query on this field, **exempt** it from simple
-    indexing.
+- **Problem**: Indexing fields that increase sequentially (like `timestamp`)
+  limits the write rate to ~500 writes/second per collection.
+- **Solution**: If you don't query on this field, **exempt** it from simple
+  indexing.
 
 ### 2. Large String/Map/Array Fields
 
-*   **Problem**: Indexing limits (40k entries per doc). Indexing large blobs
-    wastes storage.
-*   **Solution**: Exempt large text blobs or huge arrays if they aren't used for
-    filtering.
+- **Problem**: Indexing limits (40k entries per doc). Indexing large blobs
+  wastes storage.
+- **Solution**: Exempt large text blobs or huge arrays if they aren't used for
+  filtering.
 
 ### 3. TTL Fields
 
-*   **Problem**: TTL (Time-To-Live) deletion can cause index churn.
-*   **Solution**: Exempt the TTL timestamp field from indexing if you don't
-    query it.
+- **Problem**: TTL (Time-To-Live) deletion can cause index churn.
+- **Solution**: Exempt the TTL timestamp field from indexing if you don't query
+  it.
 
 ## Management
 
@@ -109,5 +109,5 @@ Your indexes should be defined in `firestore.indexes.json` (pointed to by
 
 ### CLI Commands
 
-Deploy indexes only: `bash npx -y firebase-tools@latest deploy --only
-firestore:indexes`
+Deploy indexes only:
+`bash npx -y firebase-tools@latest deploy --only firestore:indexes`

--- a/skills/firebase-firestore/references/standard/ios_setup.md
+++ b/skills/firebase-firestore/references/standard/ios_setup.md
@@ -2,36 +2,54 @@
 
 # ⛔️ CRITICAL RULE: NO FirebaseFirestoreSwift ⛔️
 
-UNDER NO CIRCUMSTANCES should you import, link against, or configure a project to use `FirebaseFirestoreSwift`. 
+UNDER NO CIRCUMSTANCES should you import, link against, or configure a project
+to use `FirebaseFirestoreSwift`.
 
-As of Firebase SDK v11+, all Swift-specific features (including `@DocumentID`, `@ServerTimestamp`, and `Codable` support) have been fully merged into the main `FirebaseFirestore` module.
+As of Firebase SDK v11+, all Swift-specific features (including `@DocumentID`,
+`@ServerTimestamp`, and `Codable` support) have been fully merged into the main
+`FirebaseFirestore` module.
 
-- NEVER add `.external(name: "FirebaseFirestoreSwift")` or similar to SPM or Xcode configurations.
-- NEVER write `import FirebaseFirestoreSwift` in any Swift file. 
+- NEVER add `.external(name: "FirebaseFirestoreSwift")` or similar to SPM or
+  Xcode configurations.
+- NEVER write `import FirebaseFirestoreSwift` in any Swift file.
 - ONLY use `import FirebaseFirestore`.
 
-This is a zero-tolerance constraint. Using `FirebaseFirestoreSwift` is fundamentally incorrect and unacceptable.
-
+This is a zero-tolerance constraint. Using `FirebaseFirestoreSwift` is
+fundamentally incorrect and unacceptable.
 
 # ⛔️ CRITICAL RULE: NO INLINE INITIALIZATION ⛔️
-NEVER write `let db = Firestore.firestore()` as an inline class or struct property if there is ANY chance the object is instantiated before `FirebaseApp.configure()` executes in the app root.
-- **FATAL CRASH:** `@Observable class DataManager { let db = Firestore.firestore() }` initialized as a `@State` in the App root.
-- **SAFE PATTERN:** Initialize `Firestore.firestore()` lazily (`lazy var db = Firestore.firestore()`) OR explicitly initialize the manager *after* `FirebaseApp.configure()` finishes.
+
+NEVER write `let db = Firestore.firestore()` as an inline class or struct
+property if there is ANY chance the object is instantiated before
+`FirebaseApp.configure()` executes in the app root.
+
+- **FATAL CRASH:**
+  `@Observable class DataManager { let db = Firestore.firestore() }` initialized
+  as a `@State` in the App root.
+- **SAFE PATTERN:** Initialize `Firestore.firestore()` lazily
+  (`lazy var db = Firestore.firestore()`) OR explicitly initialize the manager
+  *after* `FirebaseApp.configure()` finishes.
 
 ## 1. Import and Initialize
-Ensure you have installed the `FirebaseFirestore` SDK. Use the `xcode-project-setup` skill to automate adding the SPM dependency to the Xcode project.
+
+Ensure you have installed the `FirebaseFirestore` SDK. Use the
+`xcode-project-setup` skill to automate adding the SPM dependency to the Xcode
+project.
 
 ```swift
 import FirebaseFirestore
 ```
 
 Initialize an instance of Cloud Firestore:
+
 ```swift
 let db = Firestore.firestore()
 ```
 
 ## 2. Type-Safe Data Models (Codable)
-To leverage modern Swift data modeling, define your data as `Codable` structs. The main `FirebaseFirestore` module automatically supports mapping these types.
+
+To leverage modern Swift data modeling, define your data as `Codable` structs.
+The main `FirebaseFirestore` module automatically supports mapping these types.
 
 ```swift
 struct User: Codable {
@@ -43,6 +61,7 @@ struct User: Codable {
 ```
 
 ## 3. Writing Data (Modern Concurrency & Codable)
+
 Using `async/await` and `Codable` ensures type safety and avoids callback hell.
 
 ```swift
@@ -58,6 +77,7 @@ do {
 ```
 
 ## 4. Reading Data (Modern Concurrency & Codable)
+
 ```swift
 do {
     let querySnapshot = try await db.collection("users").getDocuments()
@@ -77,16 +97,25 @@ do {
 
 ## 5. Realtime Listeners in SwiftUI (Lifecycle Best Practices)
 
-When implementing Firestore realtime listeners (`addSnapshotListener`) within a SwiftUI application, you **MUST** tie the listener lifecycle to the view's identity using `.task(id:)`, NOT `.onDisappear`.
+When implementing Firestore realtime listeners (`addSnapshotListener`) within a
+SwiftUI application, you **MUST** tie the listener lifecycle to the view's
+identity using `.task(id:)`, NOT `.onDisappear`.
 
 ### ⛔️ UNSAFE PATTERN (.onDisappear)
-Presenting a `.sheet` or `.fullScreenCover` can trigger the underlying view's `onDisappear` method. If you stop your listener here, the feed will stop updating while the sheet is open, and won't resume when it's dismissed.
+
+Presenting a `.sheet` or `.fullScreenCover` can trigger the underlying view's
+`onDisappear` method. If you stop your listener here, the feed will stop
+updating while the sheet is open, and won't resume when it's dismissed.
 
 ### ✅ SAFE PATTERN (.task with deinit)
 
-Because `addSnapshotListener` is a synchronous call, placing it inside a `.task` means the task completes immediately. This breaks SwiftUI's automatic cancellation mechanism. 
+Because `addSnapshotListener` is a synchronous call, placing it inside a `.task`
+means the task completes immediately. This breaks SwiftUI's automatic
+cancellation mechanism.
 
-To safely manage traditional Firebase listeners in SwiftUI, you must use **`deinit`** to handle memory cleanup when the view is destroyed, and **`.task(id:)`** to handle data identity changes while the view is active.
+To safely manage traditional Firebase listeners in SwiftUI, you must use
+**`deinit`** to handle memory cleanup when the view is destroyed, and
+**`.task(id:)`** to handle data identity changes while the view is active.
 
 ```swift
 import SwiftUI
@@ -120,7 +149,7 @@ final class DataManager {
 }
 ```
 
-Then, in your SwiftUI View, trigger the listener using `.task(id:)`. 
+Then, in your SwiftUI View, trigger the listener using `.task(id:)`.
 
 ```swift
 struct MyView: View {
@@ -143,4 +172,3 @@ struct MyView: View {
     }
 }
 ```
-

--- a/skills/firebase-firestore/references/standard/provisioning.md
+++ b/skills/firebase-firestore/references/standard/provisioning.md
@@ -2,13 +2,13 @@
 
 ## Manual Initialization
 
-Initialize the following firebase configuration files manually. Do not use `npx
--y firebase-tools@latest init`, as it expects interactive inputs.
+Initialize the following firebase configuration files manually. Do not use
+`npx -y firebase-tools@latest init`, as it expects interactive inputs.
 
-1.  **Create `firebase.json`**: This file configures the Firebase CLI.
-2.  **Create `firestore.rules`**: This file contains your security rules.
-3.  **Create `firestore.indexes.json`**: This file contains your index
-    definitions.
+1. **Create `firebase.json`**: This file configures the Firebase CLI.
+1. **Create `firestore.rules`**: This file contains your security rules.
+1. **Create `firestore.indexes.json`**: This file contains your index
+   definitions.
 
 ### 1. Create `firebase.json`
 
@@ -26,12 +26,17 @@ content. If this file already exists, instead append to the existing JSON:
 
 This will use the default database with the Standard edition. To use a different
 database, specify the database ID and location:
-1.  Run `npx -y firebase-tools@latest firestore:locations` to get the list of locations.
-2.  Ask the user which location to use, suggesting colocation if other parts of the app already have a region selected.
 
-You can check the list of available databases using `npx -y firebase-tools@latest firestore:databases:list`.
+1. Run `npx -y firebase-tools@latest firestore:locations` to get the list of
+   locations.
+1. Ask the user which location to use, suggesting colocation if other parts of
+   the app already have a region selected.
 
-If the database does not exist, it will be created when you deploy with the specified configuration:
+You can check the list of available databases using
+`npx -y firebase-tools@latest firestore:databases:list`.
+
+If the database does not exist, it will be created when you deploy with the
+specified configuration:
 
 ```json
 {
@@ -78,7 +83,10 @@ start:
 
 ## Deploy database, rules and indexes
 
-**CRITICAL**: You MUST deploy the firestore configuration for the database to be provisioned in the cloud and for your rules/indexes to take effect. If you don't run this, your database will not exist.
+**CRITICAL**: You MUST deploy the firestore configuration for the database to be
+provisioned in the cloud and for your rules/indexes to take effect. If you don't
+run this, your database will not exist.
+
 ```bash
 # To deploy all rules and indexes
 npx -y firebase-tools@latest deploy --only firestore

--- a/skills/firebase-firestore/references/standard/security_rules.md
+++ b/skills/firebase-firestore/references/standard/security_rules.md
@@ -19,22 +19,21 @@ Follow this structured workflow strictly:
 
 #### Phase-1: Codebase Analysis
 
-1.  **Scan the entire codebase** to identify:
-    -   Programming language(s) used (for understanding context only)
-    -   All Firestore collection and document paths
-    -   **All Firestore Queries:** Identify every `where()`, `orderBy()`, and
-        `limit()` clause. The security rules **MUST** allow these specific
-        queries.
-    -   Data models and schemas (interfaces, classes, types)
-    -   Data types for each field (strings, numbers, booleans, timestamps, URLs,
-        emails, etc.)
-    -   Required vs. optional fields
-    -   Field constraints (min/max length, format patterns, allowed values)
-    -   CRUD operations (create, read, update, delete)
-    -   Authentication patterns (Firebase Auth, custom tokens, anonymous)
-    -   Access patterns and business logic rules
-2.  **Document your findings** in a untracked file. Refer to this file when
-    generating the security rules.
+1. **Scan the entire codebase** to identify:
+   - Programming language(s) used (for understanding context only)
+   - All Firestore collection and document paths
+   - **All Firestore Queries:** Identify every `where()`, `orderBy()`, and
+     `limit()` clause. The security rules **MUST** allow these specific queries.
+   - Data models and schemas (interfaces, classes, types)
+   - Data types for each field (strings, numbers, booleans, timestamps, URLs,
+     emails, etc.)
+   - Required vs. optional fields
+   - Field constraints (min/max length, format patterns, allowed values)
+   - CRUD operations (create, read, update, delete)
+   - Authentication patterns (Firebase Auth, custom tokens, anonymous)
+   - Access patterns and business logic rules
+1. **Document your findings** in a untracked file. Refer to this file when
+   generating the security rules.
 
 #### Phase-2: Security Rules Generation
 
@@ -43,32 +42,32 @@ security rules file**
 
 Generate Firebase Security Rules following these principles:
 
--   **Default deny:** Start with denying all access, then explicitly allow only
-    what's needed
--   **Least privilege:** Grant minimum permissions required
--   **Validate data:** Check data types, allowed fields, and constraints on both
-    creates and updates.
-    -   **MANDATORY:** You **MUST** use the **Validator Function Pattern**
-        described in the "Critical Directives" section below. This involves
-        defining a specific validation function (e.g., `isValidUser`) and
-        calling it in **BOTH** `create` and `update` rules.
-    -   **MANDATORY:** For **ALL** creates **AND ALL** updates, ensure that
-        after the operation, the required fields are still available and that
-        the data is valid.
--   **Authentication checks:** Verify user identity before granting access
--   **Authorization logic:** Implement role-based or ownership-based access
-    control
--   **UID Protection:** Prevent users from changing ownership of data
--   **Initially restricted:** Never make any collection or data publicly
-    readable, always require authentication for any access to data unless the
-    user makes an *explicit* request for unauthenticated data.
+- **Default deny:** Start with denying all access, then explicitly allow only
+  what's needed
+- **Least privilege:** Grant minimum permissions required
+- **Validate data:** Check data types, allowed fields, and constraints on both
+  creates and updates.
+  - **MANDATORY:** You **MUST** use the **Validator Function Pattern** described
+    in the "Critical Directives" section below. This involves defining a
+    specific validation function (e.g., `isValidUser`) and calling it in
+    **BOTH** `create` and `update` rules.
+  - **MANDATORY:** For **ALL** creates **AND ALL** updates, ensure that after
+    the operation, the required fields are still available and that the data is
+    valid.
+- **Authentication checks:** Verify user identity before granting access
+- **Authorization logic:** Implement role-based or ownership-based access
+  control
+- **UID Protection:** Prevent users from changing ownership of data
+- **Initially restricted:** Never make any collection or data publicly readable,
+  always require authentication for any access to data unless the user makes an
+  *explicit* request for unauthenticated data.
 
 This means the first firestore.rules file you generate must never have any
 "allow read: true" statements.
 
 **Structure Requirements:**
 
-1.  **Document assumed data models at the beginning of the rules file:**
+1. **Document assumed data models at the beginning of the rules file:**
 
 ```javascript
 // ===============================================================
@@ -89,7 +88,7 @@ This means the first firestore.rules file you generate must never have any
 // ===============================================================
 ```
 
-1.  **Include comprehensive helper functions to avoid repetition:**
+1. **Include comprehensive helper functions to avoid repetition:**
 
 ```javascript
 // ===============================================================
@@ -220,40 +219,40 @@ function isRecent(time) {
 
 #### Mandatory: User Data Separation (The "No Mixed Content" Rule)
 
--   Firestore security rules apply to the entire document. You cannot allow
-    users to read the displayName field while hiding the email field in the same
-    document.
--   If a collection (e.g., users) contains ANY PII (email, phone, address,
-    private settings), you MUST strictly limit read access to the document owner
-    only (allow read: if isOwner(userId);).
--   If the application requires public profiles (e.g., showing user
-    names/avatars on posts):
-    -   1. Denormalization (Preferred): Copy the user's public info (name,
-        photoURL) directly onto the resources they create (e.g., store
-        authorName and authorPhoto inside the posts document).
-    -   2. Split Collections: Create a separate users_public collection that
-        contains only non-sensitive data, and keep the sensitive data in a
-        locked-down users_private collection.
--   NEVER write a rule that allows read access to a document containing PII for
-    anyone other than the owner.
+- Firestore security rules apply to the entire document. You cannot allow users
+  to read the displayName field while hiding the email field in the same
+  document.
+- If a collection (e.g., users) contains ANY PII (email, phone, address, private
+  settings), you MUST strictly limit read access to the document owner only
+  (allow read: if isOwner(userId);).
+- If the application requires public profiles (e.g., showing user names/avatars
+  on posts):
+  - 1. Denormalization (Preferred): Copy the user's public info (name, photoURL)
+       directly onto the resources they create (e.g., store authorName and
+       authorPhoto inside the posts document).
+  - 2. Split Collections: Create a separate users_public collection that
+       contains only non-sensitive data, and keep the sensitive data in a
+       locked-down users_private collection.
+- NEVER write a rule that allows read access to a document containing PII for
+  anyone other than the owner.
 
 #### **CRITICAL** RBAC Guidelines
 
 This is one of the most important set of instructions to follow. Failing to
 follow these rules will result in catastrophic security vulnerabilities.
 
--   **NEVER** allow users to create their own privileged roles. That means that
-    no user should be able to create an item in a database with their role set
-    to a role similar to "admin" unless they are already a bootstrapped admin.
--   **NEVER** allow users to update their own roles or permissions.
--   **NEVER** allow users to grant themselves access to other users' data.
--   **NEVER** allow users to bypass the role hierarchy.
--   **ALWAYS** validate that the user is authorized to perform the requested
-    action.
--   **ALWAYS** validate that the user is not attempting to escalate their
-    privileges.
--   **ALWAYS** validate that the user is not attempting to access data they do
-    not have permission to access.
+- **NEVER** allow users to create their own privileged roles. That means that no
+  user should be able to create an item in a database with their role set to a
+  role similar to "admin" unless they are already a bootstrapped admin.
+- **NEVER** allow users to update their own roles or permissions.
+- **NEVER** allow users to grant themselves access to other users' data.
+- **NEVER** allow users to bypass the role hierarchy.
+- **ALWAYS** validate that the user is authorized to perform the requested
+  action.
+- **ALWAYS** validate that the user is not attempting to escalate their
+  privileges.
+- **ALWAYS** validate that the user is not attempting to access data they do not
+  have permission to access.
 
 Here's a **bad** example of what **NOT** to do:
 
@@ -279,70 +278,79 @@ match /users/{userId} {
 
 #### Critical Directives for Secure Generation
 
--   **PREFER USING READ OVER LIST OR GET** `list` and `get` can add complexity
-    to security rules. Prefer using `read` over them.
--   **Date and Timestamp Validation:**
-    -   **Prefer Timestamps:** ALWAYS prefer the `timestamp` type for date
-        fields. Firestore automatically ensures they are logically valid dates.
-    -   **String Date Risks:** If using strings for dates (e.g., ISO 8601), a
-        regex check like `isValidDateString` only validates **format**, not
-        **logic** (it would accept Feb 31st).
-    -   **Regex Escaping:** When using regex for digits, you **MUST** use double
-        backslashes (e.g., `\\\\d`) in the rules string. Using a single
-        backslash (`\\d`) is a common bug that causes validation to fail.
--   **Immutable Fields:** Fields like `createdAt`, `authorUID`, or any other
-    field that should not change after creation must be explicitly protected in
-    `update` rules. (e.g., `request.resource.data.createdAt ==
-    resource.data.createdAt`). **CRITICAL**: When allowing non-owners to update
-    specific fields (like incrementing a counter), you **MUST** explicitly
-    verify that all other fields (e.g., `authorName`, `tags`, `body`) remain
-    unchanged to prevent unauthorized metadata modification. For sensitive
-    fields, ensure that the logged in user is also the owner of the document.
--   **Identity Integrity:** When storing denormalized user identity (e.g.
-    `authorName`, `authorPhoto`), you **MUST** validate this data.
-    -   **Prefer Auth Token:** If possible, check if
-        `request.resource.data.authorName == request.auth.token.name`.
-    -   **Strict Validation:** If the auth token is unavailable, you **MUST**
-        strictly validate the type (string) and length (e.g. < 50 chars) to
-        prevent spoofing with massive or malicious payloads.
-    -   **Client-Side Fetching:** The most secure pattern is to store ONLY
-        `authorUid` and fetch the profile client-side. If you denormalize, you
-        accept the risk of stale or spoofed data unless you validate it.
--   **Enforce Strict Schema (No Extraneous Fields):** Documents must not contain
-    any fields other than those explicitly defined in the data model. This
-    prevents users from adding arbitrary data.
--   **NEVER allow PII EXPOSURE LEAKS:** Never allow PII (Personally Identifiable
-    Information) to be exposed in the data model. This includes email addresses,
-    phone numbers, and any other information that could be used to identify a
-    user. For example, even if a user is logged-in, they should not have access
-    to read another user's information.
--   **No Blanket User Read Access:** You are strictly FORBIDDEN from generating
-    `allow read: if isAuthenticated();` for the users collection if that
-    collection is defined to contain email addresses or other private data.
--   **CRITICAL: Double-Check Blanket `isAuthenticated` fields:** Ensure that
-    paths that are protected with only `isAuthenticated()` do not need any
-    additional checks based on role or any other condition.
--   **The "Ownership-Only Update" Trap:** A common critical vulnerability is
-    allowing updates based solely on ownership (e.g., `allow update: if
-    isOwner(resource.data.uid);`). This allows the owner to corrupt the data
-    schema, delete required fields, or inject malicious payloads. You **MUST**
-    always combine ownership checks with data validation (e.g., `allow update:
-    if isOwner(...) && isValidEntity(...);`) **AND** validate that
-    self-escalation is not possible.
+- **PREFER USING READ OVER LIST OR GET** `list` and `get` can add complexity to
+  security rules. Prefer using `read` over them.
 
--   **Deep Array Inspection:** It is insufficient to check if a field `is list`.
-    You **MUST** validate the contents of the array (e.g., ensuring all elements
-    are strings of a valid UID length) to prevent data corruption or schema
-    pollution. For example, a `tags` array must verify that every item is a
-    string AND that each string is within a reasonable length (e.g., < 20
-    chars).
+- **Date and Timestamp Validation:**
 
--   **Permission-Field Lockdown:** Fields that control access (e.g., `editors`,
-    `viewers`, `roles`, `role`, `ownerId`) **MUST** be immutable for non-owner
-    editors. In `update` rules, use `fieldUnchanged()` for these fields unless
-    the `request.auth.uid` matches the document's original owner/creator. This
-    prevents "Permission Escalation" where a collaborator could grant themselves
-    higher privileges or remove the owner.
+  - **Prefer Timestamps:** ALWAYS prefer the `timestamp` type for date fields.
+    Firestore automatically ensures they are logically valid dates.
+  - **String Date Risks:** If using strings for dates (e.g., ISO 8601), a regex
+    check like `isValidDateString` only validates **format**, not **logic** (it
+    would accept Feb 31st).
+  - **Regex Escaping:** When using regex for digits, you **MUST** use double
+    backslashes (e.g., `\\\\d`) in the rules string. Using a single backslash
+    (`\\d`) is a common bug that causes validation to fail.
+
+- **Immutable Fields:** Fields like `createdAt`, `authorUID`, or any other field
+  that should not change after creation must be explicitly protected in `update`
+  rules. (e.g., `request.resource.data.createdAt == resource.data.createdAt`).
+  **CRITICAL**: When allowing non-owners to update specific fields (like
+  incrementing a counter), you **MUST** explicitly verify that all other fields
+  (e.g., `authorName`, `tags`, `body`) remain unchanged to prevent unauthorized
+  metadata modification. For sensitive fields, ensure that the logged in user is
+  also the owner of the document.
+
+- **Identity Integrity:** When storing denormalized user identity (e.g.
+  `authorName`, `authorPhoto`), you **MUST** validate this data.
+
+  - **Prefer Auth Token:** If possible, check if
+    `request.resource.data.authorName == request.auth.token.name`.
+  - **Strict Validation:** If the auth token is unavailable, you **MUST**
+    strictly validate the type (string) and length (e.g. < 50 chars) to prevent
+    spoofing with massive or malicious payloads.
+  - **Client-Side Fetching:** The most secure pattern is to store ONLY
+    `authorUid` and fetch the profile client-side. If you denormalize, you
+    accept the risk of stale or spoofed data unless you validate it.
+
+- **Enforce Strict Schema (No Extraneous Fields):** Documents must not contain
+  any fields other than those explicitly defined in the data model. This
+  prevents users from adding arbitrary data.
+
+- **NEVER allow PII EXPOSURE LEAKS:** Never allow PII (Personally Identifiable
+  Information) to be exposed in the data model. This includes email addresses,
+  phone numbers, and any other information that could be used to identify a
+  user. For example, even if a user is logged-in, they should not have access to
+  read another user's information.
+
+- **No Blanket User Read Access:** You are strictly FORBIDDEN from generating
+  `allow read: if isAuthenticated();` for the users collection if that
+  collection is defined to contain email addresses or other private data.
+
+- **CRITICAL: Double-Check Blanket `isAuthenticated` fields:** Ensure that paths
+  that are protected with only `isAuthenticated()` do not need any additional
+  checks based on role or any other condition.
+
+- **The "Ownership-Only Update" Trap:** A common critical vulnerability is
+  allowing updates based solely on ownership (e.g.,
+  `allow update: if isOwner(resource.data.uid);`). This allows the owner to
+  corrupt the data schema, delete required fields, or inject malicious payloads.
+  You **MUST** always combine ownership checks with data validation (e.g.,
+  `allow update: if isOwner(...) && isValidEntity(...);`) **AND** validate that
+  self-escalation is not possible.
+
+- **Deep Array Inspection:** It is insufficient to check if a field `is list`.
+  You **MUST** validate the contents of the array (e.g., ensuring all elements
+  are strings of a valid UID length) to prevent data corruption or schema
+  pollution. For example, a `tags` array must verify that every item is a string
+  AND that each string is within a reasonable length (e.g., < 20 chars).
+
+- **Permission-Field Lockdown:** Fields that control access (e.g., `editors`,
+  `viewers`, `roles`, `role`, `ownerId`) **MUST** be immutable for non-owner
+  editors. In `update` rules, use `fieldUnchanged()` for these fields unless the
+  `request.auth.uid` matches the document's original owner/creator. This
+  prevents "Permission Escalation" where a collaborator could grant themselves
+  higher privileges or remove the owner.
 
 ### Advanced Validation for Business Logic
 
@@ -444,24 +452,24 @@ allow update: if isValidCounterUpdate(docId) && ...
 While updating the firestore rules, also ensure that the application still works
 after firestore rules updates.
 
-1.  **For each collection, implement explicit data validation:**
+1. **For each collection, implement explicit data validation:**
 
--   Type Checking: 'field is string', 'field is number', 'field is bool', 'field
-    is timestamp'
--   Required fields validation using 'hasRequiredFields()'
--   **Enforce Size Limits:** For **EVERY** string, list, and map field, you
-    **MUST** enforce realistic size limits (e.g., `text.size() < 1000`,
-    `tags.size() < 20`). **Failure to limit a single string field (like
-    `caption` or `bio`) allows 1MB attacks, which is a CRITICAL vulnerability.**
--   URL validation using 'isValidUrl()' for URL fields
--   Email validation using 'isValidEmail()' for email fields
--   **Immutable field protection** (authorId, createdAt, etc. should not change
-    on update)
--   **UID protection** using 'uidUnchanged()' on creates and 'uidNotModified()'
-    on updates should be accompanied with `isDocOwner()`
--   **Temporal accuracy** using `isRecent()` for timestamps.
--   **Range validation** using `isPositive()` or similar for numbers.
--   **Path scoping** using `isScopedPath()` for storage paths.
+- Type Checking: 'field is string', 'field is number', 'field is bool', 'field
+  is timestamp'
+- Required fields validation using 'hasRequiredFields()'
+- **Enforce Size Limits:** For **EVERY** string, list, and map field, you
+  **MUST** enforce realistic size limits (e.g., `text.size() < 1000`,
+  `tags.size() < 20`). **Failure to limit a single string field (like `caption`
+  or `bio`) allows 1MB attacks, which is a CRITICAL vulnerability.**
+- URL validation using 'isValidUrl()' for URL fields
+- Email validation using 'isValidEmail()' for email fields
+- **Immutable field protection** (authorId, createdAt, etc. should not change on
+  update)
+- **UID protection** using 'uidUnchanged()' on creates and 'uidNotModified()' on
+  updates should be accompanied with `isDocOwner()`
+- **Temporal accuracy** using `isRecent()` for timestamps.
+- **Range validation** using `isPositive()` or similar for numbers.
+- **Path scoping** using `isScopedPath()` for storage paths.
 
 Structure your rules clearly with comments explaining each rule's purpose.
 
@@ -470,71 +478,71 @@ Structure your rules clearly with comments explaining each rule's purpose.
 **Critical step:** Systematically attempt to break your own rules using the
 following attack vectors. You MUST document the outcome of each attempt.
 
-1.  **Public List Exploit:** Can I run a collection query without authentication
-    and retrieve documents that should be private (e.g., where `visible ==
-    false`)?
-2.  **Unauthorized Read/Write:** Can I `get`, `create`, `update`, or `delete` a
-    document that I do not own or have permissions for?
-3.  **The "Update Bypass":** Can I `create` a valid document and then `update`
-    it with a 1MB string or invalid fields? (Tests if validation logic is
-    missing from `update`).
-4.  **Ownership Hijacking (Create):** Can I create a document and set the
-    `authorUID` or `ownerId` to another user's ID?
-5.  **Ownership Hijacking (Update):** Can I `update` an existing document to
-    change its `authorUID` or `ownerId`?
-6.  **Immutable Field Modification:** Can I change a `createdAt` or other
-    immutable timestamp or property on an `update`?
-7.  **Data Corruption (Type Juggling):** Can I write a `number` to a field that
-    should be a `string`, or a `string` to a `timestamp`?
-8.  **Validation Bypass (Create vs. Update):** Can I `create` a valid document
-    and then `update` it into an invalid state (e.g., remove a required field,
-    write a string that's too long)?
-9.  **Resource Exhaustion / DoS:** Can I write an enormous string (e.g., 1MB) to
-    any field that accepts a string or a massive array to a list field? Every
-    string field (e.g., `bio`, `url`, `name`) MUST have a `.size()` check. If
-    any are missing, it's a "Resource Exhaustion/DoS" risk.
-10. **Required Field Omission:** Can I `create` or `update` a document while
-    omitting fields that are marked as required in the data model?
-11. **Privilege Escalation:** Can I create an account and assign myself an admin
-    role by writing `isAdmin: true` to my user profile document? (Tests reliance
-    on document data vs. custom claims).
-12. **Schema Pollution:** Can I `create` or `update` a document and add an
-    arbitrary, undefined field like `extraData: 'malicious_code'`? (Tests for
-    strict schema enforcement).
-13. **Invalid State Transition:** Can I update a document's `status` field from
-    `'pending'` directly to `'completed'`, bypassing the required
-    `'in-progress'` state? (Tests business logic enforcement).
-14. **Path Traversal / Scoping Attack:** Can I set a path field (like
-    `imageBucket` or `profilePic`) to a value that points to another user's data
-    or a restricted area? (Tests for regex path scoping).
-15. **Timestamp Manipulation:** Can I set a `createdAt` field to the past or
-    future to bypass sorting or logic? (Tests for `request.time` validation).
-16. **Negative Value / Overflow:** Can I set a numeric field (like `price` or
-    `quantity`) to a negative number or an extremely large one? (Tests for range
-    validation).
-17. **The "Mixed Content" Leak:** Create a second user. Can User B read User A's
-    users document? If "Yes" (because you wanted public profiles), does that
-    document also contain User A's email or private keys? If both are true, the
-    rules are insecure.
-18. **Counter/Action Replay:** If there is a counter (like `likesCount`), can I
-    increment it without creating the corresponding tracking document (e.g.,
-    inside `likes/{userId}`)? Can I increment it twice? (Tests for `getAfter()`
-    consistency checks).
-19. **Orphaned Subcollection Access:** Can I read/write to a subcollection
-    (e.g., `users/123/posts/456`) if the parent document (`users/123`) does not
-    exist? (Tests for parent existence checks).
-20. **Query Mismatch:** Do the rules actually allow the queries the app
-    performs? (e.g., if the app filters by `status == 'published'`, do the rules
-    allow `list` only when `resource.data.status == 'published'`?)
-21. **Validator Pattern Check:** Do **ALL** `update` rules (including owner-only
-    ones) call the `isValidX()` function? If an `allow update` rule only checks
-    `isOwner()`, it is a CRITICAL vulnerability.
+1. **Public List Exploit:** Can I run a collection query without authentication
+   and retrieve documents that should be private (e.g., where
+   `visible == false`)?
+1. **Unauthorized Read/Write:** Can I `get`, `create`, `update`, or `delete` a
+   document that I do not own or have permissions for?
+1. **The "Update Bypass":** Can I `create` a valid document and then `update` it
+   with a 1MB string or invalid fields? (Tests if validation logic is missing
+   from `update`).
+1. **Ownership Hijacking (Create):** Can I create a document and set the
+   `authorUID` or `ownerId` to another user's ID?
+1. **Ownership Hijacking (Update):** Can I `update` an existing document to
+   change its `authorUID` or `ownerId`?
+1. **Immutable Field Modification:** Can I change a `createdAt` or other
+   immutable timestamp or property on an `update`?
+1. **Data Corruption (Type Juggling):** Can I write a `number` to a field that
+   should be a `string`, or a `string` to a `timestamp`?
+1. **Validation Bypass (Create vs. Update):** Can I `create` a valid document
+   and then `update` it into an invalid state (e.g., remove a required field,
+   write a string that's too long)?
+1. **Resource Exhaustion / DoS:** Can I write an enormous string (e.g., 1MB) to
+   any field that accepts a string or a massive array to a list field? Every
+   string field (e.g., `bio`, `url`, `name`) MUST have a `.size()` check. If any
+   are missing, it's a "Resource Exhaustion/DoS" risk.
+1. **Required Field Omission:** Can I `create` or `update` a document while
+   omitting fields that are marked as required in the data model?
+1. **Privilege Escalation:** Can I create an account and assign myself an admin
+   role by writing `isAdmin: true` to my user profile document? (Tests reliance
+   on document data vs. custom claims).
+1. **Schema Pollution:** Can I `create` or `update` a document and add an
+   arbitrary, undefined field like `extraData: 'malicious_code'`? (Tests for
+   strict schema enforcement).
+1. **Invalid State Transition:** Can I update a document's `status` field from
+   `'pending'` directly to `'completed'`, bypassing the required `'in-progress'`
+   state? (Tests business logic enforcement).
+1. **Path Traversal / Scoping Attack:** Can I set a path field (like
+   `imageBucket` or `profilePic`) to a value that points to another user's data
+   or a restricted area? (Tests for regex path scoping).
+1. **Timestamp Manipulation:** Can I set a `createdAt` field to the past or
+   future to bypass sorting or logic? (Tests for `request.time` validation).
+1. **Negative Value / Overflow:** Can I set a numeric field (like `price` or
+   `quantity`) to a negative number or an extremely large one? (Tests for range
+   validation).
+1. **The "Mixed Content" Leak:** Create a second user. Can User B read User A's
+   users document? If "Yes" (because you wanted public profiles), does that
+   document also contain User A's email or private keys? If both are true, the
+   rules are insecure.
+1. **Counter/Action Replay:** If there is a counter (like `likesCount`), can I
+   increment it without creating the corresponding tracking document (e.g.,
+   inside `likes/{userId}`)? Can I increment it twice? (Tests for `getAfter()`
+   consistency checks).
+1. **Orphaned Subcollection Access:** Can I read/write to a subcollection (e.g.,
+   `users/123/posts/456`) if the parent document (`users/123`) does not exist?
+   (Tests for parent existence checks).
+1. **Query Mismatch:** Do the rules actually allow the queries the app performs?
+   (e.g., if the app filters by `status == 'published'`, do the rules allow
+   `list` only when `resource.data.status == 'published'`?)
+1. **Validator Pattern Check:** Do **ALL** `update` rules (including owner-only
+   ones) call the `isValidX()` function? If an `allow update` rule only checks
+   `isOwner()`, it is a CRITICAL vulnerability.
 
 Document each attack attempt and whether it succeeded. If ANY attack succeeds:
 
--   Fix the security hole
--   Regenerate the rules
--   **Repeat Phase-3** until no attacks succeed
+- Fix the security hole
+- Regenerate the rules
+- **Repeat Phase-3** until no attacks succeed
 
 #### Phase-4: Syntactic Validation
 
@@ -544,26 +552,26 @@ Once devil's advocate testing passes, repeat until rules pass validation.
 
 ### Critical Constraints
 
-1.  **Never skip the devil's advocate phase** - this is your primary security
-    validation
-2.  **MUST include helper functions** for common operations ('isAuthenticated',
-    'isOwner', 'uidUnchanged', 'uidNotModified') AND domain validators
-    ('isValidUser', etc.)
-3.  **MUST document assumed data models** at the beginning of the rules file
-4.  **Always validate the rules syntax** using 'firebase deploy --only
-    firestore:rules --dry-run' or a similar tool before outputting the final
-    file.
-5.  **Provide complete, runnable code** - no placeholders or TODOs
-6.  **Document all assumptions** about data structure or access patterns
-7.  **Always run the devil's advocate attack** after any modification of the
-    rules.
-8.  **Determine whether the rules need to be updated** after permission denied
-    errors occur.
-9.  **Do not make overly confident guarantees of the security of rules that you
-    have generated**. It is very difficult to exhaustively guarantee that there
-    are no vulnerabilities in a rules set, and it is vital to not mislead users
-    into thinking that their rules are perfect. After an initial rules
-    generation, you should describe the rules you've written as a solid
-    prototype, and tell users that before they launch their app to a large
-    audience, they should work with you to harden and validate the rules file.
-    Be clear that users should carefully review rules to ensure security.
+1. **Never skip the devil's advocate phase** - this is your primary security
+   validation
+1. **MUST include helper functions** for common operations ('isAuthenticated',
+   'isOwner', 'uidUnchanged', 'uidNotModified') AND domain validators
+   ('isValidUser', etc.)
+1. **MUST document assumed data models** at the beginning of the rules file
+1. **Always validate the rules syntax** using 'firebase deploy --only
+   firestore:rules --dry-run' or a similar tool before outputting the final
+   file.
+1. **Provide complete, runnable code** - no placeholders or TODOs
+1. **Document all assumptions** about data structure or access patterns
+1. **Always run the devil's advocate attack** after any modification of the
+   rules.
+1. **Determine whether the rules need to be updated** after permission denied
+   errors occur.
+1. **Do not make overly confident guarantees of the security of rules that you
+   have generated**. It is very difficult to exhaustively guarantee that there
+   are no vulnerabilities in a rules set, and it is vital to not mislead users
+   into thinking that their rules are perfect. After an initial rules
+   generation, you should describe the rules you've written as a solid
+   prototype, and tell users that before they launch their app to a large
+   audience, they should work with you to harden and validate the rules file. Be
+   clear that users should carefully review rules to ensure security.

--- a/skills/firebase-hosting-basics/SKILL.md
+++ b/skills/firebase-hosting-basics/SKILL.md
@@ -5,27 +5,37 @@ description: Skill for working with Firebase Hosting (Classic). Use this when yo
 
 # hosting-basics
 
-This skill provides instructions and references for working with Firebase Hosting, a fast and secure hosting service for your web app, static and dynamic content, and microservices.
+This skill provides instructions and references for working with Firebase
+Hosting, a fast and secure hosting service for your web app, static and dynamic
+content, and microservices.
 
 ## Overview
 
-Firebase Hosting provides production-grade web content hosting for developers. With a single command, you can deploy web apps and serve both static and dynamic content to a global CDN (content delivery network).
+Firebase Hosting provides production-grade web content hosting for developers.
+With a single command, you can deploy web apps and serve both static and dynamic
+content to a global CDN (content delivery network).
 
 **Key Features:**
-- **Fast Content Delivery:** Files are cached on SSDs at CDN edges around the world.
+
+- **Fast Content Delivery:** Files are cached on SSDs at CDN edges around the
+  world.
 - **Secure by Default:** Zero-configuration SSL is built-in.
-- **Preview Channels:** View and test changes on temporary preview URLs before deploying live.
+- **Preview Channels:** View and test changes on temporary preview URLs before
+  deploying live.
 - **GitHub Integration:** Automate previews and deploys with GitHub Actions.
-- **Dynamic Content:** Serve dynamic content and microservices using Cloud Functions or Cloud Run.
+- **Dynamic Content:** Serve dynamic content and microservices using Cloud
+  Functions or Cloud Run.
 
 ## Hosting vs App Hosting
 
 **Choose Firebase Hosting if:**
+
 - You are deploying a static site (HTML/CSS/JS).
 - You are deploying a simple SPA (React, Vue, etc. without SSR).
 - You want full control over the build and deploy process via CLI.
 
 **Choose Firebase App Hosting if:**
+
 - You are using a supported full-stack framework like Next.js or Angular.
 - You need Server-Side Rendering (SSR) or ISR.
 - You want an automated "git push to deploy" workflow with zero configuration.
@@ -33,14 +43,22 @@ Firebase Hosting provides production-grade web content hosting for developers. W
 ## Instructions
 
 ### 1. Configuration (`firebase.json`)
-For details on configuring Hosting behavior, including public directories, redirects, rewrites, and headers, see [configuration.md](references/configuration.md).
+
+For details on configuring Hosting behavior, including public directories,
+redirects, rewrites, and headers, see
+[configuration.md](references/configuration.md).
 
 ### 2. Deploying
-For instructions on deploying your site, using preview channels, and managing releases, see [deploying.md](references/deploying.md).
+
+For instructions on deploying your site, using preview channels, and managing
+releases, see [deploying.md](references/deploying.md).
 
 ### 3. Emulation
+
 To test your app locally:
+
 ```bash
 npx -y firebase-tools@latest emulators:start --only hosting
 ```
+
 This serves your app at `http://localhost:5000` by default.

--- a/skills/firebase-hosting-basics/references/configuration.md
+++ b/skills/firebase-hosting-basics/references/configuration.md
@@ -1,11 +1,14 @@
 # Hosting Configuration (`firebase.json`)
 
-The `hosting` section of `firebase.json` configures how your site is deployed and served.
+The `hosting` section of `firebase.json` configures how your site is deployed
+and served.
 
 ## Key Attributes
 
 ### `public` (Required)
+
 Specifies the directory to deploy to Firebase Hosting.
+
 ```json
 "hosting": {
   "public": "public"
@@ -13,11 +16,14 @@ Specifies the directory to deploy to Firebase Hosting.
 ```
 
 ### `ignore` (Optional)
-Files to ignore on deploy. Uses glob patterns (like `.gitignore`).
-**Default ignores:** `firebase.json`, `**/.*`, `**/node_modules/**`
+
+Files to ignore on deploy. Uses glob patterns (like `.gitignore`). **Default
+ignores:** `firebase.json`, `**/.*`, `**/node_modules/**`
 
 ### `redirects` (Optional)
+
 URL redirects to prevent broken links or shorten URLs.
+
 ```json
 "redirects": [
   {
@@ -29,7 +35,9 @@ URL redirects to prevent broken links or shorten URLs.
 ```
 
 ### `rewrites` (Optional)
+
 Serve the same content for multiple URLs, useful for SPAs or Dynamic Content.
+
 ```json
 "rewrites": [
   {
@@ -51,7 +59,9 @@ Serve the same content for multiple URLs, useful for SPAs or Dynamic Content.
 ```
 
 ### `headers` (Optional)
+
 Custom response headers.
+
 ```json
 "headers": [
   {
@@ -67,13 +77,17 @@ Custom response headers.
 ```
 
 ### `cleanUrls` (Optional)
+
 If `true`, drops `.html` extension from URLs.
+
 ```json
 "cleanUrls": true
 ```
 
 ### `trailingSlash` (Optional)
+
 Controls trailing slashes in static content URLs.
+
 - `true`: Adds trailing slash.
 - `false`: Removes trailing slash.
 

--- a/skills/firebase-hosting-basics/references/deploying.md
+++ b/skills/firebase-hosting-basics/references/deploying.md
@@ -1,39 +1,48 @@
 # Deploying to Firebase Hosting
 
 ## Standard Deployment
+
 To deploy your Hosting content and configuration to your live site:
 
 ```bash
 npx -y firebase-tools@latest deploy --only hosting
 ```
 
-This deploys to your default sites (`PROJECT_ID.web.app` and `PROJECT_ID.firebaseapp.com`).
+This deploys to your default sites (`PROJECT_ID.web.app` and
+`PROJECT_ID.firebaseapp.com`).
 
 ## Preview Channels
+
 Preview channels allow you to test changes on a temporary URL before going live.
 
 ### Deploy to a Preview Channel
+
 ```bash
 npx -y firebase-tools@latest hosting:channel:deploy CHANNEL_ID
 ```
-Replace `CHANNEL_ID` with a name (e.g., `feature-beta`).
-This returns a preview URL like `PROJECT_ID--CHANNEL_ID-RANDOM_HASH.web.app`.
+
+Replace `CHANNEL_ID` with a name (e.g., `feature-beta`). This returns a preview
+URL like `PROJECT_ID--CHANNEL_ID-RANDOM_HASH.web.app`.
 
 ### Expiration
+
 Channels expire after 7 days by default. To set a different expiration:
+
 ```bash
 npx -y firebase-tools@latest hosting:channel:deploy CHANNEL_ID --expires 1d
 ```
 
 ## Cloning to Live
-You can promote a version from a preview channel to your live channel without rebuilding.
+
+You can promote a version from a preview channel to your live channel without
+rebuilding.
 
 ```bash
 npx -y firebase-tools@latest hosting:clone SOURCE_SITE_ID:SOURCE_CHANNEL_ID TARGET_SITE_ID:live
 ```
 
-**Example:**
-Clone the `feature-beta` channel on your default site to live:
+**Example:** Clone the `feature-beta` channel on your default site to live:
+
 ```bash
 npx -y firebase-tools@latest hosting:clone my-project:feature-beta my-project:live
 ```

--- a/skills/firebase-remote-config-basics/SKILL.md
+++ b/skills/firebase-remote-config-basics/SKILL.md
@@ -6,72 +6,119 @@ compatibility: This skill is best used with the Firebase CLI, but does not requi
 
 # Remote Config
 
-This skill provides a complete guide for getting started with Remote Config on Android or iOS. Remote Config allows you to change the behavior and appearance of your app without publishing an app update by maintaining a cloud-based configuration template.
+This skill provides a complete guide for getting started with Remote Config on
+Android or iOS. Remote Config allows you to change the behavior and appearance
+of your app without publishing an app update by maintaining a cloud-based
+configuration template.
 
 ## Prerequisites
 
-Provisioning Remote Config requires both a Firebase project and a Firebase app, either Android or iOS. To manage the Remote Config template and conditions via the command line, use the Firebase CLI. See the `firebase-basics` skill for references on project initialization.
+Provisioning Remote Config requires both a Firebase project and a Firebase app,
+either Android or iOS. To manage the Remote Config template and conditions via
+the command line, use the Firebase CLI. See the `firebase-basics` skill for
+references on project initialization.
 
 ## Troubleshooting Execution
 
 ### Handling npx 403 Forbidden Errors
+
 If `npx -y firebase-tools@latest` fails due to registry permissions (403 error):
-1. **Inform the user**: "I am unable to fetch the latest Firebase tools via npx due to a registry error."
-2. **Fallback**: Attempt to use the local `firebase` command directly if the user confirms it is installed globally (`npm install -g firebase-tools`).
+
+1. **Inform the user**: "I am unable to fetch the latest Firebase tools via npx
+   due to a registry error."
+1. **Fallback**: Attempt to use the local `firebase` command directly if the
+   user confirms it is installed globally (`npm install -g firebase-tools`).
 
 ### Handling Project Context Issues
-If a command fails because "no active project is selected":
-1. **Check login**: Run `npx -y firebase-tools@latest login:list`.
-2. **Prompt for ID**: If logged in but no project is active, ask the user: "Please provide your Firebase Project ID to proceed."
-3. **Use Flag**: Append `--project <PROJECT_ID>` to every subsequent command.
 
+If a command fails because "no active project is selected":
+
+1. **Check login**: Run `npx -y firebase-tools@latest login:list`.
+1. **Prompt for ID**: If logged in but no project is active, ask the user:
+   "Please provide your Firebase Project ID to proceed."
+1. **Use Flag**: Append `--project <PROJECT_ID>` to every subsequent command.
 
 ## SDK Setup
 
-To learn how to set up Remote Config in your application code, choose your platform:
+To learn how to set up Remote Config in your application code, choose your
+platform:
 
-*   **Android**: [android_setup.md](references/android_setup.md)
-*   **iOS**: [ios_setup.md](references/ios_setup.md)
+- **Android**: [android_setup.md](references/android_setup.md)
+- **iOS**: [ios_setup.md](references/ios_setup.md)
 
 ## Best Practices and Template Management
 
-Follow these guidelines and use the associated CLI tools to ensure efficient and safe use of Remote Config.
+Follow these guidelines and use the associated CLI tools to ensure efficient and
+safe use of Remote Config.
 
 ### Fetching Strategies
-To optimize app performance and user experience, follow these recommended patterns (see [Loading Strategies](https://firebase.google.com/docs/remote-config/loading)):
-* **Load new values for next startup**: The most effective pattern is to activate previously fetched values immediately on startup and fetch new values in the background to be used next time. This minimizes user wait time.
-* **Real-time Updates**: Use the SDK's real-time listener to update the app instantly without a refresh when server-side configuration changes.
+
+To optimize app performance and user experience, follow these recommended
+patterns (see
+[Loading Strategies](https://firebase.google.com/docs/remote-config/loading)):
+
+- **Load new values for next startup**: The most effective pattern is to
+  activate previously fetched values immediately on startup and fetch new values
+  in the background to be used next time. This minimizes user wait time.
+- **Real-time Updates**: Use the SDK's real-time listener to update the app
+  instantly without a refresh when server-side configuration changes.
 
 ### Template Management via CLI
-Use the following commands to manage your Remote Config template and version history through the terminal:
+
+Use the following commands to manage your Remote Config template and version
+history through the terminal:
 
 ### Template Management via CLI
-Use the following commands to manage your Remote Config template and version history through the terminal:
 
-* **Get current template**: Save the remote template to a local JSON file for auditing or modification.
+Use the following commands to manage your Remote Config template and version
+history through the terminal:
+
+- **Get current template**: Save the remote template to a local JSON file for
+  auditing or modification.
+
   ```bash
   npx -y firebase-tools@latest remoteconfig:get -o remote_config.json
   ```
-* **Autonomous Editing & Discovery** : Modify the local `remote_config.json` directly. Determine the correct signal (e.g., device.country or percent) and update the "conditions" array and "parameters" map accordingly.
 
-* **MANDATORY: User Review and Verification** : STOP and ask the user to verify your changes before proceeding to deployment.
-    * Action: Inform the user: "I have prepared the changes in remote_config.json. Please review the file for accuracy. Once you are satisfied, tell me to 'deploy' to make the changes live."
-* **Deployment Orchestration** : To push changes, you must ensure the environment is configured for deployment.
-   * Config Mapping: If a firebase.json file is missing, create one to map the local JSON to the Remote Config service:
-    ```json
-      { "remoteconfig": { "template": "remote_config.json" } }
-    ```
-  * Deploy: Execute the partial deployment command
+- **Autonomous Editing & Discovery** : Modify the local `remote_config.json`
+  directly. Determine the correct signal (e.g., device.country or percent) and
+  update the "conditions" array and "parameters" map accordingly.
+
+- **MANDATORY: User Review and Verification** : STOP and ask the user to verify
+  your changes before proceeding to deployment.
+
+  - Action: Inform the user: "I have prepared the changes in remote_config.json.
+    Please review the file for accuracy. Once you are satisfied, tell me to
+    'deploy' to make the changes live."
+
+- **Deployment Orchestration** : To push changes, you must ensure the
+  environment is configured for deployment.
+
+  - Config Mapping: If a firebase.json file is missing, create one to map the
+    local JSON to the Remote Config service:
+
+  ```json
+    { "remoteconfig": { "template": "remote_config.json" } }
+  ```
+
+  - Deploy: Execute the partial deployment command
     ```bash
     npx -y firebase-tools@latest deploy --only remoteconfig
     ```
-* **Verification**: After deployment, verify the update by listing the version history.
-    ```bash
-    npx -y firebase-tools@latest remoteconfig:versions:list
-    ```
 
-The SDK provides a number of features to make your application dynamic and responsive to user segments.
+- **Verification**: After deployment, verify the update by listing the version
+  history.
 
-* **Set In-App Defaults**: Define baseline values to ensure the app functions offline or before the first fetch.
-* **Fetch and Activate**: Retrieve values from the Firebase backend and apply them to the local UI/Logic.
-* **Template Management**: Use the Firebase CLI to version-control, get, and deploy your config JSON files.
+  ```bash
+  npx -y firebase-tools@latest remoteconfig:versions:list
+  ```
+
+The SDK provides a number of features to make your application dynamic and
+responsive to user segments.
+
+- **Set In-App Defaults**: Define baseline values to ensure the app functions
+  offline or before the first fetch.
+- **Fetch and Activate**: Retrieve values from the Firebase backend and apply
+  them to the local UI/Logic.
+- **Template Management**: Use the Firebase CLI to version-control, get, and
+  deploy your config JSON files.

--- a/skills/firebase-remote-config-basics/references/android_setup.md
+++ b/skills/firebase-remote-config-basics/references/android_setup.md
@@ -2,21 +2,30 @@
 
 Important references:
 
-- Refer to the `firebase-basics` skills, particularly those for project and app setup, before proceeding.
+- Refer to the `firebase-basics` skills, particularly those for project and app
+  setup, before proceeding.
 
 ## Project and App Setup
 
-Before you begin, ensure you have the following. If a `google-services.json` file is present, then use that Firebase project and app. Otherwise you may need to create them.
+Before you begin, ensure you have the following. If a `google-services.json`
+file is present, then use that Firebase project and app. Otherwise you may need
+to create them.
 
 - **Firebase CLI**: Installed and logged in (see `firebase-basics`).
-- **Firebase Project**: Created via `npx -y firebase-tools@latest projects:create` (see `firebase-basics`).
-- **Firebase App**: Created via `npx -y firebase-tools@latest apps:create <IOS|ANDROID|WEB> <package-name-or-bundle-id>`
+- **Firebase Project**: Created via
+  `npx -y firebase-tools@latest projects:create` (see `firebase-basics`).
+- **Firebase App**: Created via
+  `npx -y firebase-tools@latest apps:create <IOS|ANDROID|WEB> <package-name-or-bundle-id>`
 
-The `google-services.json` file must be present in the Android app's module directory. If missing, get the config using the Firebase CLI: `npx -y firebase-tools@latest apps:sdkconfig ANDROID <App-ID>`.
+The `google-services.json` file must be present in the Android app's module
+directory. If missing, get the config using the Firebase CLI:
+`npx -y firebase-tools@latest apps:sdkconfig ANDROID <App-ID>`.
 
 ## Add Dependencies to Gradle Build
 
-These changes are made to your Android project's Gradle files. Google Analytics is highly recommended as it enables conditional targeting based on user properties and audiences.
+These changes are made to your Android project's Gradle files. Google Analytics
+is highly recommended as it enables conditional targeting based on user
+properties and audiences.
 
 ### Project-level `build.gradle.kts` (`<project>/build.gradle.kts`)
 
@@ -31,71 +40,52 @@ plugins {
 
 ### App-level `build.gradle.kts` (`<project>/<app-module>/build.gradle.kts`)
 
-1.  Add the Google Services plugin to the `plugins` block:
+1. Add the Google Services plugin to the `plugins` block:
 
-    ```kotlin
-    plugins {
-        // ... other plugins
-        id("com.google.gms.google-services")
-    }
-    ```
+   ```kotlin
+   plugins {
+       // ... other plugins
+       id("com.google.gms.google-services")
+   }
+   ```
 
-2.  Add the Firebase Remote Config and Analytics dependencies. Using the Firebase Bill of Materials (BoM) is the best practice for version management.
+1. Add the Firebase Remote Config and Analytics dependencies. Using the Firebase
+   Bill of Materials (BoM) is the best practice for version management.
 
-    ```kotlin
-    dependencies {
-        // ... other dependencies
+   ```kotlin
+   dependencies {
+       // ... other dependencies
 
-        // Import the Firebase BoM
-        implementation(platform("com.google.firebase:firebase-bom:32.7.0"))
+       // Import the Firebase BoM
+       implementation(platform("com.google.firebase:firebase-bom:32.7.0"))
 
-        // Add the dependencies for Remote Config and Analytics
-        implementation("com.google.firebase:firebase-config-ktx")
-        implementation("com.google.firebase:firebase-analytics-ktx")
-    }
-    ```
-
+       // Add the dependencies for Remote Config and Analytics
+       implementation("com.google.firebase:firebase-config-ktx")
+       implementation("com.google.firebase:firebase-analytics-ktx")
+   }
+   ```
 
 ## Follow up Steps
 
-The following steps cover the essential patterns for using Remote Config effectively.
+The following steps cover the essential patterns for using Remote Config
+effectively.
 
 ### Set In-App Defaults
-Define default values so your app has functional logic before it ever fetches a template from the server. Create an XML file (e.g., `res/xml/remote_config_defaults.xml`):
-    ```xml
-    <!-- Example Remote Config Defaults File -->
-    <?xml version="1.0" encoding="utf-8"?>
-    <defaultsMap>
-        <entry>
-            <key>welcome_message</key>
-            <value>Welcome to the app!</value>
-        </entry>
-        <entry>
-            <key>is_feature_enabled</key>
-            <value>false</value>
-        </entry>
-    </defaultsMap>
-    ```
+
+Define default values so your app has functional logic before it ever fetches a
+template from the server. Create an XML file (e.g.,
+`res/xml/remote_config_defaults.xml`):
+`xml     <!-- Example Remote Config Defaults File -->     <?xml version="1.0" encoding="utf-8"?>     <defaultsMap>         <entry>             <key>welcome_message</key>             <value>Welcome to the app!</value>         </entry>         <entry>             <key>is_feature_enabled</key>             <value>false</value>         </entry>     </defaultsMap>     `
 Then, initialize the SDK in your Activity or Application class:
 
-    ```kotlin
-    val remoteConfig = Firebase.remoteConfig
-    remoteConfig.setDefaultsAsync(R.xml.remote_config_defaults)
-    ```
-
+````
+```kotlin
+val remoteConfig = Firebase.remoteConfig
+remoteConfig.setDefaultsAsync(R.xml.remote_config_defaults)
+```
+````
 
 ### Fetch and Activate Values
+
 To apply values from the cloud, you must fetch them and then activate them.
-    ```kotlin
-    remoteConfig.fetchAndActivate()
-    .addOnCompleteListener(this) { task ->
-        if (task.isSuccessful) {
-            val updated = task.result
-            println("Config params updated: $updated")
-        } else {
-            println("Fetch failed")
-        }
-        // Access a value
-        val message = remoteConfig.getString("welcome_message")
-    }
-    ```
+`kotlin     remoteConfig.fetchAndActivate()     .addOnCompleteListener(this) { task ->         if (task.isSuccessful) {             val updated = task.result             println("Config params updated: $updated")         } else {             println("Fetch failed")         }         // Access a value         val message = remoteConfig.getString("welcome_message")     }     `

--- a/skills/firebase-remote-config-basics/references/ios_setup.md
+++ b/skills/firebase-remote-config-basics/references/ios_setup.md
@@ -2,70 +2,88 @@
 
 Important references:
 
-- Refer to the `firebase-basics` skills, particularly those for iOS setup, before proceeding.
+- Refer to the `firebase-basics` skills, particularly those for iOS setup,
+  before proceeding.
 - Refer to the `xcode-project-setup` skills.
 
 ## Project and App Setup
 
 Use the `firebase-tools` CLI to set up the project if necessary.
 
-1.  **Find Bundle ID:** Read the Xcode project to find the iOS bundle ID. Check the `PRODUCT_BUNDLE_IDENTIFIER` value in the `.pbxproj` file or the `Info.plist` file.
-2.  **Create Firebase Project:** If no project exists, create one:
-    `npx -y firebase-tools@latest projects:create <project-id> --display-name="My Awesome App"`
-3.  **Create Firebase App:** Register the iOS app with the discovered bundle ID:
-    `npx -y firebase-tools@latest apps:create IOS <bundle-id>`
-4.  **Link the GoogleService-Info.plist file:** Use the script in the `xcode-project-setup` skill to obtain the config and link.
+1. **Find Bundle ID:** Read the Xcode project to find the iOS bundle ID. Check
+   the `PRODUCT_BUNDLE_IDENTIFIER` value in the `.pbxproj` file or the
+   `Info.plist` file.
+1. **Create Firebase Project:** If no project exists, create one:
+   `npx -y firebase-tools@latest projects:create <project-id> --display-name="My Awesome App"`
+1. **Create Firebase App:** Register the iOS app with the discovered bundle ID:
+   `npx -y firebase-tools@latest apps:create IOS <bundle-id>`
+1. **Link the GoogleService-Info.plist file:** Use the script in the
+   `xcode-project-setup` skill to obtain the config and link.
 
 ## Add Swift Package Dependencies
 
 Install the Remote Config and Analytics SDKs using the Swift package manager.
 
-Install the `FirebaseRemoteConfig` and `FirebaseAnalytics` packages from the [https://github.com/firebase/firebase-ios-sdk.git](https://github.com/firebase/firebase-ios-sdk.git) repository.
+Install the `FirebaseRemoteConfig` and `FirebaseAnalytics` packages from the
+[https://github.com/firebase/firebase-ios-sdk.git](https://github.com/firebase/firebase-ios-sdk.git)
+repository.
 
 ## Initialize Firebase in App Code
 
-Modify the application's entry point to initialize Firebase. Refer to the iOS setup reference in the firebase-basics skill.
+Modify the application's entry point to initialize Firebase. Refer to the iOS
+setup reference in the firebase-basics skill.
 
 ## Follow up Steps
 
-The following steps cover the essential patterns for using Remote Config effectively in your iOS app.
+The following steps cover the essential patterns for using Remote Config
+effectively in your iOS app.
 
 ### Set In-App Defaults
-Define default values so your app behaves as intended before it connects to the backend. Create a property list file (e.g., RemoteConfigDefaults.plist):
 
-    ```xml
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-    <dict>
-        <key>welcome_message</key>
-        <string>Welcome to the app!</string>
-        <key>is_feature_enabled</key>
-        <false/>
-    </dict>
-    </plist>
-    ```
+Define default values so your app behaves as intended before it connects to the
+backend. Create a property list file (e.g., RemoteConfigDefaults.plist):
+
+````
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>welcome_message</key>
+    <string>Welcome to the app!</string>
+    <key>is_feature_enabled</key>
+    <false/>
+</dict>
+</plist>
+```
+````
 
 Then, initialize the SDK and set the defaults:
 
-    ```swift
-    import FirebaseRemoteConfig
+````
+```swift
+import FirebaseRemoteConfig
 
-    let remoteConfig = RemoteConfig.remoteConfig()
-    remoteConfig.setDefaults(fromPlist: "RemoteConfigDefaults")
-    ```
+let remoteConfig = RemoteConfig.remoteConfig()
+remoteConfig.setDefaults(fromPlist: "RemoteConfigDefaults")
+```
+````
+
 ### Fetch and Activate Values
+
 To retrieve values from the cloud and apply them to your app:
 
-    ```swift
-    remoteConfig.fetchAndActivate { (status, error) in
-        if status == .successFetchedFromRemote || status == .successUsingPreFetchedData {
-            print("Config fetched and activated!")
-        } else {
-            print("Config not fetched")
-        }
-        
-        // Access a value
-        let message = remoteConfig.configValue(forKey: "welcome_message").stringValue
+````
+```swift
+remoteConfig.fetchAndActivate { (status, error) in
+    if status == .successFetchedFromRemote || status == .successUsingPreFetchedData {
+        print("Config fetched and activated!")
+    } else {
+        print("Config not fetched")
     }
-    ```
+    
+    // Access a value
+    let message = remoteConfig.configValue(forKey: "welcome_message").stringValue
+}
+```
+````

--- a/skills/firebase-security-rules-auditor/SKILL.md
+++ b/skills/firebase-security-rules-auditor/SKILL.md
@@ -4,42 +4,67 @@ description: A skill to evaluate how secure Firestore security rules are. Use th
 ---
 
 # Overview
-This skill acts as an auditor for Firebase Security Rules, evaluating them against a rigorous set of criteria to ensure they are secure, robust, and correctly implemented.
+
+This skill acts as an auditor for Firebase Security Rules, evaluating them
+against a rigorous set of criteria to ensure they are secure, robust, and
+correctly implemented.
 
 # Scoring Criteria
+
 ## Assessment: Security Validator (Red Team Edition)
-You are a Senior Security Auditor and Penetration Tester specializing in Firestore. Your goal is to find "the hole in the wall." Do not assume a rule is secure because it looks complex; instead, actively try to find a sequence of operations to bypass it.
+
+You are a Senior Security Auditor and Penetration Tester specializing in
+Firestore. Your goal is to find "the hole in the wall." Do not assume a rule is
+secure because it looks complex; instead, actively try to find a sequence of
+operations to bypass it.
 
 ### Mandatory Audit Checklist:
-1. **The Update Bypass:** Compare 'create' and 'update' rules. Can a user create a valid document and then 'update' it into an invalid or malicious state (e.g., changing their role, bypassing size limits, or corrupting data types)?
-2. **Authority Source:** Does the security rely on user-provided data (request.resource.data) for sensitive fields like 'role', 'isAdmin', or 'ownerId'? Carefully consider the source for that authority.
-3. **Business Logic vs. Rules:** Does the rule set actually support the app's purpose? (e.g., In a collaboration app, can collaborators actually read the data? If not, the rules are "broken" or will force insecure workarounds).
-4. **Storage Abuse:** Are there string length or array size limits? If not, label it as a "Resource Exhaustion/DoS" risk.
-5. **Type Safety:** Are fields checked with 'is string', 'is int', or 'is timestamp'?
-6. **Field-Level vs. Identity-Level Security:** Be careful with rules that use \`hasOnly()\` or \`diff()\`. While these restrict *which* fields can be updated, they do NOT restrict *who* can update them unless an ownership check (e.g., \`resource.data.uid == request.auth.uid\`) is also present. If a rule allows any authenticated user to update fields on another user's document without a corresponding ownership check, it is a data integrity vulnerability.
+
+1. **The Update Bypass:** Compare 'create' and 'update' rules. Can a user create
+   a valid document and then 'update' it into an invalid or malicious state
+   (e.g., changing their role, bypassing size limits, or corrupting data types)?
+1. **Authority Source:** Does the security rely on user-provided data
+   (request.resource.data) for sensitive fields like 'role', 'isAdmin', or
+   'ownerId'? Carefully consider the source for that authority.
+1. **Business Logic vs. Rules:** Does the rule set actually support the app's
+   purpose? (e.g., In a collaboration app, can collaborators actually read the
+   data? If not, the rules are "broken" or will force insecure workarounds).
+1. **Storage Abuse:** Are there string length or array size limits? If not,
+   label it as a "Resource Exhaustion/DoS" risk.
+1. **Type Safety:** Are fields checked with 'is string', 'is int', or 'is
+   timestamp'?
+1. **Field-Level vs. Identity-Level Security:** Be careful with rules that use
+   \`hasOnly()\` or \`diff()\`. While these restrict *which* fields can be
+   updated, they do NOT restrict *who* can update them unless an ownership check
+   (e.g., \`resource.data.uid == request.auth.uid\`) is also present. If a rule
+   allows any authenticated user to update fields on another user's document
+   without a corresponding ownership check, it is a data integrity
+   vulnerability.
 
 ### Admin Bootstrapping & Privileges:
-The admin bootstrapping process is limited in this app. If the rules use a single hardcoded admin email (e.g., checking request.auth.token.email == 'admin@example.com'), this should NOT count against the score as long as:
+
+The admin bootstrapping process is limited in this app. If the rules use a
+single hardcoded admin email (e.g., checking request.auth.token.email ==
+'admin@example.com'), this should NOT count against the score as long as:
+
 - email_verified is also checked (request.auth.token.email_verified == true).
-- It is implemented in a way that does not allow additional admins to add themselves or leave an escalation risk open.
+- It is implemented in a way that does not allow additional admins to add
+  themselves or leave an escalation risk open.
 
 ### Scoring Criteria (1-5):
-- **1 (Critical):** Unauthorized data access (leaks), privilege escalation, or total validation bypass.
-- **2 (Major):** Broken business logic, self-assigned roles, bypass of controls.
-- **3 (Moderate):** PII exposure (e.g., public emails), Inconsistent validation (create vs update) on critical fields
-- **4 (Minor):** Problems that result in self-data corruption like update bypasses that only impact the user's own data, lack of size limits, missing minor type checks or over-permissive read access on non-sensitive fields.
-- **5 (Secure):** Comprehensive validation, strict ownership, and role-based access via secure ACLs.
 
-Return your assessment in JSON format using the following structure:
-{
-  "score": 1-5,
-  "summary": "overall assessment",
-  "findings": [
-    {
-      "check": "checklist item",
-      "severity": "critical|major|moderate|minor",
-      "issue": "description",
-      "recommendation": "fix"
-    }
-  ]
-}
+- **1 (Critical):** Unauthorized data access (leaks), privilege escalation, or
+  total validation bypass.
+- **2 (Major):** Broken business logic, self-assigned roles, bypass of controls.
+- **3 (Moderate):** PII exposure (e.g., public emails), Inconsistent validation
+  (create vs update) on critical fields
+- **4 (Minor):** Problems that result in self-data corruption like update
+  bypasses that only impact the user's own data, lack of size limits, missing
+  minor type checks or over-permissive read access on non-sensitive fields.
+- **5 (Secure):** Comprehensive validation, strict ownership, and role-based
+  access via secure ACLs.
+
+Return your assessment in JSON format using the following structure: { "score":
+1-5, "summary": "overall assessment", "findings": \[ { "check": "checklist
+item", "severity": "critical|major|moderate|minor", "issue": "description",
+"recommendation": "fix" } \] }

--- a/skills/xcode-project-setup/SKILL.md
+++ b/skills/xcode-project-setup/SKILL.md
@@ -8,68 +8,117 @@ compatibility: Requires Swift to be installed locally and macOS environment.
 
 ## ⛔️ CRITICAL RULES & ENVIRONMENT CHECKS
 
-Before performing any Xcode setup or file manipulation, you **MUST** adhere to the following rules. A hefty fee will be applied if you violate them.
+Before performing any Xcode setup or file manipulation, you **MUST** adhere to
+the following rules. A hefty fee will be applied if you violate them.
 
 ### 1. The Anti-Ruby Mandate
-You are **strictly forbidden** from using Ruby, Rails, or any Ruby gems (including the `xcodeproj` gem). Under no circumstances may you write or execute Ruby scripts.
+
+You are **strictly forbidden** from using Ruby, Rails, or any Ruby gems
+(including the `xcodeproj` gem). Under no circumstances may you write or execute
+Ruby scripts.
 
 ### 2. Modern Xcode Folder Synchronization
-Modern Xcode projects support folder synchronization. When adding new source code (`.swift`) or resource files, simply write them to the correct directory on disk. They will be automatically included in the Xcode project. **Never manually modify the `.pbxproj` file to add files.**
+
+Modern Xcode projects support folder synchronization. When adding new source
+code (`.swift`) or resource files, simply write them to the correct directory on
+disk. They will be automatically included in the Xcode project. **Never manually
+modify the `.pbxproj` file to add files.**
 
 ### 3. Allowed Scripting Languages
-If you absolutely must write a script to manipulate the project environment (e.g., configuring SPM packages beyond what the provided `xcode_spm_setup` script does), you **must use Swift**. Only as an absolute last resort, if Swift is completely unviable, may you use Node.js or TypeScript.
+
+If you absolutely must write a script to manipulate the project environment
+(e.g., configuring SPM packages beyond what the provided `xcode_spm_setup`
+script does), you **must use Swift**. Only as an absolute last resort, if Swift
+is completely unviable, may you use Node.js or TypeScript.
 
 ### 4. Toolchain Verification
-Because this skill relies entirely on a native Swift script, you must verify the environment:
+
+Because this skill relies entirely on a native Swift script, you must verify the
+environment:
+
 - Run `swift --version` before proceeding.
-- If the Swift command is not found, you must stop and recommend the user install the Swift toolchain (e.g., via `xcode-select --install` on macOS), or ask if you can attempt to install it for them. Do not attempt to proceed without Swift.
+- If the Swift command is not found, you must stop and recommend the user
+  install the Swift toolchain (e.g., via `xcode-select --install` on macOS), or
+  ask if you can attempt to install it for them. Do not attempt to proceed
+  without Swift.
 
 ### 5. Mandatory Linker Flags for Static Frameworks (Firebase)
-When setting up SPM dependencies that heavily rely on internal Objective-C categories and `+load` methods (such as the Firebase iOS SDK suite), the Apple linker will aggressively strip these methods out if they are linked statically.
 
-This causes fatal runtime crashes (e.g., `FirebaseAuth/Auth.swift:167: Fatal error: Unexpectedly found nil`).
+When setting up SPM dependencies that heavily rely on internal Objective-C
+categories and `+load` methods (such as the Firebase iOS SDK suite), the Apple
+linker will aggressively strip these methods out if they are linked statically.
 
-**The provided `xcode_spm_setup` Swift script automatically injects the `-ObjC` flag to `OTHER_LDFLAGS` when adding Firebase products.** However, you should still verify it is present in the build settings if you encounter issues.
-- Failing to include this flag when adding Firebase dependencies is a critical error.
----
+This causes fatal runtime crashes (e.g.,
+`FirebaseAuth/Auth.swift:167: Fatal error: Unexpectedly found nil`).
+
+**The provided `xcode_spm_setup` Swift script automatically injects the `-ObjC`
+flag to `OTHER_LDFLAGS` when adding Firebase products.** However, you should
+still verify it is present in the build settings if you encounter issues.
+
+- Failing to include this flag when adding Firebase dependencies is a critical
+  error.
+
+______________________________________________________________________
 
 ## Empty Directory Workflow
 
-If you are asked to build an iOS app or configure Xcode dependencies but **no `.xcodeproj` or `.xcworkspace` exists**, you MUST ask the user to create the project first:
+If you are asked to build an iOS app or configure Xcode dependencies but **no
+`.xcodeproj` or `.xcworkspace` exists**, you MUST ask the user to create the
+project first:
 
-**"No Xcode project found in this directory. Please create an empty Xcode project manually and let me know when you are ready to proceed."**
+**"No Xcode project found in this directory. Please create an empty Xcode
+project manually and let me know when you are ready to proceed."**
 
-Wait for the user to confirm they have created the `.xcodeproj` via Xcode, then proceed with the Standard Xcode Workflow below.
+Wait for the user to confirm they have created the `.xcodeproj` via Xcode, then
+proceed with the Standard Xcode Workflow below.
 
----
+______________________________________________________________________
 
 ## Standard Xcode Workflow
 
-Do not use raw text parsing, `sed`, or Ruby scripts to modify `.pbxproj` files directly.
+Do not use raw text parsing, `sed`, or Ruby scripts to modify `.pbxproj` files
+directly.
 
-Instead, execute the Swift configuration package bundled with this skill (`scripts/xcode_spm_setup`) to securely install SPM packages and link optional config files (like `GoogleService-Info.plist`).
+Instead, execute the Swift configuration package bundled with this skill
+(`scripts/xcode_spm_setup`) to securely install SPM packages and link optional
+config files (like `GoogleService-Info.plist`).
 
 ### **CRITICAL: Always Use Latest SDK Version**
-To ensure access to the latest features and security fixes, always use the most recent version of the Firebase iOS SDK. Check for the latest release version at [https://github.com/firebase/firebase-ios-sdk/releases](https://github.com/firebase/firebase-ios-sdk/releases). 
-- Use the most recent version number (e.g., `11.x.y`) in your commands instead of hardcoded placeholders.
+
+To ensure access to the latest features and security fixes, always use the most
+recent version of the Firebase iOS SDK. Check for the latest release version at
+[https://github.com/firebase/firebase-ios-sdk/releases](https://github.com/firebase/firebase-ios-sdk/releases).
+
+- Use the most recent version number (e.g., `11.x.y`) in your commands instead
+  of hardcoded placeholders.
 
 ### Understanding the Script's Actions
-When adding a Swift Package to an Xcode project, two distinct steps must occur:
-1. Adding the package repository dependency (e.g., `https://github.com/Alamofire/Alamofire`).
-2. Selecting the target (e.g., `MyApp`), navigating to **General > Frameworks, Libraries, and Embedded Content**, and hitting the `+` button to explicitly link the specific product modules (e.g., `Alamofire`).
 
-**The provided `xcode_spm_setup` Swift script automatically handles BOTH of these steps for you.** By passing the list of modules as arguments, it safely injects the package dependency and automatically wires those modules to the main target's Frameworks build phase. You do not need to do any manual linking.
+When adding a Swift Package to an Xcode project, two distinct steps must occur:
+
+1. Adding the package repository dependency (e.g.,
+   `https://github.com/Alamofire/Alamofire`).
+1. Selecting the target (e.g., `MyApp`), navigating to **General > Frameworks,
+   Libraries, and Embedded Content**, and hitting the `+` button to explicitly
+   link the specific product modules (e.g., `Alamofire`).
+
+**The provided `xcode_spm_setup` Swift script automatically handles BOTH of
+these steps for you.** By passing the list of modules as arguments, it safely
+injects the package dependency and automatically wires those modules to the main
+target's Frameworks build phase. You do not need to do any manual linking.
 
 ## Usage
 
-1. **Locate the package path:** Find the absolute path to this skill's `scripts/xcode_spm_setup` directory on disk.
-2. **Execute:** Run the native `swift run` command using the signature below:
+1. **Locate the package path:** Find the absolute path to this skill's
+   `scripts/xcode_spm_setup` directory on disk.
+1. **Execute:** Run the native `swift run` command using the signature below:
 
 ```bash
 swift run --package-path <PATH_TO_SKILL>/scripts/xcode_spm_setup xcode_spm_setup <ProjectPath.xcodeproj> <RepoURL> <VersionRequirement> [--plist <Optional/Path/To/Config.plist>] <Product1> [Product2 ...]
 ```
 
 ### Example 1: Generic Package (e.g., Alamofire)
+
 Adding Alamofire to a standard Xcode project. Notice there is no `--plist` flag.
 
 ```bash
@@ -77,11 +126,15 @@ swift run --package-path /Users/foo/.agents/skills/xcode-project-setup/scripts/x
 ```
 
 ### Example 2: Firebase (Requires Plist)
-Adding Firebase and linking the `GoogleService-Info.plist` to the resources build phase automatically. 
-*Note: Replace `11.0.0` with the actual latest version from [the releases page](https://github.com/firebase/firebase-ios-sdk/releases).*
+
+Adding Firebase and linking the `GoogleService-Info.plist` to the resources
+build phase automatically. *Note: Replace `11.0.0` with the actual latest
+version from
+[the releases page](https://github.com/firebase/firebase-ios-sdk/releases).*
 
 ```bash
 swift run --package-path /Users/foo/.agents/skills/xcode-project-setup/scripts/xcode_spm_setup xcode_spm_setup MyApp.xcodeproj https://github.com/firebase/firebase-ios-sdk 11.0.0 --plist MyApp/GoogleService-Info.plist FirebaseCore FirebaseAuth FirebaseFirestore
 ```
 
-*Note: The script is idempotent. It will automatically skip linking files or packages that are already present in the project.*
+*Note: The script is idempotent. It will automatically skip linking files or
+packages that are already present in the project.*


### PR DESCRIPTION
This PR introduces a Markdown formatter (`mdformat`) configured to match Google's internal C++ implementation, using a 80-character wrap width, GFM, and YAML frontmatter preservation. It includes a script in `scripts/` to format markdown files locally and a GitHub Action to enforce formatting on pull requests.