### PR TITLE
feat: add extension-to-functions-codebase migration skill

### DIFF
--- a/skills/extension-to-functions-codebase/SKILL.md
+++ b/skills/extension-to-functions-codebase/SKILL.md
@@ -9,63 +9,69 @@ description: Skill for converting an installed Firebase Extension (or extension 
 
 This skill guides the agent in migrating a Firebase Extension repository or
 instance into either:
+
 1. **A standalone Cloud Functions for Firebase (CF3) codebase** (for end-user
-  app integration), or
-2. **A publishable npm package / function kit** (for extension publishers
-  distributing reusable V2 functions).
+   app integration), or
+1. **A publishable npm package / function kit** (for extension publishers
+   distributing reusable V2 functions).
 
 It leverages CF3 GA capabilities to handle permissions, dependencies, and
 lifecycle hooks natively in code, and provides instructions for modernizing
 legacy V1 triggers to V2 using the Destructuring Compatibility Shim.
 
----
+______________________________________________________________________
 
 ## Triggers
 
 Activate this skill when a user asks to:
+
 - Migrate or convert an installed Firebase Extension into a standalone functions
   codebase.
 - Convert an extension repository into a publishable npm package (function kit).
 - Upgrade extension triggers from V1 to V2.
 
----
+______________________________________________________________________
 
 ## Target Migration Workflows
 
 Before starting, determine the target destination with the developer:
 
 - **Target A: Local Functions Codebase** (End-User App Integration)
+
   - Output: Source code placed in the project's `functions/src/` folder.
   - Configuration: Parameters defined via `defineString`, `defineSecret`, etc.
     in `.env`.
   - Deployment: Deployed directly via `firebase deploy --only functions`.
 
 - **Target B: Publishable npm Package / Function Kit** (Publisher Distribution)
+
   - Output: Reusable npm package containing exported V2 functions.
-  - Configuration: `package.json` with `exports` map and `peerDependencies: {
-    "firebase-functions": ">=7.0.0" }`.
+  - Configuration: `package.json` with `exports` map and
+    `peerDependencies: { "firebase-functions": ">=7.0.0" }`.
   - Usage: End users install the package (`npm i @scope/package`) and re-export
     functions in their `index.ts`.
 
----
+______________________________________________________________________
 
 ## Getting Started & Git Safety
 
 1. **Git Status**: Verify the workspace has a clean git status before starting.
-2. **In-Place Copying**: If copying code to a new subdirectory within the same
-  repository:
+1. **In-Place Copying**: If copying code to a new subdirectory within the same
+   repository:
    - Use `git cp` (or copy files and commit) to copy the extension's source
      directory to the target directory.
-   - Commit immediately: `"Copying [extension-name] extension to [directory] in
-     preparation for rewrite"`
+   - Commit immediately:
+     `"Copying [extension-name] extension to [directory] in preparation for rewrite"`
 
----
+______________________________________________________________________
 
 ## Rules and Constraints
 
 ### 1. Zero-Local-Overhead (CF3 Integration)
+
 Assume CF3 Workload Identities, Declarative Security, and SDK Lifecycle Hooks
 are fully GA.
+
 - **Do NOT** output instructions or scripts telling users to run manual `gcloud`
   IAM commands or create service accounts.
 - **Do NOT** write code comments instructing users to manually enable Google
@@ -74,6 +80,7 @@ are fully GA.
   SDK.
 
 ### 2. Global Parameter Access Restriction
+
 - **Never call `.value()` on any parameter at global scope.**
 - If a global variable or class instance is initialized using a parameter value,
   declare the variable globally and initialize it inside the `onInit()`
@@ -91,18 +98,21 @@ are fully GA.
   ```
 
 ### 3. Concurrency & Cost Parity for V2
+
 When upgrading triggers to V2:
+
 - By default, V2 functions enable concurrency (up to 80 requests per instance).
 - If you want to maintain V1 fractional CPU pricing (and disable concurrency),
   set `cpu: "gcf_gen1"` in the function's options object.
 
----
+______________________________________________________________________
 
 ## Step-by-Step Migration Execution
 
 ### Step 1: Inventory the Extension & Setup Package Structure
 
 1. **Inventory `extension.yaml`**:
+
    - `params`: Convert to Functions params (`defineString`, `defineSecret`,
      etc.).
    - `apis`: Convert to `requiresAPI(...)` declarations.
@@ -112,7 +122,8 @@ When upgrading triggers to V2:
    - `resources`: Convert V1 triggers to V2, and task queue functions to
      `onTaskDispatched`.
 
-2. **Package Configuration (`package.json`)**:
+1. **Package Configuration (`package.json`)**:
+
    - **For Target A (Local Codebase)**: Merge dependencies from
      `functions/package.json` into project root `package.json`.
    - **For Target B (npm Package)**:
@@ -138,16 +149,16 @@ When upgrading triggers to V2:
 ### Step 2: Parameterization & Secret Migration
 
 1. Read all parameters declared in `extension.yaml`.
-2. Define matching Functions params in code (e.g. `src/config.ts`):
+1. Define matching Functions params in code (e.g. `src/config.ts`):
    - Type `secret` -> `defineSecret('PARAM_NAME')`
    - Type `string` -> `defineString('PARAM_NAME')`
    - Type `select` / `multiSelect` -> `defineString('PARAM_NAME')` /
      `defineList('PARAM_NAME')`
    - Type `int` -> `defineInt('PARAM_NAME')`
-3. Replace all direct `process.env.PARAM_NAME` calls with `PARAM_NAME.value()`,
-  ensuring the global scope restriction is respected.
-4. **Secret Binding**: For functions using secrets, bind them in the function
-  options:
+1. Replace all direct `process.env.PARAM_NAME` calls with `PARAM_NAME.value()`,
+   ensuring the global scope restriction is respected.
+1. **Secret Binding**: For functions using secrets, bind them in the function
+   options:
    ```typescript
    const apiKey = defineSecret("API_KEY");
    export const fn = onRequest({ secrets: [apiKey] }, handler);
@@ -159,12 +170,12 @@ When upgrading triggers to V2:
 ### Step 3: Upgrading Functions & Triggers (V1 to V2)
 
 1. **Imports**: Replace legacy `* as functions` imports with targeted V2 trigger
-  imports from `firebase-functions/v2/...` (e.g. `onDocumentCreated`,
-  `onMessagePublished`, `onValueWritten`, `onObjectFinalized`).
-2. **Signature Modernization (Destructuring Shim)**:
-   Use the Destructuring Compatibility Shim to preserve internal V1 business
-   logic without rewriting function bodies. Instead of `(data, context)`, accept
-   a single `CloudEvent` and destructure `{ shimmedKey, context }`.
+   imports from `firebase-functions/v2/...` (e.g. `onDocumentCreated`,
+   `onMessagePublished`, `onValueWritten`, `onObjectFinalized`).
+1. **Signature Modernization (Destructuring Shim)**: Use the Destructuring
+   Compatibility Shim to preserve internal V1 business logic without rewriting
+   function bodies. Instead of `(data, context)`, accept a single `CloudEvent`
+   and destructure `{ shimmedKey, context }`.
    - *Pub/Sub Example*:
      ```typescript
      // V1 Legacy
@@ -180,10 +191,10 @@ When upgrading triggers to V2:
      ```
    - Refer to [signature-mapping.md](references/signature-mapping.md) for full
      trigger key mappings.
-3. **HTTP Callables**: Callables do not use the destructuring shim. Rewrite the
-  signature to destructure `({ data, auth })` directly.
-4. **Internal Task Queue Enqueue Calls**:
-   If the code enqueues tasks using `getFunctions().taskQueue(...)`:
+1. **HTTP Callables**: Callables do not use the destructuring shim. Rewrite the
+   signature to destructure `({ data, auth })` directly.
+1. **Internal Task Queue Enqueue Calls**: If the code enqueues tasks using
+   `getFunctions().taskQueue(...)`:
    - Replace `process.env.EXT_INSTANCE_ID` with `process.env.KIT_INSTANCE_ID`
      (or codebase equivalent).
    - Ensure `firebase-admin` dependency version supports task queue enqueueing
@@ -212,9 +223,9 @@ codebase's managed runtime service account.
 If `extension.yaml` declares `lifecycleEvents` (`onInstall`, `onUpdate`,
 `onConfigure`):
 
-1. **Convert Task Queue Handlers**:
-   Upgrade 1st gen task queue functions to V2 `onTaskDispatched` from
-   `firebase-functions/v2/tasks`:
+1. **Convert Task Queue Handlers**: Upgrade 1st gen task queue functions to V2
+   `onTaskDispatched` from `firebase-functions/v2/tasks`:
+
    ```typescript
    import { onTaskDispatched } from "firebase-functions/v2/tasks";
 
@@ -225,11 +236,12 @@ If `extension.yaml` declares `lifecycleEvents` (`onInstall`, `onUpdate`,
      }
    );
    ```
+
    *Note*: Remove calls to `getExtensions().runtime().setProcessingState(...)`
    as lifecycle state is managed by CF3.
 
-2. **Register Lifecycle Hooks**:
-   Inject declarative lifecycle hooks:
+1. **Register Lifecycle Hooks**: Inject declarative lifecycle hooks:
+
    ```typescript
    import { afterFirstDeploy, afterRedeploy } from "firebase-functions/v2";
 
@@ -240,28 +252,26 @@ If `extension.yaml` declares `lifecycleEvents` (`onInstall`, `onUpdate`,
    afterRedeploy({ task: { function: "setupBigQuerySync" } });
    ```
 
-3. **Idempotency & Manual Rerun**:
-   Ensure lifecycle handlers are idempotent. Document that users can manually
-   rerun hooks if needed:
+1. **Idempotency & Manual Rerun**: Ensure lifecycle handlers are idempotent.
+   Document that users can manually rerun hooks if needed:
    `firebase functions:lifecycle:run afterFirstDeploy CODEBASE_NAME`
 
 ### Step 6: Package Exporting & Documentation (Publisher Path)
 
 If creating an npm package (Target B):
 
-1. **Re-export Functions in Package Entry (`src/index.ts`)**:
-   Ensure all deployable V2 functions and task queue handlers are exported:
+1. **Re-export Functions in Package Entry (`src/index.ts`)**: Ensure all
+   deployable V2 functions and task queue handlers are exported:
    ```typescript
    export { syncV2, initBigQuerySync, setupBigQuerySync } from "./functions";
    ```
-2. **End-User Re-export Instructions**:
-   Document in `README.md` that end users deploy package functions by
-   re-exporting them in their `functions/src/index.ts`:
+1. **End-User Re-export Instructions**: Document in `README.md` that end users
+   deploy package functions by re-exporting them in their
+   `functions/src/index.ts`:
    ```typescript
    export { syncV2, initBigQuerySync, setupBigQuerySync } from "@scope/extension-pkg";
    ```
-3. **Package README Checklist**:
-   Include:
+1. **Package README Checklist**: Include:
    - Installation (`npm install @scope/extension-pkg`)
    - Re-export snippet for user's `index.ts`
    - Required `.env` parameter names & types
@@ -272,11 +282,11 @@ If creating an npm package (Target B):
 ### Step 7: Build & Verification
 
 1. Run `npm run build` (or `npx tsc`) to ensure no compilation or type errors.
-2. If unit/integration tests exist, run `npm test`.
-   - Update test mocks for upgraded V2 triggers (single destructured object `{
-     change, context }` instead of two arguments `(data, context)`).
+1. If unit/integration tests exist, run `npm test`.
+   - Update test mocks for upgraded V2 triggers (single destructured object
+     `{ change, context }` instead of two arguments `(data, context)`).
 
----
+______________________________________________________________________
 
 ## References
 

--- a/skills/extension-to-functions-codebase/SKILL.md
+++ b/skills/extension-to-functions-codebase/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: extension-to-functions-codebase
-description: Skill for converting an installed Firebase Extension (or extension source) to a standalone Cloud Functions for Firebase (CF3) codebase or publishable npm package, including upgrading triggers from V1 to V2 and configuring lifecycle hooks and declarative security
+description: Skill for converting an installed Firebase Extension (or extension source) to a standalone Cloud Functions for Firebase codebase or publishable npm package, including upgrading triggers from V1 to V2 and configuring lifecycle hooks and declarative security
 ---
 
 # Extension to Functions Codebase & npm Package Migration
@@ -10,14 +10,15 @@ description: Skill for converting an installed Firebase Extension (or extension 
 This skill guides the agent in migrating a Firebase Extension repository or
 instance into either:
 
-1. **A standalone Cloud Functions for Firebase (CF3) codebase** (for end-user
-   app integration), or
-1. **A publishable npm package / function kit** (for extension publishers
-   distributing reusable V2 functions).
+1. **A standalone Cloud Functions for Firebase codebase** (`firebase-functions`,
+   for end-user app integration), or
+1. **A publishable npm package / shareable open source package** (for extension
+   publishers distributing reusable V2 functions).
 
-It leverages CF3 GA capabilities to handle permissions, dependencies, and
-lifecycle hooks natively in code, and provides instructions for modernizing
-legacy V1 triggers to V2 using the Destructuring Compatibility Shim.
+It leverages native Cloud Functions for Firebase GA capabilities to handle
+permissions, dependencies, and lifecycle hooks natively in code, and provides
+instructions for modernizing legacy V1 triggers to V2 using the Destructuring
+Compatibility Shim.
 
 ______________________________________________________________________
 
@@ -27,7 +28,8 @@ Activate this skill when a user asks to:
 
 - Migrate or convert an installed Firebase Extension into a standalone functions
   codebase.
-- Convert an extension repository into a publishable npm package (function kit).
+- Convert an extension repository into a publishable npm package (shareable open
+  source package).
 - Upgrade extension triggers from V1 to V2.
 
 ______________________________________________________________________
@@ -43,11 +45,11 @@ Before starting, determine the target destination with the developer:
     in `.env`.
   - Deployment: Deployed directly via `firebase deploy --only functions`.
 
-- **Target B: Publishable npm Package / Function Kit** (Publisher Distribution)
+- **Target B: Publishable npm Package / Shareable Open Source Package**
 
   - Output: Reusable npm package containing exported V2 functions.
-  - Configuration: `package.json` with `exports` map and
-    `peerDependencies: { "firebase-functions": "^7.0.0" }`.
+  - Configuration: `package.json` with `exports` map and `firebase-functions`
+    declared in `dependencies` (or `peerDependencies`).
   - Usage: End users install the package (`npm i <package-name>`) and re-export
     functions in their `index.ts`.
 
@@ -67,10 +69,10 @@ ______________________________________________________________________
 
 ## Rules and Constraints
 
-### 1. Zero-Local-Overhead (CF3 Integration)
+### 1. Zero-Local-Overhead (Cloud Functions Integration)
 
-Assume CF3 Workload Identities, Declarative Security, and SDK Lifecycle Hooks
-are fully GA.
+Assume Cloud Functions for Firebase Workload Identities, Declarative Security,
+and SDK Lifecycle Hooks are fully GA.
 
 - **Do NOT** output instructions or scripts telling users to run manual `gcloud`
   IAM commands or create service accounts.
@@ -121,12 +123,13 @@ documents so that nothing is lost during migration:
    - `roles`: Convert to `requiresRole(...)` declarations.
    - `lifecycleEvents` (`onInstall`, `onUpdate`, `onConfigure`): Convert to
      `afterFirstDeploy` and `afterRedeploy` hooks.
-   - `resources`: Convert V1 triggers to V2, and task queue functions to
-     `onTaskDispatched`.
+   - `resources`: Note all function triggers to convert from 1st gen
+     (`firebase-functions/v1`) to 2nd gen (`firebase-functions/v2`), including
+     standard event triggers, HTTP handlers, and task queues
+     (`onTaskDispatched`).
 1. **Inventory Files & Tooling**:
    - `functions/`: Source code, triggers, helpers, and task queue handlers.
-   - Documentation: `README.md`, `PREINSTALL.md`, and `POSTINSTALL.md` (migrate
-     setup warnings and billing notes to package README).
+   - Documentation: `README.md`, `PREINSTALL.md`, and `POSTINSTALL.md`.
    - `scripts/`: Note any backfill, import, or helper scripts shipped with the
      extension.
 
@@ -141,7 +144,9 @@ in a dedicated workspace directory):
   test scripts (`"test": "..."`) from the legacy extension
   (`functions/package.json` or root `package.json`). Do not drop test frameworks
   or type definitions.
-- Move `firebase-functions` from `dependencies` to `peerDependencies`:
+- Declare `firebase-functions` (e.g. `^7.0.0`) in `dependencies` (or
+  `peerDependencies` if creating a lightweight middleware package where the root
+  consumer manages the runtime version):
   ```json
   {
     "name": "<package-name>",
@@ -157,7 +162,8 @@ in a dedicated workspace directory):
     "engines": {
       "node": ">=22"
     },
-    "peerDependencies": {
+    "dependencies": {
+      "firebase-admin": "^12.0.0",
       "firebase-functions": "^7.0.0"
     }
   }
@@ -180,27 +186,36 @@ Move the extension's function source into the package's `src/` folder:
 
 ### Step 4: Upgrade Functions from 1st Gen to 2nd Gen
 
-Convert each exported 1st gen function trigger to its 2nd gen equivalent
-(`firebase-functions/v2/...`):
+Convert each exported 1st gen function trigger (`onWrite`, `onRequest`,
+`tasks.taskQueue().onDispatch`) to its 2nd gen equivalent (`onDocumentWritten`,
+`onRequest`, `onTaskDispatched` from `firebase-functions/v2/...`):
 
 1. **Signatures & Destructuring Shim**: Use the Destructuring Compatibility Shim
    (`{ shimmedKey, context }`) to preserve V1 business logic without rewriting
    function bodies. See [signature-mapping.md](references/signature-mapping.md)
    and [destructuring-shim.md](references/destructuring-shim.md).
 1. **Authentication Triggers Exception**: If your extension uses v1
-   Authentication Triggers (`auth.user().onCreate()`, etc.), keep those specific
-   triggers on **1st gen** for now, as 2nd gen Auth triggers are not yet
-   supported. Call this out clearly in your package README.
+   Authentication Triggers (`auth.user().onCreate()`, `auth.user().onDelete()`),
+   instruct the agent to check live whether a 2nd gen alternative exists in the
+   installed `firebase-functions` package or live documentation. If 2nd gen Auth
+   triggers are not yet supported for those events, warn the user clearly and
+   halt or refuse the migration for those specific triggers until a V2
+   alternative becomes available.
 
 ### Step 5: Replace Extension Params with Functions Params
 
 Each parameter in `extension.yaml` becomes a Parameterized Configuration call:
 
-1. Map parameter types:
-   - Type `string` / `select` -> `defineString("PARAM_NAME", { label: "..." })`
+1. Map parameter primitives and attributes:
+   - Type `string` ->
+     `defineString("PARAM_NAME", { label: "...", description: "...", default: "..." })`
    - Type `secret` -> `defineSecret("PARAM_NAME")`
-   - Type `int` -> `defineInt("PARAM_NAME")`
-   - Type `boolean` -> `defineBoolean("PARAM_NAME")`
+   - Type `int` -> `defineInt("PARAM_NAME", { label: "...", default: 123 })`
+   - Type `boolean` -> `defineBoolean("PARAM_NAME", { default: true })`
+   - Type `select` / `multiSelect` -> map `options` into `input`:
+     `defineString("PARAM_NAME", { input: { select: { options: [{ value: "val", label: "Val" }] } } })`
+   - `validationRegex` -> map into text input options:
+     `defineString("PARAM_NAME", { input: { text: { validationRegex: "^[a-z]+$" } } })`
 1. Read parameter values inside handlers using `paramName.value()`.
 1. **Keep Exact Parameter Names**: Never change parameter names
    (`COLLECTION_PATH`, `DATASET_ID`, etc.) so that existing values carry over
@@ -292,27 +307,20 @@ lifecycle hooks:
 
 ### Step 10: Document Setup for Your Users (`README.md`)
 
-Write a comprehensive package README containing:
+Preserve whatever documentation, secrets, and setup instructions the original
+extension already documented in `README.md` (and `PREINSTALL.md` /
+`POSTINSTALL.md`), updating them as needed:
 
-1. **Installation Step**: `npm install <package-name>`
-1. **Re-export Snippet**: Show the exact snippet users must add to `index.ts`:
-   ```typescript
-   export * from "<package-name>";
-   ```
-1. **`.env` Configuration Table & Sample Block**: List required parameters.
-1. **Secrets & IAM Roles**: List declared secrets and `requiresRole(...)` roles.
-1. **Lifecycle Hooks & Rerun Commands**: Explain setup task and rerun CLI
-   commands.
-1. **What Changed Comparison Table**:
-   | Concern      | As the extension             | As `<package-name>`                    |
-   | :----------- | :--------------------------- | :------------------------------------- |
-   | Install      | Extensions runtime           | `npm install` into Functions codebase  |
-   | Config       | Extension params             | Functions params via `.env`            |
-   | IAM          | Granted by Extensions        | `requiresRole(...)`, applied at deploy |
-   | Provisioning | Lifecycle task by Extensions | `afterFirstDeploy` / `afterRedeploy`   |
-1. **Multiple Instances & Troubleshooting**: Note separate codebases/prefixing
-   for multiple instances, checking re-exports, and rerunning failed lifecycle
-   hooks.
+1. **Update Configuration References**: Replace instructions referencing legacy
+   `extension.yaml` installation prompts or `ext-*.env` files with standard
+   `.env` Parameterized Configuration setup matching the `defineString`
+   parameters.
+1. **Include Re-export Snippet**: Ensure the basic root re-export snippet is
+   shown (`export * from "<package-name>";`) so users know how to expose the
+   functions in their root `index.ts`.
+1. **Avoid Unnecessary Boilerplate**: Do not generate redundant comparison
+   tables or generic installation steps if the setup is self-evident in the code
+   or already covered by existing README sections.
 
 ### Step 11: Build & Test Verification
 

--- a/skills/extension-to-functions-codebase/SKILL.md
+++ b/skills/extension-to-functions-codebase/SKILL.md
@@ -234,6 +234,6 @@ If creating an npm package (Target B):
 
 ## References
 
-- **Destructuring Shim**: See [destructuring-shim.md](references/destructuring-shim.md) for event property translation.
+- **Destructuring Shim**: See [destructuring-shim.md](references/destructuring-shim.md) for details on event property translation.
 - **Trigger Mapping**: See [signature-mapping.md](references/signature-mapping.md) for V1 vs V2 trigger definitions and shim keys.
 - **Configuration & Parameters**: See [configuration-migration.md](references/configuration-migration.md) for `runWith` options, params, and secret bindings.

--- a/skills/extension-to-functions-codebase/SKILL.md
+++ b/skills/extension-to-functions-codebase/SKILL.md
@@ -47,8 +47,8 @@ Before starting, determine the target destination with the developer:
 
   - Output: Reusable npm package containing exported V2 functions.
   - Configuration: `package.json` with `exports` map and
-    `peerDependencies: { "firebase-functions": ">=7.0.0" }`.
-  - Usage: End users install the package (`npm i @scope/package`) and re-export
+    `peerDependencies: { "firebase-functions": "^7.0.0" }`.
+  - Usage: End users install the package (`npm i <package-name>`) and re-export
     functions in their `index.ts`.
 
 ______________________________________________________________________
@@ -109,10 +109,12 @@ ______________________________________________________________________
 
 ## Step-by-Step Migration Execution
 
-### Step 1: Inventory the Extension & Setup Package Structure
+### Step 1: Inventory the Extension
+
+Conduct a complete inventory of everything the extension declares, ships, and
+documents so that nothing is lost during migration:
 
 1. **Inventory `extension.yaml`**:
-
    - `params`: Convert to Functions params (`defineString`, `defineSecret`,
      etc.).
    - `apis`: Convert to `requiresAPI(...)` declarations.
@@ -121,170 +123,191 @@ ______________________________________________________________________
      `afterFirstDeploy` and `afterRedeploy` hooks.
    - `resources`: Convert V1 triggers to V2, and task queue functions to
      `onTaskDispatched`.
+1. **Inventory Files & Tooling**:
+   - `functions/`: Source code, triggers, helpers, and task queue handlers.
+   - Documentation: `README.md`, `PREINSTALL.md`, and `POSTINSTALL.md` (migrate
+     setup warnings and billing notes to package README).
+   - `scripts/`: Note any backfill, import, or helper scripts shipped with the
+     extension.
 
-1. **Package Configuration (`package.json`)**:
+### Step 2: Create / Update `package.json`
 
-   - **For Target A (Local Codebase)**: Merge dependencies from
-     `functions/package.json` into project root `package.json`.
-   - **For Target B (npm Package)**:
-     - Set publishable package name (e.g. `@firebase/firestore-bigquery-export`
-       or `@scope/pkg`).
-     - Move `firebase-functions` from `dependencies` to `peerDependencies`
-       (`"firebase-functions": ">=7.0.0"`).
-     - Add `exports` map and engine requirements:
-       ```json
-       {
-         "name": "@scope/extension-pkg",
-         "version": "1.0.0",
-         "main": "lib/index.js",
-         "types": "lib/index.d.ts",
-         "exports": {
-           ".": { "types": "./lib/index.d.ts", "default": "./lib/index.js" }
-         },
-         "engines": { "node": ">=22" },
-         "peerDependencies": { "firebase-functions": ">=7.0.0" }
-       }
-       ```
+Create an npm package for the migrated extension code (either at project root or
+in a dedicated workspace directory):
 
-### Step 2: Parameterization & Secret Migration
+- Set a publishable package name (`name: "<package-name>"`).
+- Move `firebase-functions` from `dependencies` to `peerDependencies`:
+  ```json
+  {
+    "name": "<package-name>",
+    "version": "1.0.0",
+    "main": "lib/index.js",
+    "types": "lib/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./lib/index.d.ts",
+        "default": "./lib/index.js"
+      }
+    },
+    "engines": {
+      "node": ">=22"
+    },
+    "peerDependencies": {
+      "firebase-functions": "^7.0.0"
+    }
+  }
+  ```
 
-1. Read all parameters declared in `extension.yaml`.
-1. Define matching Functions params in code (e.g. `src/config.ts`):
-   - Type `secret` -> `defineSecret('PARAM_NAME')`
-   - Type `string` -> `defineString('PARAM_NAME')`
-   - Type `select` / `multiSelect` -> `defineString('PARAM_NAME')` /
-     `defineList('PARAM_NAME')`
-   - Type `int` -> `defineInt('PARAM_NAME')`
-1. Replace all direct `process.env.PARAM_NAME` calls with `PARAM_NAME.value()`,
-   ensuring the global scope restriction is respected.
-1. **Secret Binding**: For functions using secrets, bind them in the function
-   options:
+### Step 3: Move Function Code & Expose Deployable Functions
+
+Move the extension's function source into the package's `src/` folder:
+
+1. Keep normal Firebase trigger exports. The package must expose deployable
+   functions that end users can re-export from their entrypoint (`index.ts`).
+1. Document that consumers must deploy packaged functions by re-exporting them:
    ```typescript
+   export * from "<package-name>";
+   // Or named exports:
+   // export { syncV2, initBigQuerySync } from "<package-name>";
+   ```
+   *Note*: A bare import (`import "<package-name>"`) is not enough. The Firebase
+   CLI only deploys functions exported from the user's root entry file.
+
+### Step 4: Upgrade Functions from 1st Gen to 2nd Gen
+
+Convert each exported 1st gen function trigger to its 2nd gen equivalent
+(`firebase-functions/v2/...`):
+
+1. **Signatures & Destructuring Shim**: Use the Destructuring Compatibility Shim
+   (`{ shimmedKey, context }`) to preserve V1 business logic without rewriting
+   function bodies. See [signature-mapping.md](references/signature-mapping.md)
+   and [destructuring-shim.md](references/destructuring-shim.md).
+1. **Authentication Triggers Exception**: If your extension uses v1
+   Authentication Triggers (`auth.user().onCreate()`, etc.), keep those specific
+   triggers on **1st gen** for now, as 2nd gen Auth triggers are not yet
+   supported. Call this out clearly in your package README.
+
+### Step 5: Replace Extension Params with Functions Params
+
+Each parameter in `extension.yaml` becomes a Parameterized Configuration call:
+
+1. Map parameter types:
+   - Type `string` / `select` -> `defineString("PARAM_NAME", { label: "..." })`
+   - Type `secret` -> `defineSecret("PARAM_NAME")`
+   - Type `int` -> `defineInt("PARAM_NAME")`
+   - Type `boolean` -> `defineBoolean("PARAM_NAME")`
+1. Read parameter values inside handlers using `paramName.value()`.
+1. **Keep Exact Parameter Names**: Never change parameter names
+   (`COLLECTION_PATH`, `DATASET_ID`, etc.) so that existing values carry over
+   seamlessly in `.env`.
+
+### Step 6: Migrate Internal Task Queue Calls (`queue.enqueue(...)`)
+
+If your extension code enqueues tasks onto its own queue using the Admin SDK
+(`getFunctions().taskQueue(...)`):
+
+- Under the Extensions runtime, the Admin SDK resolved queues by function name
+  plus `process.env.EXT_INSTANCE_ID`.
+- **In an npm package / regular codebase**: Remove the second argument
+  (`EXT_INSTANCE_ID`) entirely. The Admin SDK automatically targets the current
+  codebase:
+  ```typescript
+  // Before (extension runtime):
+  // const queue = getFunctions().taskQueue(`locations/${region}/functions/syncBigQuery`, process.env.EXT_INSTANCE_ID);
+
+  // After (npm package):
+  const queue = getFunctions().taskQueue(`locations/${region}/functions/syncBigQuery`);
+  await queue.enqueue(taskData);
+  ```
+
+### Step 7: Migrate Secrets
+
+For parameters declared with `type: secret`:
+
+1. Declare the secret explicitly:
+   ```typescript
+   import { defineSecret } from "firebase-functions/params";
    const apiKey = defineSecret("API_KEY");
+   ```
+1. Bind the secret in the trigger options:
+   ```typescript
    export const fn = onRequest({ secrets: [apiKey] }, handler);
    ```
-   *Note*: Keep exact param and secret names unchanged so that existing user
-   installation values in `.env` or Secret Manager carry over without
-   re-prompting.
+1. Keep exact secret names unchanged so existing Secret Manager bindings work.
 
-### Step 3: Upgrading Functions & Triggers (V1 to V2)
+### Step 8: Declare Required APIs and IAM Roles
 
-1. **Imports**: Replace legacy `* as functions` imports with targeted V2 trigger
-   imports from `firebase-functions/v2/...` (e.g. `onDocumentCreated`,
-   `onMessagePublished`, `onValueWritten`, `onObjectFinalized`).
-1. **Signature Modernization (Destructuring Shim)**: Use the Destructuring
-   Compatibility Shim to preserve internal V1 business logic without rewriting
-   function bodies. Instead of `(data, context)`, accept a single `CloudEvent`
-   and destructure `{ shimmedKey, context }`.
-   - *Pub/Sub Example*:
-     ```typescript
-     // V1 Legacy
-     export const myFn = functions.pubsub.topic("orders").onPublish((message, context) => {
-       const orderId = message.json.id;
-     });
-
-     // V2 + Shim
-     import { onMessagePublished } from "firebase-functions/v2/pubsub";
-     export const myFn = onMessagePublished("orders", ({ message, context }) => {
-       const orderId = message.json.id; // Logic remains untouched!
-     });
-     ```
-   - Refer to [signature-mapping.md](references/signature-mapping.md) for full
-     trigger key mappings.
-1. **HTTP Callables**: Callables do not use the destructuring shim. Rewrite the
-   signature to destructure `({ data, auth })` directly.
-1. **Internal Task Queue Enqueue Calls**: If the code enqueues tasks using
-   `getFunctions().taskQueue(...)`:
-   - Replace `process.env.EXT_INSTANCE_ID` with `process.env.KIT_INSTANCE_ID`
-     (or codebase equivalent).
-   - Ensure `firebase-admin` dependency version supports task queue enqueueing
-     in plain codebases.
-
-### Step 4: Declarative Security Injection (IAM Roles & APIs)
-
-Inject declarative security requirements at the top of the main entry file (e.g.
-`src/index.ts`):
+Replace `apis` and `roles` from `extension.yaml` with declarative code in your
+entry file:
 
 ```typescript
-import { requiresAPI, requiresRole } from "firebase-functions/v2";
+import { requiresAPI, requiresRole } from "firebase-functions";
 
-requiresAPI("bigquery.googleapis.com", "Needed to write changelog rows and views");
-
+requiresAPI("bigquery.googleapis.com", "Needed to write changelog rows");
 requiresRole("roles/bigquery.dataEditor");
-requiresRole("roles/datastore.user");
 requiresRole("roles/bigquery.user");
 ```
 
-At deploy time, the Firebase CLI will grant these declared roles to the
-codebase's managed runtime service account.
+At deploy time, the Firebase CLI automatically grants these roles to the managed
+runtime service account and enables the required APIs.
 
-### Step 5: Lifecycle Hook Migration (`afterFirstDeploy` & `afterRedeploy`)
+### Step 9: Convert Lifecycle Hooks (`afterFirstDeploy` & `afterRedeploy`)
 
-If `extension.yaml` declares `lifecycleEvents` (`onInstall`, `onUpdate`,
-`onConfigure`):
+Replace `lifecycleEvents` (`onInstall`, `onUpdate`, `onConfigure`) with SDK
+lifecycle hooks:
 
-1. **Convert Task Queue Handlers**: Upgrade 1st gen task queue functions to V2
-   `onTaskDispatched` from `firebase-functions/v2/tasks`:
-
-   ```typescript
-   import { onTaskDispatched } from "firebase-functions/v2/tasks";
-
-   export const initBigQuerySync = onTaskDispatched(
-     { retryConfig: { maxAttempts: 5 } },
-     async (request) => {
-       await initializeResources(request.data);
-     }
-   );
-   ```
-
-   *Note*: Remove calls to `getExtensions().runtime().setProcessingState(...)`
-   as lifecycle state is managed by CF3.
-
-1. **Register Lifecycle Hooks**: Inject declarative lifecycle hooks:
-
+1. Convert task queue handlers (`initBigQuerySync`, `setupBigQuerySync`) to V2
+   `onTaskDispatched` from `firebase-functions/v2/tasks` (removing legacy
+   `getExtensions().runtime().setProcessingState(...)` calls).
+1. Register lifecycle hooks in code:
    ```typescript
    import { afterFirstDeploy, afterRedeploy } from "firebase-functions/v2";
 
    // Replaces onInstall:
-   afterFirstDeploy({ task: { function: "initBigQuerySync" } });
+   afterFirstDeploy({
+     task: {
+       function: "runInitialSetup",
+       body: {}
+     }
+   });
 
    // Replaces onUpdate & onConfigure:
-   afterRedeploy({ task: { function: "setupBigQuerySync" } });
+   afterRedeploy({
+     task: {
+       function: "runInitialSetup",
+       body: { reconcile: true }
+     }
+   });
+   ```
+1. Ensure handlers are idempotent and document manual rerun commands:
+   ```bash
+   firebase functions:lifecycle:run afterFirstDeploy CODEBASE_NAME
+   firebase functions:lifecycle:run afterRedeploy CODEBASE_NAME
    ```
 
-1. **Idempotency & Manual Rerun**: Ensure lifecycle handlers are idempotent.
-   Document that users can manually rerun hooks if needed:
-   `firebase functions:lifecycle:run afterFirstDeploy CODEBASE_NAME`
+### Step 10: Document Setup for Your Users (`README.md`)
 
-### Step 6: Package Exporting & Documentation (Publisher Path)
+Write a comprehensive package README containing:
 
-If creating an npm package (Target B):
-
-1. **Re-export Functions in Package Entry (`src/index.ts`)**: Ensure all
-   deployable V2 functions and task queue handlers are exported:
+1. **Installation Step**: `npm install <package-name>`
+1. **Re-export Snippet**: Show the exact snippet users must add to `index.ts`:
    ```typescript
-   export { syncV2, initBigQuerySync, setupBigQuerySync } from "./functions";
+   export * from "<package-name>";
    ```
-1. **End-User Re-export Instructions**: Document in `README.md` that end users
-   deploy package functions by re-exporting them in their
-   `functions/src/index.ts`:
-   ```typescript
-   export { syncV2, initBigQuerySync, setupBigQuerySync } from "@scope/extension-pkg";
-   ```
-1. **Package README Checklist**: Include:
-   - Installation (`npm install @scope/extension-pkg`)
-   - Re-export snippet for user's `index.ts`
-   - Required `.env` parameter names & types
-   - IAM roles declared (`requiresRole`)
-   - Lifecycle hooks behavior & manual rerun commands
-   - "What changed" comparison table (Extension vs npm Package)
-
-### Step 7: Build & Verification
-
-1. Run `npm run build` (or `npx tsc`) to ensure no compilation or type errors.
-1. If unit/integration tests exist, run `npm test`.
-   - Update test mocks for upgraded V2 triggers (single destructured object
-     `{ change, context }` instead of two arguments `(data, context)`).
+1. **`.env` Configuration Table & Sample Block**: List required parameters.
+1. **Secrets & IAM Roles**: List declared secrets and `requiresRole(...)` roles.
+1. **Lifecycle Hooks & Rerun Commands**: Explain setup task and rerun CLI
+   commands.
+1. **What Changed Comparison Table**:
+   | Concern      | As the extension             | As `<package-name>`                    |
+   | :----------- | :--------------------------- | :------------------------------------- |
+   | Install      | Extensions runtime           | `npm install` into Functions codebase  |
+   | Config       | Extension params             | Functions params via `.env`            |
+   | IAM          | Granted by Extensions        | `requiresRole(...)`, applied at deploy |
+   | Provisioning | Lifecycle task by Extensions | `afterFirstDeploy` / `afterRedeploy`   |
+1. **Multiple Instances & Troubleshooting**: Note separate codebases/prefixing
+   for multiple instances, checking re-exports, and rerunning failed lifecycle
+   hooks.
 
 ______________________________________________________________________
 

--- a/skills/extension-to-functions-codebase/SKILL.md
+++ b/skills/extension-to-functions-codebase/SKILL.md
@@ -78,7 +78,7 @@ If the extracted functions are written using the legacy Firebase Functions V1 SD
 
 1.  **Imports**: Replace legacy `* as functions` imports with targeted V2 trigger imports from `firebase-functions/v2/...` (e.g. `onDocumentCreated`, `onMessagePublished`).
 2.  **Signature Modernization (Destructuring Shim)**:
-    Use the Destructuring Compatibility Shim to preserve internal V1 business logic. Instead of accepting two parameters `(data, context)`, accept a single `CloudEvent` object and destructure `{ [shimmedKey], context }`.
+    Use the Destructuring Compatibility Shim to preserve internal V1 business logic. Instead of accepting two parameters `(data, context)`, accept a single `CloudEvent` object and destructure `{ shimmedKey, context }`.
     *   *Example (Pub/Sub)*:
         ```typescript
         // V1 Legacy

--- a/skills/extension-to-functions-codebase/SKILL.md
+++ b/skills/extension-to-functions-codebase/SKILL.md
@@ -1,147 +1,239 @@
 ---
 name: extension-to-functions-codebase
-description: Skill for converting an installed Firebase Extension (or extension source) to a standalone Cloud Functions for Firebase (CF3) codebase, including upgrading triggers from V1 to V2
+description: Skill for converting an installed Firebase Extension (or extension source) to a standalone Cloud Functions for Firebase (CF3) codebase or publishable npm package, including upgrading triggers from V1 to V2 and configuring lifecycle hooks and declarative security
 ---
 
-# Extension to Functions Codebase Migration
+# Extension to Functions Codebase & npm Package Migration
 
 ## Overview
 
-This skill guides the agent in migrating a Firebase Extension repository or
-instance into a standalone, self-owned Cloud Functions for Firebase (CF3)
-codebase.
+This skill guides the agent in migrating a Firebase Extension repository or instance into either:
+1. **A standalone Cloud Functions for Firebase (CF3) codebase** (for end-user app integration), or
+2. **A publishable npm package / function kit** (for extension publishers distributing reusable V2 functions).
 
-It leverages the GA capabilities of the CF3 Fabricator to handle permissions,
-dependencies, and lifecycle hooks natively in the cloud, and provides
-instructions for modernizing legacy V1 triggers to V2 using the Destructuring
-Compatibility Shim.
+It leverages CF3 GA capabilities to handle permissions, dependencies, and lifecycle hooks natively in code, and provides instructions for modernizing legacy V1 triggers to V2 using the Destructuring Compatibility Shim.
 
 ---
 
 ## Triggers
-Activate this skill when a user asks to migrate or convert an installed Firebase
-Extension (or extension source code) into a standalone functions codebase.
+
+Activate this skill when a user asks to:
+- Migrate or convert an installed Firebase Extension into a standalone functions codebase.
+- Convert an extension repository into a publishable npm package (function kit).
+- Upgrade extension triggers from V1 to V2.
+
+---
+
+## Target Migration Workflows
+
+Before starting, determine the target destination with the developer:
+
+- **Target A: Local Functions Codebase** (End-User App Integration)
+  - Output: Source code placed in the project's `functions/src/` folder.
+  - Configuration: Parameters defined via `defineString`, `defineSecret`, etc. in `.env`.
+  - Deployment: Deployed directly via `firebase deploy --only functions`.
+
+- **Target B: Publishable npm Package / Function Kit** (Publisher Distribution)
+  - Output: Reusable npm package containing exported V2 functions.
+  - Configuration: `package.json` with `exports` map and `peerDependencies: { "firebase-functions": ">=7.0.0" }`.
+  - Usage: End users install the package (`npm i @scope/package`) and re-export functions in their `index.ts`.
 
 ---
 
 ## Getting Started & Git Safety
 
-1.  **Git Status**: Verify the workspace has a clean git status before starting.
-2.  **In-Place Copying**: If the user asks to copy the code to a new subdirectory within the same repository:
-    *   Use `git cp` (or copy files and commit) to copy the extension's source directory to the target functions codebase directory.
-    *   Commit immediately with the message:
-`"Copying [extension-name] extension to [directory] in preparation for rewrite"`
+1. **Git Status**: Verify the workspace has a clean git status before starting.
+2. **In-Place Copying**: If copying code to a new subdirectory within the same repository:
+   - Use `git cp` (or copy files and commit) to copy the extension's source directory to the target directory.
+   - Commit immediately: `"Copying [extension-name] extension to [directory] in preparation for rewrite"`
 
 ---
 
 ## Rules and Constraints
 
 ### 1. Zero-Local-Overhead (CF3 Integration)
-Assume that CF3 Workload Identities and SDK Lifecycle Hooks are fully GA.
-*   **Do NOT** output instructions or scripts telling the user to run `gcloud` commands or create service accounts.
-*   **Do NOT** write code comments telling the user to manually enable Google APIs in the cloud console.
-*   Instead, use declarative `requiresAPI` and `requiresRole` imports from the SDK.
+Assume CF3 Workload Identities, Declarative Security, and SDK Lifecycle Hooks are fully GA.
+- **Do NOT** output instructions or scripts telling users to run manual `gcloud` IAM commands or create service accounts.
+- **Do NOT** write code comments instructing users to manually enable Google APIs in the cloud console.
+- Instead, use declarative `requiresAPI` and `requiresRole` imports from the SDK.
 
 ### 2. Global Parameter Access Restriction
-*   **Never call `.value()` on any parameter at the global scope.**
-*   If a global variable or class instance is initialized using a parameter value, declare the variable globally and initialize it inside the `onInit()` callback:
-    ```typescript
-    const bqDataset = defineString("DATASET_ID");
-    let bqClient: BigQuery;
+- **Never call `.value()` on any parameter at global scope.**
+- If a global variable or class instance is initialized using a parameter value, declare the variable globally and initialize it inside the `onInit()` callback:
+  ```typescript
+  import { defineString } from "firebase-functions/params";
+  import { onInit } from "firebase-functions/v2";
 
-    onInit(() => {
-      bqClient = new BigQuery({ datasetId: bqDataset.value() });
-    });
-    ```
+  const bqDataset = defineString("DATASET_ID");
+  let bqClient: BigQuery;
+
+  onInit(() => {
+    bqClient = new BigQuery({ datasetId: bqDataset.value() });
+  });
+  ```
 
 ### 3. Concurrency & Cost Parity for V2
 When upgrading triggers to V2:
-*   By default, V2 functions enable concurrency (up to 80 requests per instance).
-*   If you want to maintain V1 fractional CPU pricing (and disable concurrency), set `cpu: "gcf_gen1"` in the function's options object.
+- By default, V2 functions enable concurrency (up to 80 requests per instance).
+- If you want to maintain V1 fractional CPU pricing (and disable concurrency), set `cpu: "gcf_gen1"` in the function's options object.
 
 ---
 
 ## Step-by-Step Migration Execution
 
-### Step 1: Code Extraction & Package Merge
-1. Extract the extension's trigger source code (usually located under `functions/src/` or a dedicated source zip) into the targeted codebase directory.
-2. Merge all dependencies and peer dependencies from the extension's `package.json` into the root `package.json` of the functions project.
-3. Align Node engines and dependencies:
-   *   Read the runtime engine specified in the extension's `extension.yaml` (e.g., `nodejs20` maps to `"node": "20"`).
-   *   Update `package.json` `engines` and `tsconfig.json` compiler options to target this runtime version.
+### Step 1: Inventory the Extension & Setup Package Structure
 
-### Step 2: Parameterization Mapping
-1. Read the list of all parameters declared in `extension.yaml`.
-2. Define a matching parameter in the codebase for each one:
-   *   If type is `secret`, use `defineSecret('PARAM_NAME')`.
-   *   Otherwise, use `defineString('PARAM_NAME')` or `defineInt('PARAM_NAME')`.
-3. Locate all `process.env.PARAM_NAME` calls in the code and replace them with `PARAM_NAME.value()`, ensuring the global scope constraint is respected.
-4. **Custom Events**: If the extension emits custom events, list them as a `multiSelect` parameter named `events` with the label `"Events to emit"`. The description should be `"Select the events that this function should emit from the following list:"`, listing the events as options in `*[type]*: [description]\n` format.
-5. Generate a local `.env` file in the functions folder containing the active parameter values for local execution and deployment.
+1. **Inventory `extension.yaml`**:
+   - `params`: Convert to Functions params (`defineString`, `defineSecret`, etc.).
+   - `apis`: Convert to `requiresAPI(...)` declarations.
+   - `roles`: Convert to `requiresRole(...)` declarations.
+   - `lifecycleEvents` (`onInstall`, `onUpdate`, `onConfigure`): Convert to `afterFirstDeploy` and `afterRedeploy` hooks.
+   - `resources`: Convert V1 triggers to V2, and task queue functions to `onTaskDispatched`.
 
-### Step 3: Upgrading V1 Functions to V2 (Modernization)
-If the extracted functions are written using the legacy Firebase Functions V1
-SDK, upgrade them to V2 to ensure compatibility with CF3 Workload Identities:
+2. **Package Configuration (`package.json`)**:
+   - **For Target A (Local Codebase)**: Merge dependencies from `functions/package.json` into project root `package.json`.
+   - **For Target B (npm Package)**:
+     - Set publishable package name (e.g. `@firebase/firestore-bigquery-export` or `@scope/pkg`).
+     - Move `firebase-functions` from `dependencies` to `peerDependencies` (`"firebase-functions": ">=7.0.0"`).
+     - Add `exports` map and engine requirements:
+       ```json
+       {
+         "name": "@scope/extension-pkg",
+         "version": "1.0.0",
+         "main": "lib/index.js",
+         "types": "lib/index.d.ts",
+         "exports": {
+           ".": { "types": "./lib/index.d.ts", "default": "./lib/index.js" }
+         },
+         "engines": { "node": ">=22" },
+         "peerDependencies": { "firebase-functions": ">=7.0.0" }
+       }
+       ```
 
-1.  **Imports**: Replace legacy `* as functions` imports with targeted V2 trigger imports from `firebase-functions/v2/...` (e.g. `onDocumentCreated`, `onMessagePublished`).
-2.  **Signature Modernization (Destructuring Shim)**:
-Use the Destructuring Compatibility Shim to preserve internal V1 business logic.
-Instead of accepting two parameters `(data, context)`, accept a single
-`CloudEvent` object and destructure `{ shimmedKey, context }`.
-    *   *Example (Pub/Sub)*:
-        ```typescript
-        // V1 Legacy
-        export const myFn = functions.pubsub.topic("orders").onPublish((message, context) => {
-          const orderId = message.json.id;
-        });
+### Step 2: Parameterization & Secret Migration
 
-        // V2 + Shim
-        import { onMessagePublished } from "firebase-functions/v2/pubsub";
-        export const myFn = onMessagePublished("orders", ({ message, context }) => {
-          const orderId = message.json.id; // Logic remains untouched!
-        });
-        ```
-    *   Refer to [signature-mapping.md](references/signature-mapping.md) for the exact shimmed keys for each trigger type.
-3.  **HTTP Callables**: Callables do not use the destructuring shim. Rewrite the signature to destructure `({ data, auth })` directly. The legacy `context` object is unavailable in V2 callables.
-4.  **Options Migration**: Move trigger configurations (memory, timeouts, secrets) from `.runWith(...)` to the V2 options argument (passed as the first parameter). Refer to [configuration-migration.md](references/configuration-migration.md) for property mapping.
+1. Read all parameters declared in `extension.yaml`.
+2. Define matching Functions params in code (e.g. `src/config.ts`):
+   - Type `secret` -> `defineSecret('PARAM_NAME')`
+   - Type `string` -> `defineString('PARAM_NAME')`
+   - Type `select` / `multiSelect` -> `defineString('PARAM_NAME')` / `defineList('PARAM_NAME')`
+   - Type `int` -> `defineInt('PARAM_NAME')`
+3. Replace all direct `process.env.PARAM_NAME` calls with `PARAM_NAME.value()`, ensuring the global scope restriction is respected.
+4. **Secret Binding**: For functions using secrets, bind them in the function options:
+   ```typescript
+   const apiKey = defineSecret("API_KEY");
+   export const fn = onRequest({ secrets: [apiKey] }, handler);
+   ```
+   *Note*: Keep exact param and secret names unchanged so that existing user installation values in `.env` or Secret Manager carry over without re-prompting.
 
-### Step 4: Declarative Requirements Injection
-Inject the required IAM roles and APIs at the very top of the main entry point
-file (e.g., `index.ts`):
-1. **APIs**: For each service listed in the `apis` field in `extension.yaml`, inject `requiresAPI("service-name.googleapis.com")`.
-2. **Roles**: For each role listed in the `iamRoles` field in `extension.yaml`, inject `requiresRole("roles/role-name")`.
+### Step 3: Upgrading Functions & Triggers (V1 to V2)
 
-*Example Headers*:
+1. **Imports**: Replace legacy `* as functions` imports with targeted V2 trigger imports from `firebase-functions/v2/...` (e.g. `onDocumentCreated`, `onMessagePublished`, `onValueWritten`, `onObjectFinalized`).
+2. **Signature Modernization (Destructuring Shim)**:
+   Use the Destructuring Compatibility Shim to preserve internal V1 business logic without rewriting function bodies. Instead of `(data, context)`, accept a single `CloudEvent` and destructure `{ shimmedKey, context }`.
+   - *Pub/Sub Example*:
+     ```typescript
+     // V1 Legacy
+     export const myFn = functions.pubsub.topic("orders").onPublish((message, context) => {
+       const orderId = message.json.id;
+     });
+
+     // V2 + Shim
+     import { onMessagePublished } from "firebase-functions/v2/pubsub";
+     export const myFn = onMessagePublished("orders", ({ message, context }) => {
+       const orderId = message.json.id; // Logic remains untouched!
+     });
+     ```
+   - Refer to [signature-mapping.md](references/signature-mapping.md) for full trigger key mappings.
+3. **HTTP Callables**: Callables do not use the destructuring shim. Rewrite the signature to destructure `({ data, auth })` directly.
+4. **Internal Task Queue Enqueue Calls**:
+   If the code enqueues tasks using `getFunctions().taskQueue(...)`:
+   - Replace `process.env.EXT_INSTANCE_ID` with `process.env.KIT_INSTANCE_ID` (or codebase equivalent).
+   - Ensure `firebase-admin` dependency version supports task queue enqueueing in plain codebases.
+
+### Step 4: Declarative Security Injection (IAM Roles & APIs)
+
+Inject declarative security requirements at the top of the main entry file (e.g. `src/index.ts`):
+
 ```typescript
-import { requiresAPI, requiresRole } from "firebase-functions/core";
+import { requiresAPI, requiresRole } from "firebase-functions/v2";
 
-requiresAPI("bigquery.googleapis.com");
+requiresAPI("bigquery.googleapis.com", "Needed to write changelog rows and views");
+
 requiresRole("roles/bigquery.dataEditor");
+requiresRole("roles/datastore.user");
+requiresRole("roles/bigquery.user");
 ```
 
-### Step 5: Lifecycle Hook Migration
-If `extension.yaml` contains `lifecycleEvents` (such as `onInstall` / `onUpdate`
-triggers):
-1. Ensure the backing function is defined using `functions.tasks.taskQueue().onDispatch(...)` (or `onTaskDispatched` in V2).
-2. Inject the declarative lifecycle call at the bottom of the entry point:
-   ```typescript
-   import { afterInstall } from "firebase-functions/lifecycle";
+At deploy time, the Firebase CLI will grant these declared roles to the codebase's managed runtime service account.
 
-   afterInstall({
-     task: { function: "myLifecycleTaskFunction" }
-   });
+### Step 5: Lifecycle Hook Migration (`afterFirstDeploy` & `afterRedeploy`)
+
+If `extension.yaml` declares `lifecycleEvents` (`onInstall`, `onUpdate`, `onConfigure`):
+
+1. **Convert Task Queue Handlers**:
+   Upgrade 1st gen task queue functions to V2 `onTaskDispatched` from `firebase-functions/v2/tasks`:
+   ```typescript
+   import { onTaskDispatched } from "firebase-functions/v2/tasks";
+
+   export const initBigQuerySync = onTaskDispatched(
+     { retryConfig: { maxAttempts: 5 } },
+     async (request) => {
+       await initializeResources(request.data);
+     }
+   );
+   ```
+   *Note*: Remove calls to `getExtensions().runtime().setProcessingState(...)` as lifecycle state is managed by CF3.
+
+2. **Register Lifecycle Hooks**:
+   Inject declarative lifecycle hooks:
+   ```typescript
+   import { afterFirstDeploy, afterRedeploy } from "firebase-functions/v2";
+
+   // Replaces onInstall:
+   afterFirstDeploy({ task: { function: "initBigQuerySync" } });
+
+   // Replaces onUpdate & onConfigure:
+   afterRedeploy({ task: { function: "setupBigQuerySync" } });
    ```
 
-### Step 6: Firebase Integration & Verification
-1. Add the newly created functions codebase configuration under the `functions` block in `firebase.json`.
-2. Run `npm run build` (or `npx tsc`) to verify no compilation or type errors exist.
-3. **Tests**: If unit tests exist in the codebase:
-   *   Run `npm test` to verify compliance.
-   *   *Note*: Upgraded triggers change signature from two arguments `(data, context)` to one destructured object `({ change, context })`. Update test mocks to pass a single object with the correct shimmed key.
+3. **Idempotency & Manual Rerun**:
+   Ensure lifecycle handlers are idempotent. Document that users can manually rerun hooks if needed:
+   `firebase functions:lifecycle:run afterFirstDeploy CODEBASE_NAME`
+
+### Step 6: Package Exporting & Documentation (Publisher Path)
+
+If creating an npm package (Target B):
+
+1. **Re-export Functions in Package Entry (`src/index.ts`)**:
+   Ensure all deployable V2 functions and task queue handlers are exported:
+   ```typescript
+   export { syncV2, initBigQuerySync, setupBigQuerySync } from "./functions";
+   ```
+2. **End-User Re-export Instructions**:
+   Document in `README.md` that end users deploy package functions by re-exporting them in their `functions/src/index.ts`:
+   ```typescript
+   export { syncV2, initBigQuerySync, setupBigQuerySync } from "@scope/extension-pkg";
+   ```
+3. **Package README Checklist**:
+   Include:
+   - Installation (`npm install @scope/extension-pkg`)
+   - Re-export snippet for user's `index.ts`
+   - Required `.env` parameter names & types
+   - IAM roles declared (`requiresRole`)
+   - Lifecycle hooks behavior & manual rerun commands
+   - "What changed" comparison table (Extension vs npm Package)
+
+### Step 7: Build & Verification
+
+1. Run `npm run build` (or `npx tsc`) to ensure no compilation or type errors.
+2. If unit/integration tests exist, run `npm test`.
+   - Update test mocks for upgraded V2 triggers (single destructured object `{ change, context }` instead of two arguments `(data, context)`).
 
 ---
 
 ## References
-*   **Destructuring Shim**: See [destructuring-shim.md](references/destructuring-shim.md) for details on event property translation.
-*   **Trigger Mapping**: See [signature-mapping.md](references/signature-mapping.md) for V1 vs V2 trigger definitions and shim keys.
-*   **Configuration & Parameters**: See [configuration-migration.md](references/configuration-migration.md) for runWith and parameter definition mappings.
+
+- **Destructuring Shim**: See [destructuring-shim.md](references/destructuring-shim.md) for event property translation.
+- **Trigger Mapping**: See [signature-mapping.md](references/signature-mapping.md) for V1 vs V2 trigger definitions and shim keys.
+- **Configuration & Parameters**: See [configuration-migration.md](references/configuration-migration.md) for `runWith` options, params, and secret bindings.

--- a/skills/extension-to-functions-codebase/SKILL.md
+++ b/skills/extension-to-functions-codebase/SKILL.md
@@ -7,18 +7,24 @@ description: Skill for converting an installed Firebase Extension (or extension 
 
 ## Overview
 
-This skill guides the agent in migrating a Firebase Extension repository or instance into either:
-1. **A standalone Cloud Functions for Firebase (CF3) codebase** (for end-user app integration), or
-2. **A publishable npm package / function kit** (for extension publishers distributing reusable V2 functions).
+This skill guides the agent in migrating a Firebase Extension repository or
+instance into either:
+1. **A standalone Cloud Functions for Firebase (CF3) codebase** (for end-user
+  app integration), or
+2. **A publishable npm package / function kit** (for extension publishers
+  distributing reusable V2 functions).
 
-It leverages CF3 GA capabilities to handle permissions, dependencies, and lifecycle hooks natively in code, and provides instructions for modernizing legacy V1 triggers to V2 using the Destructuring Compatibility Shim.
+It leverages CF3 GA capabilities to handle permissions, dependencies, and
+lifecycle hooks natively in code, and provides instructions for modernizing
+legacy V1 triggers to V2 using the Destructuring Compatibility Shim.
 
 ---
 
 ## Triggers
 
 Activate this skill when a user asks to:
-- Migrate or convert an installed Firebase Extension into a standalone functions codebase.
+- Migrate or convert an installed Firebase Extension into a standalone functions
+  codebase.
 - Convert an extension repository into a publishable npm package (function kit).
 - Upgrade extension triggers from V1 to V2.
 
@@ -30,36 +36,48 @@ Before starting, determine the target destination with the developer:
 
 - **Target A: Local Functions Codebase** (End-User App Integration)
   - Output: Source code placed in the project's `functions/src/` folder.
-  - Configuration: Parameters defined via `defineString`, `defineSecret`, etc. in `.env`.
+  - Configuration: Parameters defined via `defineString`, `defineSecret`, etc.
+    in `.env`.
   - Deployment: Deployed directly via `firebase deploy --only functions`.
 
 - **Target B: Publishable npm Package / Function Kit** (Publisher Distribution)
   - Output: Reusable npm package containing exported V2 functions.
-  - Configuration: `package.json` with `exports` map and `peerDependencies: { "firebase-functions": ">=7.0.0" }`.
-  - Usage: End users install the package (`npm i @scope/package`) and re-export functions in their `index.ts`.
+  - Configuration: `package.json` with `exports` map and `peerDependencies: {
+    "firebase-functions": ">=7.0.0" }`.
+  - Usage: End users install the package (`npm i @scope/package`) and re-export
+    functions in their `index.ts`.
 
 ---
 
 ## Getting Started & Git Safety
 
 1. **Git Status**: Verify the workspace has a clean git status before starting.
-2. **In-Place Copying**: If copying code to a new subdirectory within the same repository:
-   - Use `git cp` (or copy files and commit) to copy the extension's source directory to the target directory.
-   - Commit immediately: `"Copying [extension-name] extension to [directory] in preparation for rewrite"`
+2. **In-Place Copying**: If copying code to a new subdirectory within the same
+  repository:
+   - Use `git cp` (or copy files and commit) to copy the extension's source
+     directory to the target directory.
+   - Commit immediately: `"Copying [extension-name] extension to [directory] in
+     preparation for rewrite"`
 
 ---
 
 ## Rules and Constraints
 
 ### 1. Zero-Local-Overhead (CF3 Integration)
-Assume CF3 Workload Identities, Declarative Security, and SDK Lifecycle Hooks are fully GA.
-- **Do NOT** output instructions or scripts telling users to run manual `gcloud` IAM commands or create service accounts.
-- **Do NOT** write code comments instructing users to manually enable Google APIs in the cloud console.
-- Instead, use declarative `requiresAPI` and `requiresRole` imports from the SDK.
+Assume CF3 Workload Identities, Declarative Security, and SDK Lifecycle Hooks
+are fully GA.
+- **Do NOT** output instructions or scripts telling users to run manual `gcloud`
+  IAM commands or create service accounts.
+- **Do NOT** write code comments instructing users to manually enable Google
+  APIs in the cloud console.
+- Instead, use declarative `requiresAPI` and `requiresRole` imports from the
+  SDK.
 
 ### 2. Global Parameter Access Restriction
 - **Never call `.value()` on any parameter at global scope.**
-- If a global variable or class instance is initialized using a parameter value, declare the variable globally and initialize it inside the `onInit()` callback:
+- If a global variable or class instance is initialized using a parameter value,
+  declare the variable globally and initialize it inside the `onInit()`
+  callback:
   ```typescript
   import { defineString } from "firebase-functions/params";
   import { onInit } from "firebase-functions/v2";
@@ -75,7 +93,8 @@ Assume CF3 Workload Identities, Declarative Security, and SDK Lifecycle Hooks ar
 ### 3. Concurrency & Cost Parity for V2
 When upgrading triggers to V2:
 - By default, V2 functions enable concurrency (up to 80 requests per instance).
-- If you want to maintain V1 fractional CPU pricing (and disable concurrency), set `cpu: "gcf_gen1"` in the function's options object.
+- If you want to maintain V1 fractional CPU pricing (and disable concurrency),
+  set `cpu: "gcf_gen1"` in the function's options object.
 
 ---
 
@@ -84,17 +103,23 @@ When upgrading triggers to V2:
 ### Step 1: Inventory the Extension & Setup Package Structure
 
 1. **Inventory `extension.yaml`**:
-   - `params`: Convert to Functions params (`defineString`, `defineSecret`, etc.).
+   - `params`: Convert to Functions params (`defineString`, `defineSecret`,
+     etc.).
    - `apis`: Convert to `requiresAPI(...)` declarations.
    - `roles`: Convert to `requiresRole(...)` declarations.
-   - `lifecycleEvents` (`onInstall`, `onUpdate`, `onConfigure`): Convert to `afterFirstDeploy` and `afterRedeploy` hooks.
-   - `resources`: Convert V1 triggers to V2, and task queue functions to `onTaskDispatched`.
+   - `lifecycleEvents` (`onInstall`, `onUpdate`, `onConfigure`): Convert to
+     `afterFirstDeploy` and `afterRedeploy` hooks.
+   - `resources`: Convert V1 triggers to V2, and task queue functions to
+     `onTaskDispatched`.
 
 2. **Package Configuration (`package.json`)**:
-   - **For Target A (Local Codebase)**: Merge dependencies from `functions/package.json` into project root `package.json`.
+   - **For Target A (Local Codebase)**: Merge dependencies from
+     `functions/package.json` into project root `package.json`.
    - **For Target B (npm Package)**:
-     - Set publishable package name (e.g. `@firebase/firestore-bigquery-export` or `@scope/pkg`).
-     - Move `firebase-functions` from `dependencies` to `peerDependencies` (`"firebase-functions": ">=7.0.0"`).
+     - Set publishable package name (e.g. `@firebase/firestore-bigquery-export`
+       or `@scope/pkg`).
+     - Move `firebase-functions` from `dependencies` to `peerDependencies`
+       (`"firebase-functions": ">=7.0.0"`).
      - Add `exports` map and engine requirements:
        ```json
        {
@@ -116,21 +141,30 @@ When upgrading triggers to V2:
 2. Define matching Functions params in code (e.g. `src/config.ts`):
    - Type `secret` -> `defineSecret('PARAM_NAME')`
    - Type `string` -> `defineString('PARAM_NAME')`
-   - Type `select` / `multiSelect` -> `defineString('PARAM_NAME')` / `defineList('PARAM_NAME')`
+   - Type `select` / `multiSelect` -> `defineString('PARAM_NAME')` /
+     `defineList('PARAM_NAME')`
    - Type `int` -> `defineInt('PARAM_NAME')`
-3. Replace all direct `process.env.PARAM_NAME` calls with `PARAM_NAME.value()`, ensuring the global scope restriction is respected.
-4. **Secret Binding**: For functions using secrets, bind them in the function options:
+3. Replace all direct `process.env.PARAM_NAME` calls with `PARAM_NAME.value()`,
+  ensuring the global scope restriction is respected.
+4. **Secret Binding**: For functions using secrets, bind them in the function
+  options:
    ```typescript
    const apiKey = defineSecret("API_KEY");
    export const fn = onRequest({ secrets: [apiKey] }, handler);
    ```
-   *Note*: Keep exact param and secret names unchanged so that existing user installation values in `.env` or Secret Manager carry over without re-prompting.
+   *Note*: Keep exact param and secret names unchanged so that existing user
+   installation values in `.env` or Secret Manager carry over without
+   re-prompting.
 
 ### Step 3: Upgrading Functions & Triggers (V1 to V2)
 
-1. **Imports**: Replace legacy `* as functions` imports with targeted V2 trigger imports from `firebase-functions/v2/...` (e.g. `onDocumentCreated`, `onMessagePublished`, `onValueWritten`, `onObjectFinalized`).
+1. **Imports**: Replace legacy `* as functions` imports with targeted V2 trigger
+  imports from `firebase-functions/v2/...` (e.g. `onDocumentCreated`,
+  `onMessagePublished`, `onValueWritten`, `onObjectFinalized`).
 2. **Signature Modernization (Destructuring Shim)**:
-   Use the Destructuring Compatibility Shim to preserve internal V1 business logic without rewriting function bodies. Instead of `(data, context)`, accept a single `CloudEvent` and destructure `{ shimmedKey, context }`.
+   Use the Destructuring Compatibility Shim to preserve internal V1 business
+   logic without rewriting function bodies. Instead of `(data, context)`, accept
+   a single `CloudEvent` and destructure `{ shimmedKey, context }`.
    - *Pub/Sub Example*:
      ```typescript
      // V1 Legacy
@@ -144,16 +178,21 @@ When upgrading triggers to V2:
        const orderId = message.json.id; // Logic remains untouched!
      });
      ```
-   - Refer to [signature-mapping.md](references/signature-mapping.md) for full trigger key mappings.
-3. **HTTP Callables**: Callables do not use the destructuring shim. Rewrite the signature to destructure `({ data, auth })` directly.
+   - Refer to [signature-mapping.md](references/signature-mapping.md) for full
+     trigger key mappings.
+3. **HTTP Callables**: Callables do not use the destructuring shim. Rewrite the
+  signature to destructure `({ data, auth })` directly.
 4. **Internal Task Queue Enqueue Calls**:
    If the code enqueues tasks using `getFunctions().taskQueue(...)`:
-   - Replace `process.env.EXT_INSTANCE_ID` with `process.env.KIT_INSTANCE_ID` (or codebase equivalent).
-   - Ensure `firebase-admin` dependency version supports task queue enqueueing in plain codebases.
+   - Replace `process.env.EXT_INSTANCE_ID` with `process.env.KIT_INSTANCE_ID`
+     (or codebase equivalent).
+   - Ensure `firebase-admin` dependency version supports task queue enqueueing
+     in plain codebases.
 
 ### Step 4: Declarative Security Injection (IAM Roles & APIs)
 
-Inject declarative security requirements at the top of the main entry file (e.g. `src/index.ts`):
+Inject declarative security requirements at the top of the main entry file (e.g.
+`src/index.ts`):
 
 ```typescript
 import { requiresAPI, requiresRole } from "firebase-functions/v2";
@@ -165,14 +204,17 @@ requiresRole("roles/datastore.user");
 requiresRole("roles/bigquery.user");
 ```
 
-At deploy time, the Firebase CLI will grant these declared roles to the codebase's managed runtime service account.
+At deploy time, the Firebase CLI will grant these declared roles to the
+codebase's managed runtime service account.
 
 ### Step 5: Lifecycle Hook Migration (`afterFirstDeploy` & `afterRedeploy`)
 
-If `extension.yaml` declares `lifecycleEvents` (`onInstall`, `onUpdate`, `onConfigure`):
+If `extension.yaml` declares `lifecycleEvents` (`onInstall`, `onUpdate`,
+`onConfigure`):
 
 1. **Convert Task Queue Handlers**:
-   Upgrade 1st gen task queue functions to V2 `onTaskDispatched` from `firebase-functions/v2/tasks`:
+   Upgrade 1st gen task queue functions to V2 `onTaskDispatched` from
+   `firebase-functions/v2/tasks`:
    ```typescript
    import { onTaskDispatched } from "firebase-functions/v2/tasks";
 
@@ -183,7 +225,8 @@ If `extension.yaml` declares `lifecycleEvents` (`onInstall`, `onUpdate`, `onConf
      }
    );
    ```
-   *Note*: Remove calls to `getExtensions().runtime().setProcessingState(...)` as lifecycle state is managed by CF3.
+   *Note*: Remove calls to `getExtensions().runtime().setProcessingState(...)`
+   as lifecycle state is managed by CF3.
 
 2. **Register Lifecycle Hooks**:
    Inject declarative lifecycle hooks:
@@ -198,7 +241,8 @@ If `extension.yaml` declares `lifecycleEvents` (`onInstall`, `onUpdate`, `onConf
    ```
 
 3. **Idempotency & Manual Rerun**:
-   Ensure lifecycle handlers are idempotent. Document that users can manually rerun hooks if needed:
+   Ensure lifecycle handlers are idempotent. Document that users can manually
+   rerun hooks if needed:
    `firebase functions:lifecycle:run afterFirstDeploy CODEBASE_NAME`
 
 ### Step 6: Package Exporting & Documentation (Publisher Path)
@@ -211,7 +255,8 @@ If creating an npm package (Target B):
    export { syncV2, initBigQuerySync, setupBigQuerySync } from "./functions";
    ```
 2. **End-User Re-export Instructions**:
-   Document in `README.md` that end users deploy package functions by re-exporting them in their `functions/src/index.ts`:
+   Document in `README.md` that end users deploy package functions by
+   re-exporting them in their `functions/src/index.ts`:
    ```typescript
    export { syncV2, initBigQuerySync, setupBigQuerySync } from "@scope/extension-pkg";
    ```
@@ -228,12 +273,19 @@ If creating an npm package (Target B):
 
 1. Run `npm run build` (or `npx tsc`) to ensure no compilation or type errors.
 2. If unit/integration tests exist, run `npm test`.
-   - Update test mocks for upgraded V2 triggers (single destructured object `{ change, context }` instead of two arguments `(data, context)`).
+   - Update test mocks for upgraded V2 triggers (single destructured object `{
+     change, context }` instead of two arguments `(data, context)`).
 
 ---
 
 ## References
 
-- **Destructuring Shim**: See [destructuring-shim.md](references/destructuring-shim.md) for details on event property translation.
-- **Trigger Mapping**: See [signature-mapping.md](references/signature-mapping.md) for V1 vs V2 trigger definitions and shim keys.
-- **Configuration & Parameters**: See [configuration-migration.md](references/configuration-migration.md) for `runWith` options, params, and secret bindings.
+- **Destructuring Shim**: See
+  [destructuring-shim.md](references/destructuring-shim.md) for details on event
+  property translation.
+- **Trigger Mapping**: See
+  [signature-mapping.md](references/signature-mapping.md) for V1 vs V2 trigger
+  definitions and shim keys.
+- **Configuration & Parameters**: See
+  [configuration-migration.md](references/configuration-migration.md) for
+  `runWith` options, params, and secret bindings.

--- a/skills/extension-to-functions-codebase/SKILL.md
+++ b/skills/extension-to-functions-codebase/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: extension-to-functions-codebase
+description: Skill for converting an installed Firebase Extension (or extension source) to a standalone Cloud Functions for Firebase (CF3) codebase, including upgrading triggers from V1 to V2
+---
+
+# Extension to Functions Codebase Migration
+
+## Overview
+
+This skill guides the agent in migrating a Firebase Extension repository or instance into a standalone, self-owned Cloud Functions for Firebase (CF3) codebase. 
+
+It leverages the GA capabilities of the CF3 Fabricator to handle permissions, dependencies, and lifecycle hooks natively in the cloud, and provides instructions for modernizing legacy V1 triggers to V2 using the Destructuring Compatibility Shim.
+
+---
+
+## Triggers
+Activate this skill when a user asks to migrate or convert an installed Firebase Extension (or extension source code) into a standalone functions codebase.
+
+---
+
+## Getting Started & Git Safety
+
+1.  **Git Status**: Verify the workspace has a clean git status before starting.
+2.  **In-Place Copying**: If the user asks to copy the code to a new subdirectory within the same repository:
+    *   Use `git cp` (or copy files and commit) to copy the extension's source directory to the target functions codebase directory.
+    *   Commit immediately with the message:
+        `"Copying [extension-name] extension to [directory] in preparation for rewrite"`
+
+---
+
+## Rules and Constraints
+
+### 1. Zero-Local-Overhead (CF3 Integration)
+Assume that CF3 Workload Identities and SDK Lifecycle Hooks are fully GA. 
+*   **Do NOT** output instructions or scripts telling the user to run `gcloud` commands or create service accounts.
+*   **Do NOT** write code comments telling the user to manually enable Google APIs in the cloud console.
+*   Instead, use declarative `requiresAPI` and `requiresRole` imports from the SDK.
+
+### 2. Global Parameter Access Restriction
+*   **Never call `.value()` on any parameter at the global scope.**
+*   If a global variable or class instance is initialized using a parameter value, declare the variable globally and initialize it inside the `onInit()` callback:
+    ```typescript
+    const bqDataset = defineString("DATASET_ID");
+    let bqClient: BigQuery;
+
+    onInit(() => {
+      bqClient = new BigQuery({ datasetId: bqDataset.value() });
+    });
+    ```
+
+### 3. Concurrency & Cost Parity for V2
+When upgrading triggers to V2:
+*   By default, V2 functions enable concurrency (up to 80 requests per instance).
+*   If you want to maintain V1 fractional CPU pricing (and disable concurrency), set `cpu: "gcf_gen1"` in the function's options object.
+
+---
+
+## Step-by-Step Migration Execution
+
+### Step 1: Code Extraction & Package Merge
+1. Extract the extension's trigger source code (usually located under `functions/src/` or a dedicated source zip) into the targeted codebase directory.
+2. Merge all dependencies and peer dependencies from the extension's `package.json` into the root `package.json` of the functions project.
+3. Align Node engines and dependencies:
+   *   Read the runtime engine specified in the extension's `extension.yaml` (e.g., `nodejs20` maps to `"node": "20"`).
+   *   Update `package.json` `engines` and `tsconfig.json` compiler options to target this runtime version.
+
+### Step 2: Parameterization Mapping
+1. Read the list of all parameters declared in `extension.yaml`.
+2. Define a matching parameter in the codebase for each one:
+   *   If type is `secret`, use `defineSecret('PARAM_NAME')`.
+   *   Otherwise, use `defineString('PARAM_NAME')` or `defineInt('PARAM_NAME')`.
+3. Locate all `process.env.PARAM_NAME` calls in the code and replace them with `PARAM_NAME.value()`, ensuring the global scope constraint is respected.
+4. **Custom Events**: If the extension emits custom events, list them as a `multiSelect` parameter named `events` with the label `"Events to emit"`. The description should be `"Select the events that this function should emit from the following list:"`, listing the events as options in `*[type]*: [description]\n` format.
+5. Generate a local `.env` file in the functions folder containing the active parameter values for local execution and deployment.
+
+### Step 3: Upgrading V1 Functions to V2 (Modernization)
+If the extracted functions are written using the legacy Firebase Functions V1 SDK, upgrade them to V2 to ensure compatibility with CF3 Workload Identities:
+
+1.  **Imports**: Replace legacy `* as functions` imports with targeted V2 trigger imports from `firebase-functions/v2/...` (e.g. `onDocumentCreated`, `onMessagePublished`).
+2.  **Signature Modernization (Destructuring Shim)**:
+    Use the Destructuring Compatibility Shim to preserve internal V1 business logic. Instead of accepting two parameters `(data, context)`, accept a single `CloudEvent` object and destructure `{ [shimmedKey], context }`.
+    *   *Example (Pub/Sub)*:
+        ```typescript
+        // V1 Legacy
+        export const myFn = functions.pubsub.topic("orders").onPublish((message, context) => {
+          const orderId = message.json.id;
+        });
+
+        // V2 + Shim
+        import { onMessagePublished } from "firebase-functions/v2/pubsub";
+        export const myFn = onMessagePublished("orders", ({ message, context }) => {
+          const orderId = message.json.id; // Logic remains untouched!
+        });
+        ```
+    *   Refer to [signature-mapping.md](references/signature-mapping.md) for the exact shimmed keys for each trigger type.
+3.  **HTTP Callables**: Callables do not use the destructuring shim. Rewrite the signature to destructure `({ data, auth })` directly. The legacy `context` object is unavailable in V2 callables.
+4.  **Options Migration**: Move trigger configurations (memory, timeouts, secrets) from `.runWith(...)` to the V2 options argument (passed as the first parameter). Refer to [configuration-migration.md](references/configuration-migration.md) for property mapping.
+
+### Step 4: Declarative Requirements Injection
+Inject the required IAM roles and APIs at the very top of the main entry point file (e.g., `index.ts`):
+1. **APIs**: For each service listed in the `apis` field in `extension.yaml`, inject `requiresAPI("service-name.googleapis.com")`.
+2. **Roles**: For each role listed in the `iamRoles` field in `extension.yaml`, inject `requiresRole("roles/role-name")`.
+
+*Example Headers*:
+```typescript
+import { requiresAPI, requiresRole } from "firebase-functions/core";
+
+requiresAPI("bigquery.googleapis.com");
+requiresRole("roles/bigquery.dataEditor");
+```
+
+### Step 5: Lifecycle Hook Migration
+If `extension.yaml` contains `lifecycleEvents` (such as `onInstall` / `onUpdate` triggers):
+1. Ensure the backing function is defined using `functions.tasks.taskQueue().onDispatch(...)` (or `onTaskDispatched` in V2).
+2. Inject the declarative lifecycle call at the bottom of the entry point:
+   ```typescript
+   import { afterInstall } from "firebase-functions/lifecycle";
+
+   afterInstall({
+     task: { function: "myLifecycleTaskFunction" }
+   });
+   ```
+
+### Step 6: Firebase Integration & Verification
+1. Add the newly created functions codebase configuration under the `functions` block in `firebase.json`.
+2. Run `npm run build` (or `npx tsc`) to verify no compilation or type errors exist.
+3. **Tests**: If unit tests exist in the codebase:
+   *   Run `npm test` to verify compliance.
+   *   *Note*: Upgraded triggers change signature from two arguments `(data, context)` to one destructured object `({ change, context })`. Update test mocks to pass a single object with the correct shimmed key.
+
+---
+
+## References
+*   **Destructuring Shim**: See [destructuring-shim.md](references/destructuring-shim.md) for details on event property translation.
+*   **Trigger Mapping**: See [signature-mapping.md](references/signature-mapping.md) for V1 vs V2 trigger definitions and shim keys.
+*   **Configuration & Parameters**: See [configuration-migration.md](references/configuration-migration.md) for runWith and parameter definition mappings.

--- a/skills/extension-to-functions-codebase/SKILL.md
+++ b/skills/extension-to-functions-codebase/SKILL.md
@@ -136,6 +136,11 @@ Create an npm package for the migrated extension code (either at project root or
 in a dedicated workspace directory):
 
 - Set a publishable package name (`name: "<package-name>"`).
+- **Preserve Dev & Test Dependencies**: Preserve all existing `devDependencies`,
+  test runners (`jest`, `ts-jest`, `@types/jest`, `mocha`, `@types/mocha`), and
+  test scripts (`"test": "..."`) from the legacy extension
+  (`functions/package.json` or root `package.json`). Do not drop test frameworks
+  or type definitions.
 - Move `firebase-functions` from `dependencies` to `peerDependencies`:
   ```json
   {
@@ -308,6 +313,22 @@ Write a comprehensive package README containing:
 1. **Multiple Instances & Troubleshooting**: Note separate codebases/prefixing
    for multiple instances, checking re-exports, and rerunning failed lifecycle
    hooks.
+
+### Step 11: Build & Test Verification
+
+1. **Verify Source Compilation**: Run `npm run build` (`tsc`) to ensure no
+   TypeScript compilation errors in `src/`.
+1. **Verify Unit Test Suite & Type Definitions**:
+   - If existing unit tests (`__tests__/`, `test/`) are present in the
+     extension:
+     - Ensure `@types/jest` (or the original test framework types) are present
+       in `devDependencies` so test files type-check cleanly.
+     - Update test invocations for upgraded V2 triggers to pass a single
+       destructured event object
+       (`({ change: mockChange, context: mockContext })` instead of positional
+       arguments `(mockChange, mockContext)`).
+     - Run `npm test` or type-check test files (`npx tsc --noEmit`) to verify
+       zero regressions.
 
 ______________________________________________________________________
 

--- a/skills/extension-to-functions-codebase/SKILL.md
+++ b/skills/extension-to-functions-codebase/SKILL.md
@@ -216,6 +216,9 @@ Each parameter in `extension.yaml` becomes a Parameterized Configuration call:
      `defineString("PARAM_NAME", { input: { select: { options: [{ value: "val", label: "Val" }] } } })`
    - `validationRegex` -> map into text input options:
      `defineString("PARAM_NAME", { input: { text: { validationRegex: "^[a-z]+$" } } })`
+   - `required: true` / Non-empty validation -> map `nonEmpty: true` into input
+     options:
+     `defineString("PARAM_NAME", { input: { text: { nonEmpty: true } } })`
 1. Read parameter values inside handlers using `paramName.value()`.
 1. **Keep Exact Parameter Names**: Never change parameter names
    (`COLLECTION_PATH`, `DATASET_ID`, etc.) so that existing values carry over
@@ -340,8 +343,14 @@ extension already documented in `README.md` (and `PREINSTALL.md` /
 
 ______________________________________________________________________
 
-## References
+## References & Official Resources
 
+- **Official Google Migration Guide**:
+  [Prepare Firebase Extensions for migration to Cloud Functions](https://firebase.google.com/docs/extensions/publishers/migrate)
+- **Publisher Support Contacts**:
+  - Support Email: `firebase-extensions-migrator-support-external@google.com`
+  - Support Group Subscription:
+    `firebase-extensions-migrator-support-external+subscribe@google.com`
 - **Destructuring Shim**: See
   [destructuring-shim.md](references/destructuring-shim.md) for details on event
   property translation.

--- a/skills/extension-to-functions-codebase/SKILL.md
+++ b/skills/extension-to-functions-codebase/SKILL.md
@@ -7,14 +7,20 @@ description: Skill for converting an installed Firebase Extension (or extension 
 
 ## Overview
 
-This skill guides the agent in migrating a Firebase Extension repository or instance into a standalone, self-owned Cloud Functions for Firebase (CF3) codebase. 
+This skill guides the agent in migrating a Firebase Extension repository or
+instance into a standalone, self-owned Cloud Functions for Firebase (CF3)
+codebase.
 
-It leverages the GA capabilities of the CF3 Fabricator to handle permissions, dependencies, and lifecycle hooks natively in the cloud, and provides instructions for modernizing legacy V1 triggers to V2 using the Destructuring Compatibility Shim.
+It leverages the GA capabilities of the CF3 Fabricator to handle permissions,
+dependencies, and lifecycle hooks natively in the cloud, and provides
+instructions for modernizing legacy V1 triggers to V2 using the Destructuring
+Compatibility Shim.
 
 ---
 
 ## Triggers
-Activate this skill when a user asks to migrate or convert an installed Firebase Extension (or extension source code) into a standalone functions codebase.
+Activate this skill when a user asks to migrate or convert an installed Firebase
+Extension (or extension source code) into a standalone functions codebase.
 
 ---
 
@@ -24,14 +30,14 @@ Activate this skill when a user asks to migrate or convert an installed Firebase
 2.  **In-Place Copying**: If the user asks to copy the code to a new subdirectory within the same repository:
     *   Use `git cp` (or copy files and commit) to copy the extension's source directory to the target functions codebase directory.
     *   Commit immediately with the message:
-        `"Copying [extension-name] extension to [directory] in preparation for rewrite"`
+`"Copying [extension-name] extension to [directory] in preparation for rewrite"`
 
 ---
 
 ## Rules and Constraints
 
 ### 1. Zero-Local-Overhead (CF3 Integration)
-Assume that CF3 Workload Identities and SDK Lifecycle Hooks are fully GA. 
+Assume that CF3 Workload Identities and SDK Lifecycle Hooks are fully GA.
 *   **Do NOT** output instructions or scripts telling the user to run `gcloud` commands or create service accounts.
 *   **Do NOT** write code comments telling the user to manually enable Google APIs in the cloud console.
 *   Instead, use declarative `requiresAPI` and `requiresRole` imports from the SDK.
@@ -74,11 +80,14 @@ When upgrading triggers to V2:
 5. Generate a local `.env` file in the functions folder containing the active parameter values for local execution and deployment.
 
 ### Step 3: Upgrading V1 Functions to V2 (Modernization)
-If the extracted functions are written using the legacy Firebase Functions V1 SDK, upgrade them to V2 to ensure compatibility with CF3 Workload Identities:
+If the extracted functions are written using the legacy Firebase Functions V1
+SDK, upgrade them to V2 to ensure compatibility with CF3 Workload Identities:
 
 1.  **Imports**: Replace legacy `* as functions` imports with targeted V2 trigger imports from `firebase-functions/v2/...` (e.g. `onDocumentCreated`, `onMessagePublished`).
 2.  **Signature Modernization (Destructuring Shim)**:
-    Use the Destructuring Compatibility Shim to preserve internal V1 business logic. Instead of accepting two parameters `(data, context)`, accept a single `CloudEvent` object and destructure `{ shimmedKey, context }`.
+Use the Destructuring Compatibility Shim to preserve internal V1 business logic.
+Instead of accepting two parameters `(data, context)`, accept a single
+`CloudEvent` object and destructure `{ shimmedKey, context }`.
     *   *Example (Pub/Sub)*:
         ```typescript
         // V1 Legacy
@@ -97,7 +106,8 @@ If the extracted functions are written using the legacy Firebase Functions V1 SD
 4.  **Options Migration**: Move trigger configurations (memory, timeouts, secrets) from `.runWith(...)` to the V2 options argument (passed as the first parameter). Refer to [configuration-migration.md](references/configuration-migration.md) for property mapping.
 
 ### Step 4: Declarative Requirements Injection
-Inject the required IAM roles and APIs at the very top of the main entry point file (e.g., `index.ts`):
+Inject the required IAM roles and APIs at the very top of the main entry point
+file (e.g., `index.ts`):
 1. **APIs**: For each service listed in the `apis` field in `extension.yaml`, inject `requiresAPI("service-name.googleapis.com")`.
 2. **Roles**: For each role listed in the `iamRoles` field in `extension.yaml`, inject `requiresRole("roles/role-name")`.
 
@@ -110,7 +120,8 @@ requiresRole("roles/bigquery.dataEditor");
 ```
 
 ### Step 5: Lifecycle Hook Migration
-If `extension.yaml` contains `lifecycleEvents` (such as `onInstall` / `onUpdate` triggers):
+If `extension.yaml` contains `lifecycleEvents` (such as `onInstall` / `onUpdate`
+triggers):
 1. Ensure the backing function is defined using `functions.tasks.taskQueue().onDispatch(...)` (or `onTaskDispatched` in V2).
 2. Inject the declarative lifecycle call at the bottom of the entry point:
    ```typescript

--- a/skills/extension-to-functions-codebase/references/configuration-migration.md
+++ b/skills/extension-to-functions-codebase/references/configuration-migration.md
@@ -1,11 +1,8 @@
 # Migrating Runtime Configurations (runWith)
 
-In Firebase Functions V1, you configured runtime settings like memory, timeout,
-and service accounts using `.runWith()`. In V2, `.runWith()` is removed and
-replaced by a more flexible options system.
+In Firebase Functions V1, you configured runtime settings like memory, timeout, and service accounts using `.runWith()`. In V2, `.runWith()` is removed and replaced by a more flexible options system.
 
-You can configure V2 functions in two ways: **Globally** (for all functions in a
-file) or **Per-Function**.
+You can configure V2 functions in two ways: **Globally** (for all functions in a file) or **Per-Function**.
 
 ---
 
@@ -47,8 +44,7 @@ export const myFn = onRequest((req, res) => { ... });
 
 ## 🎯 2. Per-Function Configuration
 
-Pass the configuration object as the **first argument** to the V2 trigger
-function.
+Pass the configuration object as the **first argument** to the V2 trigger function.
 
 ### V1 Legacy
 
@@ -95,37 +91,40 @@ export const processOrder = onMessagePublished(
 
 ## 🔐 3. Migrating Environment Configurations (`functions.config()`)
 
-In V1, you used `functions.config()` to access environment configuration. In V2,
-this is replaced by **Parameterized Configuration**.
+In V1, you used `functions.config()` to access environment configuration. In V2, this is replaced by **Parameterized Configuration**.
 
 ### Deterministic Rules for Migration
 
 Follow these rules to ensure a deterministic and safe migration:
 
 #### Typing
-*   **Numbers**: If the value is used as a number, use `defineNumber`.
-*   **Secrets**: If the key contains "KEY", "SECRET", "TOKEN", or "PASSWORD", use `defineSecret()`.
-    *   *Note*: Secrets MUST be explicitly bound to the function that uses them in the options object (e.g., `{ secrets: [myKey] }`).
-*   **Lists**: Use `defineList` for comma-separated lists.
-*   **JSON**: Use `defineJSON` for JSON strings.
-*   **Buckets**: If the param is a storage bucket, set `input: 'BUCKET_PICKER'`.
+
+- **Numbers**: If the value is used as a number, use `defineNumber`.
+- **Secrets**: If the key contains "KEY", "SECRET", "TOKEN", or "PASSWORD", use `defineSecret()`.
+  - *Note*: Secrets MUST be explicitly bound to the function that uses them in the options object (e.g., `{ secrets: [myKey] }`).
+- **Lists**: Use `defineList` for comma-separated lists.
+- **JSON**: Use `defineJSON` for JSON strings.
+- **Buckets**: If the param is a storage bucket, set `input: 'BUCKET_PICKER'`.
 
 #### Initialization & Scope
-*   **Global Initialization**: If a variable was initialized globally in V1 (e.g., `const client = new Client(functions.config().key)`), you must split it to have declaration at global scope and initialization inside `onInit`:
-    ```typescript
-    import { onInit } from "firebase-functions/v2";
-    
-    const myKey = defineSecret("MY_KEY");
-    let client: Client;
-    
-    onInit(() => {
-      client = new Client(myKey.value());
-    });
-    ```
+
+- **Global Initialization**: If a variable was initialized globally in V1 (e.g., `const client = new Client(functions.config().key)`), you must split it to have declaration at global scope and initialization inside `onInit`:
+  ```typescript
+  import { onInit } from "firebase-functions/v2";
+
+  const myKey = defineSecret("MY_KEY");
+  let client: Client;
+
+  onInit(() => {
+    client = new Client(myKey.value());
+  });
+  ```
 
 #### Advanced Interpolation & Logic
-*   **String Interpolation**: Use the `expr` tagged template literal from `firebase-functions/params` (e.g., `` `expr`every ${period} days` ``) instead of standard template literals when constructing dynamic strings with parameters. Do NOT call `.value()` inside `expr`.
-*   **Logic Operators**: Use expressions like `projectID.equals('prod').thenElse(1, 0)` for logical operations instead of ternary operators on `.value()`.
+
+- **String Interpolation**: Use the `expr` tagged template literal from `firebase-functions/params` (e.g., `` `expr`every ${period} days` ``) instead of standard template literals when constructing dynamic strings with parameters. Do NOT call `.value()` inside `expr`.
+- **Logic Operators**: Use expressions like `projectID.equals('prod').thenElse(1, 0)` for logical operations instead of ternary operators on `.value()`.
 
 #### Built-ins
-*   Prefer built-in variables like `databaseURL`, `projectID`, `gcloudProject`, `storageBucket` rather than defining new params for these values.
+
+- Prefer built-in variables like `databaseURL`, `projectID`, `gcloudProject`, `storageBucket` rather than defining new params for these values.

--- a/skills/extension-to-functions-codebase/references/configuration-migration.md
+++ b/skills/extension-to-functions-codebase/references/configuration-migration.md
@@ -1,0 +1,126 @@
+# Migrating Runtime Configurations (runWith)
+
+In Firebase Functions V1, you configured runtime settings like memory, timeout, and service accounts using `.runWith()`. In V2, `.runWith()` is removed and replaced by a more flexible options system.
+
+You can configure V2 functions in two ways: **Globally** (for all functions in a file) or **Per-Function**.
+
+---
+
+## 🌍 1. Global Configuration (`setGlobalOptions`)
+
+Use `setGlobalOptions` at the top of your file to set defaults for all functions defined after it.
+
+### V1 Legacy
+
+```typescript
+import * as functions from "firebase-functions";
+
+export const myFn = functions
+  .runWith({
+    memory: "1GB",
+    timeoutSeconds: 120,
+    serviceAccount: "custom-sa@my-project.iam.gserviceaccount.com",
+  })
+  .https.onRequest((req, res) => { ... });
+```
+
+### V2 Modern Equivalent
+
+```typescript
+import { setGlobalOptions } from "firebase-functions/v2";
+import { onRequest } from "firebase-functions/v2/https";
+
+// Set global defaults for this file
+setGlobalOptions({
+  memory: "1GiB", // Note: GiB instead of GB is preferred in V2 types
+  timeoutSeconds: 120,
+  serviceAccount: "custom-sa@my-project.iam.gserviceaccount.com",
+});
+
+export const myFn = onRequest((req, res) => { ... });
+```
+
+---
+
+## 🎯 2. Per-Function Configuration
+
+Pass the configuration object as the **first argument** to the V2 trigger function.
+
+### V1 Legacy
+
+```typescript
+export const processOrder = functions
+  .runWith({ memory: "2GB" })
+  .pubsub.topic("orders")
+  .onPublish((message, context) => { ... });
+```
+
+### V2 Modern Equivalent
+
+```typescript
+import { onMessagePublished } from "firebase-functions/v2/pubsub";
+
+export const processOrder = onMessagePublished(
+  {
+    topic: "orders",
+    memory: "2GiB", // Options passed as the first argument!
+  },
+  ({ message, context }) => { ... } // Destructuring shim pattern
+);
+```
+
+> [!TIP]
+> **Memory Unit Caveat**: V1 accepted `"1GB"`. V2 types strongly prefer IEC units like `"1GiB"`, `"2GiB"`, etc.
+
+---
+
+## ⚠️ Common Property Translations
+
+| V1 Property | V2 Property | Notes |
+| :--- | :--- | :--- |
+| `memory` | `memory` | Use `"1GiB"` instead of `"1GB"`. |
+| `timeoutSeconds` | `timeoutSeconds` | Same. |
+| `ingressSettings` | `ingressSettings` | Same. |
+| `vpcConnector` | `vpcConnector` | Same. |
+| `vpcConnectorEgressSettings` | `vpcConnectorEgressSettings` | Same. |
+| `serviceAccount` | `serviceAccount` | Same. |
+| `secrets` | `secrets` | Same. |
+| `failurePolicy` | `retry` | Renamed to boolean `retry: true/false` in V2 Eventarc triggers. |
+
+---
+
+## 🔐 3. Migrating Environment Configurations (`functions.config()`)
+
+In V1, you used `functions.config()` to access environment configuration. In V2, this is replaced by **Parameterized Configuration**.
+
+### Deterministic Rules for Migration
+
+Follow these rules to ensure a deterministic and safe migration:
+
+#### Typing
+*   **Numbers**: If the value is used as a number, use `defineNumber`.
+*   **Secrets**: If the key contains "KEY", "SECRET", "TOKEN", or "PASSWORD", use `defineSecret()`.
+    *   *Note*: Secrets MUST be explicitly bound to the function that uses them in the options object (e.g., `{ secrets: [MY_SECRET] }`).
+*   **Lists**: Use `defineList` for comma-separated lists.
+*   **JSON**: Use `defineJSON` for JSON strings.
+*   **Buckets**: If the param is a storage bucket, set `input: 'BUCKET_PICKER'`.
+
+#### Initialization & Scope
+*   **Global Initialization**: If a variable was initialized globally in V1 (e.g., `const client = new Client(functions.config().key)`), you must split it to have declaration at global scope and initialization inside `onInit`:
+    ```typescript
+    import { onInit } from "firebase-functions/v2";
+    
+    const myKey = defineSecret("MY_KEY");
+    let client: Client;
+    
+    onInit(() => {
+      client = new Client(myKey.value());
+    });
+    ```
+
+#### Advanced Interpolation & Logic
+*   **String Interpolation**: Use the `expr` tagged template literal from `firebase-functions/params` (e.g., `expr`every ${period} days``) instead of standard template literals when constructing dynamic strings with parameters. Do NOT call `.value()` inside `expr`.
+*   **Logic Operators**: Use expressions like `projectID.equals('prod').thenElse(1, 0)` for logical operations instead of ternary operators on `.value()`.
+
+#### Built-ins
+*   Prefer built-in variables like `databaseURL`, `projectID`, `gcloudProject`, `storageBucket` rather than defining new params for these values.

--- a/skills/extension-to-functions-codebase/references/configuration-migration.md
+++ b/skills/extension-to-functions-codebase/references/configuration-migration.md
@@ -100,7 +100,7 @@ Follow these rules to ensure a deterministic and safe migration:
 #### Typing
 *   **Numbers**: If the value is used as a number, use `defineNumber`.
 *   **Secrets**: If the key contains "KEY", "SECRET", "TOKEN", or "PASSWORD", use `defineSecret()`.
-    *   *Note*: Secrets MUST be explicitly bound to the function that uses them in the options object (e.g., `{ secrets: [MY_SECRET] }`).
+    *   *Note*: Secrets MUST be explicitly bound to the function that uses them in the options object (e.g., `{ secrets: [myKey] }`).
 *   **Lists**: Use `defineList` for comma-separated lists.
 *   **JSON**: Use `defineJSON` for JSON strings.
 *   **Buckets**: If the param is a storage bucket, set `input: 'BUCKET_PICKER'`.
@@ -119,7 +119,7 @@ Follow these rules to ensure a deterministic and safe migration:
     ```
 
 #### Advanced Interpolation & Logic
-*   **String Interpolation**: Use the `expr` tagged template literal from `firebase-functions/params` (e.g., `expr`every ${period} days``) instead of standard template literals when constructing dynamic strings with parameters. Do NOT call `.value()` inside `expr`.
+*   **String Interpolation**: Use the `expr` tagged template literal from `firebase-functions/params` (e.g., `` `expr`every ${period} days` ``) instead of standard template literals when constructing dynamic strings with parameters. Do NOT call `.value()` inside `expr`.
 *   **Logic Operators**: Use expressions like `projectID.equals('prod').thenElse(1, 0)` for logical operations instead of ternary operators on `.value()`.
 
 #### Built-ins

--- a/skills/extension-to-functions-codebase/references/configuration-migration.md
+++ b/skills/extension-to-functions-codebase/references/configuration-migration.md
@@ -1,8 +1,11 @@
 # Migrating Runtime Configurations (runWith)
 
-In Firebase Functions V1, you configured runtime settings like memory, timeout, and service accounts using `.runWith()`. In V2, `.runWith()` is removed and replaced by a more flexible options system.
+In Firebase Functions V1, you configured runtime settings like memory, timeout,
+and service accounts using `.runWith()`. In V2, `.runWith()` is removed and
+replaced by a more flexible options system.
 
-You can configure V2 functions in two ways: **Globally** (for all functions in a file) or **Per-Function**.
+You can configure V2 functions in two ways: **Globally** (for all functions in a
+file) or **Per-Function**.
 
 ---
 
@@ -44,7 +47,8 @@ export const myFn = onRequest((req, res) => { ... });
 
 ## 🎯 2. Per-Function Configuration
 
-Pass the configuration object as the **first argument** to the V2 trigger function.
+Pass the configuration object as the **first argument** to the V2 trigger
+function.
 
 ### V1 Legacy
 
@@ -70,7 +74,8 @@ export const processOrder = onMessagePublished(
 ```
 
 > [!TIP]
-> **Memory Unit Caveat**: V1 accepted `"1GB"`. V2 types strongly prefer IEC units like `"1GiB"`, `"2GiB"`, etc.
+> **Memory Unit Caveat**: V1 accepted `"1GB"`. V2 types strongly prefer IEC
+> units like `"1GiB"`, `"2GiB"`, etc.
 
 ---
 
@@ -91,7 +96,8 @@ export const processOrder = onMessagePublished(
 
 ## 🔐 3. Migrating Environment Configurations (`functions.config()`)
 
-In V1, you used `functions.config()` to access environment configuration. In V2, this is replaced by **Parameterized Configuration**.
+In V1, you used `functions.config()` to access environment configuration. In V2,
+this is replaced by **Parameterized Configuration**.
 
 ### Deterministic Rules for Migration
 
@@ -100,15 +106,19 @@ Follow these rules to ensure a deterministic and safe migration:
 #### Typing
 
 - **Numbers**: If the value is used as a number, use `defineNumber`.
-- **Secrets**: If the key contains "KEY", "SECRET", "TOKEN", or "PASSWORD", use `defineSecret()`.
-  - *Note*: Secrets MUST be explicitly bound to the function that uses them in the options object (e.g., `{ secrets: [myKey] }`).
+- **Secrets**: If the key contains "KEY", "SECRET", "TOKEN", or "PASSWORD", use
+  `defineSecret()`.
+  - *Note*: Secrets MUST be explicitly bound to the function that uses them in
+    the options object (e.g., `{ secrets: [myKey] }`).
 - **Lists**: Use `defineList` for comma-separated lists.
 - **JSON**: Use `defineJSON` for JSON strings.
 - **Buckets**: If the param is a storage bucket, set `input: 'BUCKET_PICKER'`.
 
 #### Initialization & Scope
 
-- **Global Initialization**: If a variable was initialized globally in V1 (e.g., `const client = new Client(functions.config().key)`), you must split it to have declaration at global scope and initialization inside `onInit`:
+- **Global Initialization**: If a variable was initialized globally in V1 (e.g.,
+  `const client = new Client(functions.config().key)`), you must split it to
+  have declaration at global scope and initialization inside `onInit`:
   ```typescript
   import { onInit } from "firebase-functions/v2";
 
@@ -122,9 +132,15 @@ Follow these rules to ensure a deterministic and safe migration:
 
 #### Advanced Interpolation & Logic
 
-- **String Interpolation**: Use the `expr` tagged template literal from `firebase-functions/params` (e.g., `` `expr`every ${period} days` ``) instead of standard template literals when constructing dynamic strings with parameters. Do NOT call `.value()` inside `expr`.
-- **Logic Operators**: Use expressions like `projectID.equals('prod').thenElse(1, 0)` for logical operations instead of ternary operators on `.value()`.
+- **String Interpolation**: Use the `expr` tagged template literal from
+  `firebase-functions/params` (e.g., `` `expr`every ${period} days` ``) instead
+  of standard template literals when constructing dynamic strings with
+  parameters. Do NOT call `.value()` inside `expr`.
+- **Logic Operators**: Use expressions like
+  `projectID.equals('prod').thenElse(1, 0)` for logical operations instead of
+  ternary operators on `.value()`.
 
 #### Built-ins
 
-- Prefer built-in variables like `databaseURL`, `projectID`, `gcloudProject`, `storageBucket` rather than defining new params for these values.
+- Prefer built-in variables like `databaseURL`, `projectID`, `gcloudProject`,
+  `storageBucket` rather than defining new params for these values.

--- a/skills/extension-to-functions-codebase/references/configuration-migration.md
+++ b/skills/extension-to-functions-codebase/references/configuration-migration.md
@@ -109,16 +109,25 @@ this is replaced by **Parameterized Configuration**.
 
 Follow these rules to ensure a deterministic and safe migration:
 
-#### Typing
+#### Typing & Exports
 
-- **Numbers**: If the value is used as a number, use `defineNumber`.
+- **Numbers**: If the value is used as a number, use `defineInt` or
+  `defineNumber`.
 - **Secrets**: If the key contains "KEY", "SECRET", "TOKEN", or "PASSWORD", use
-  `defineSecret()`.
+  `defineSecret()` or `defineJsonSecret()`.
   - *Note*: Secrets MUST be explicitly bound to the function that uses them in
-    the options object (e.g., `{ secrets: [myKey] }`).
+    the options object (e.g., `{ secrets: [myKey, myJsonSecret] }`). Both
+    `SecretParam` and `JsonSecretParam` are supported in the `secrets` array.
 - **Lists**: Use `defineList` for comma-separated lists.
 - **JSON**: Use `defineJSON` for JSON strings.
-- **Buckets**: If the param is a storage bucket, set `input: 'BUCKET_PICKER'`.
+- **Buckets**: If the param is a storage bucket, set `input: { text: {} }` or
+  bucket selector.
+- **Input Validation**: Use `nonEmpty: true` inside `input.text` or
+  `input.multiSelect` to enforce non-empty parameter input during CLI prompting
+  (e.g. `defineString("PARAM", { input: { text: { nonEmpty: true } } })`).
+- **Type Annotations**: Import parameter types directly from
+  `firebase-functions/params` (e.g.
+  `import type { StringParam, SecretParam, JsonSecretParam, IntParam } from "firebase-functions/params"`).
 
 #### Initialization & Scope
 

--- a/skills/extension-to-functions-codebase/references/configuration-migration.md
+++ b/skills/extension-to-functions-codebase/references/configuration-migration.md
@@ -1,59 +1,26 @@
 # Migrating Runtime Configurations (runWith)
 
-In Firebase Functions V1, you configured runtime settings like memory, timeout,
-and service accounts using `.runWith()`. In V2, `.runWith()` is removed and
-replaced by a more flexible options system.
+In Cloud Functions for Firebase V1 (`firebase-functions/v1`), you configured
+runtime settings like memory, timeout, and service accounts using `.runWith()`.
+In V2 (`firebase-functions/v2`), `.runWith()` is removed and replaced by a more
+flexible options system.
 
-You can configure V2 functions in two ways: **Globally** (for all functions in a
-file) or **Per-Function**.
+You can configure V2 functions in two ways: **Per-Function** (passing an options
+object directly to the trigger) or **Globally** (`setGlobalOptions` at the top
+of a file).
 
 ______________________________________________________________________
 
-## 🌍 1. Global Configuration (`setGlobalOptions`)
+## 1. Per-Function Configuration
 
-Use `setGlobalOptions` at the top of your file to set defaults for all functions
-defined after it.
+Pass the configuration options object as the **first argument** to the V2
+trigger function. Per-function options always override any global defaults.
 
 ### V1 Legacy
 
 ```typescript
 import * as functions from "firebase-functions";
 
-export const myFn = functions
-  .runWith({
-    memory: "1GB",
-    timeoutSeconds: 120,
-    serviceAccount: "custom-sa@my-project.iam.gserviceaccount.com",
-  })
-  .https.onRequest((req, res) => { ... });
-```
-
-### V2 Modern Equivalent
-
-```typescript
-import { setGlobalOptions } from "firebase-functions/v2";
-import { onRequest } from "firebase-functions/v2/https";
-
-// Set global defaults for this file
-setGlobalOptions({
-  memory: "1GiB", // Note: GiB instead of GB is preferred in V2 types
-  timeoutSeconds: 120,
-  serviceAccount: "custom-sa@my-project.iam.gserviceaccount.com",
-});
-
-export const myFn = onRequest((req, res) => { ... });
-```
-
-______________________________________________________________________
-
-## 🎯 2. Per-Function Configuration
-
-Pass the configuration object as the **first argument** to the V2 trigger
-function.
-
-### V1 Legacy
-
-```typescript
 export const processOrder = functions
   .runWith({ memory: "2GB" })
   .pubsub.topic("orders")
@@ -79,7 +46,46 @@ export const processOrder = onMessagePublished(
 
 ______________________________________________________________________
 
-## ⚠️ Common Property Translations
+## 2. Global Configuration (`setGlobalOptions`)
+
+Use `setGlobalOptions` at the top of your file when all or most functions in
+that file share the exact same runtime requirements (e.g. identical region,
+memory allocation, timeout, or service account). Individual functions can still
+override specific settings by declaring per-function options.
+
+### V1 Legacy
+
+```typescript
+import * as functions from "firebase-functions";
+
+export const myFn = functions
+  .runWith({
+    memory: "1GB",
+    timeoutSeconds: 120,
+    serviceAccount: "custom-sa@my-project.iam.gserviceaccount.com",
+  })
+  .https.onRequest((req, res) => { ... });
+```
+
+### V2 Modern Equivalent
+
+```typescript
+import { setGlobalOptions } from "firebase-functions/v2";
+import { onRequest } from "firebase-functions/v2/https";
+
+// Set global defaults for all functions defined after this call in this file
+setGlobalOptions({
+  memory: "1GiB", // Note: GiB instead of GB is preferred in V2 types
+  timeoutSeconds: 120,
+  serviceAccount: "custom-sa@my-project.iam.gserviceaccount.com",
+});
+
+export const myFn = onRequest((req, res) => { ... });
+```
+
+______________________________________________________________________
+
+## Common Property Translations
 
 | V1 Property                  | V2 Property                  | Notes                                                           |
 | :--------------------------- | :--------------------------- | :-------------------------------------------------------------- |
@@ -94,7 +100,7 @@ ______________________________________________________________________
 
 ______________________________________________________________________
 
-## 🔐 3. Migrating Environment Configurations (`functions.config()`)
+## 3. Migrating Environment Configurations (`functions.config()`)
 
 In V1, you used `functions.config()` to access environment configuration. In V2,
 this is replaced by **Parameterized Configuration**.

--- a/skills/extension-to-functions-codebase/references/configuration-migration.md
+++ b/skills/extension-to-functions-codebase/references/configuration-migration.md
@@ -7,11 +7,12 @@ replaced by a more flexible options system.
 You can configure V2 functions in two ways: **Globally** (for all functions in a
 file) or **Per-Function**.
 
----
+______________________________________________________________________
 
 ## 🌍 1. Global Configuration (`setGlobalOptions`)
 
-Use `setGlobalOptions` at the top of your file to set defaults for all functions defined after it.
+Use `setGlobalOptions` at the top of your file to set defaults for all functions
+defined after it.
 
 ### V1 Legacy
 
@@ -43,7 +44,7 @@ setGlobalOptions({
 export const myFn = onRequest((req, res) => { ... });
 ```
 
----
+______________________________________________________________________
 
 ## 🎯 2. Per-Function Configuration
 
@@ -73,26 +74,25 @@ export const processOrder = onMessagePublished(
 );
 ```
 
-> [!TIP]
-> **Memory Unit Caveat**: V1 accepted `"1GB"`. V2 types strongly prefer IEC
-> units like `"1GiB"`, `"2GiB"`, etc.
+> [!TIP] **Memory Unit Caveat**: V1 accepted `"1GB"`. V2 types strongly prefer
+> IEC units like `"1GiB"`, `"2GiB"`, etc.
 
----
+______________________________________________________________________
 
 ## ⚠️ Common Property Translations
 
-| V1 Property | V2 Property | Notes |
-| :--- | :--- | :--- |
-| `memory` | `memory` | Use `"1GiB"` instead of `"1GB"`. |
-| `timeoutSeconds` | `timeoutSeconds` | Same. |
-| `ingressSettings` | `ingressSettings` | Same. |
-| `vpcConnector` | `vpcConnector` | Same. |
-| `vpcConnectorEgressSettings` | `vpcConnectorEgressSettings` | Same. |
-| `serviceAccount` | `serviceAccount` | Same. |
-| `secrets` | `secrets` | Same. |
-| `failurePolicy` | `retry` | Renamed to boolean `retry: true/false` in V2 Eventarc triggers. |
+| V1 Property                  | V2 Property                  | Notes                                                           |
+| :--------------------------- | :--------------------------- | :-------------------------------------------------------------- |
+| `memory`                     | `memory`                     | Use `"1GiB"` instead of `"1GB"`.                                |
+| `timeoutSeconds`             | `timeoutSeconds`             | Same.                                                           |
+| `ingressSettings`            | `ingressSettings`            | Same.                                                           |
+| `vpcConnector`               | `vpcConnector`               | Same.                                                           |
+| `vpcConnectorEgressSettings` | `vpcConnectorEgressSettings` | Same.                                                           |
+| `serviceAccount`             | `serviceAccount`             | Same.                                                           |
+| `secrets`                    | `secrets`                    | Same.                                                           |
+| `failurePolicy`              | `retry`                      | Renamed to boolean `retry: true/false` in V2 Eventarc triggers. |
 
----
+______________________________________________________________________
 
 ## 🔐 3. Migrating Environment Configurations (`functions.config()`)
 

--- a/skills/extension-to-functions-codebase/references/configuration-migration.md
+++ b/skills/extension-to-functions-codebase/references/configuration-migration.md
@@ -1,8 +1,11 @@
 # Migrating Runtime Configurations (runWith)
 
-In Firebase Functions V1, you configured runtime settings like memory, timeout, and service accounts using `.runWith()`. In V2, `.runWith()` is removed and replaced by a more flexible options system.
+In Firebase Functions V1, you configured runtime settings like memory, timeout,
+and service accounts using `.runWith()`. In V2, `.runWith()` is removed and
+replaced by a more flexible options system.
 
-You can configure V2 functions in two ways: **Globally** (for all functions in a file) or **Per-Function**.
+You can configure V2 functions in two ways: **Globally** (for all functions in a
+file) or **Per-Function**.
 
 ---
 
@@ -44,7 +47,8 @@ export const myFn = onRequest((req, res) => { ... });
 
 ## 🎯 2. Per-Function Configuration
 
-Pass the configuration object as the **first argument** to the V2 trigger function.
+Pass the configuration object as the **first argument** to the V2 trigger
+function.
 
 ### V1 Legacy
 
@@ -91,7 +95,8 @@ export const processOrder = onMessagePublished(
 
 ## 🔐 3. Migrating Environment Configurations (`functions.config()`)
 
-In V1, you used `functions.config()` to access environment configuration. In V2, this is replaced by **Parameterized Configuration**.
+In V1, you used `functions.config()` to access environment configuration. In V2,
+this is replaced by **Parameterized Configuration**.
 
 ### Deterministic Rules for Migration
 

--- a/skills/extension-to-functions-codebase/references/destructuring-shim.md
+++ b/skills/extension-to-functions-codebase/references/destructuring-shim.md
@@ -7,7 +7,7 @@ business logic.
 
 ______________________________________________________________________
 
-## 🛠️ How it Works
+## How it Works
 
 When you migrate a V1 function to V2, the signature changes from two parameters
 `(data, context)` to a single `CloudEvent` object.
@@ -39,7 +39,7 @@ export const processOrder = onMessagePublished("orders", ({ message, context }) 
 });
 ```
 
-### 🧠 Why This Works
+### Why This Works
 
 The Firebase Functions SDK uses a utility called `addV1Compat` to attach these
 properties via **Lazy Getters** on the `CloudEvent` object for standard event
@@ -50,7 +50,7 @@ supported by the SDK.
 
 ______________________________________________________________________
 
-## 📖 Provider Mapping Examples
+## Provider Mapping Examples
 
 Here are the exact destructuring patterns for every supported V2 provider:
 
@@ -95,14 +95,18 @@ Here are the exact destructuring patterns for every supported V2 provider:
 
 ______________________________________________________________________
 
-## 🛡️ Best Practices for AI Agents
+## Best Practices for AI Agents
 
-1. **Do NOT attempt to rewrite variable access inside the body.** It is
-   error-prone and time-consuming.
-1. **Rely on the shim by default.** Only attempt a pure V2 rewrite if the user
-   explicitly asks for "clean-room" modernization.
+1. **Rely on the shim for complex logic.** When converting functions with
+   extensive or complex internal business logic, prefer using the destructuring
+   shim (`{ shimmedKey, context }`) by default to minimize risk and avoid
+   introducing subtle bugs.
+1. **Clean-room rewrites.** If the function body is very simple, or if the user
+   explicitly asks for a comprehensive code modernization/cleanup, you can ask
+   the user if they would prefer a full clean-room rewrite to native V2 event
+   properties.
 1. **Always type-check (`tsc`) after the rewrite.** If the types are wrong, the
-   shim might not be fully supported for that specific provider yet!
+   shim might not be fully supported for that specific provider yet.
 1. **HTTPS Callables (Flattened Context)**: Unlike event triggers, Callables do
    **not** use `V1Compat` or a `context` object. Instead, all context properties
    are flattened onto the request object.
@@ -111,40 +115,8 @@ ______________________________________________________________________
 
 ______________________________________________________________________
 
-## 🔗 Related Migrations
+## Related Migrations
 
-Migrating event signatures is only one part of moving from V1 to V2. Another
-critical area is configuration management.
-
-### Parameterized Configuration
-
-If your functions use `functions.config()`, you should migrate to the new
-**Parameterized Configuration** system in V2. The destructuring shim handles
-event signatures, but it does not shim `functions.config()`.
-
-#### How to Migrate:
-
-1. **Identify Usages**: Search for `functions.config().path.to.value`.
-1. **Define Parameters**: At the top of your file, define the parameter using
-   the appropriate primitive from `firebase-functions/params` (available types
-   include `defineString`, `defineSecret`, `defineInt`, `defineBoolean`,
-   `defineList`, and `defineJSON`):
-   ```typescript
-   import { defineString, defineSecret } from "firebase-functions/params";
-
-   const stripeKey = defineSecret("STRIPE_KEY");
-   const apiDomain = defineString("API_DOMAIN");
-   ```
-1. **Access Values**: Replace the V1 call with the `.value()` method of the
-   defined parameter:
-   - **V1**: `const key = functions.config().stripe.key;`
-   - **V2**: `const key = stripeKey.value();`
-
-> [!NOTE] When you migrate a function to V2 (even with the destructuring shim),
-> `functions.config()` will return `undefined` unless you have explicitly set up
-> environment variables or are running in a specific emulation mode.
-> Parameterized configuration is the standard and recommended way to handle this
-> in V2.
-
-For a complete guide and deterministic rules on how to migrate configurations,
-refer to [configuration-migration.md](configuration-migration.md).
+For a complete guide on migrating runtime options and `functions.config()` to V2
+Parameterized Configuration, refer to
+[configuration-migration.md](configuration-migration.md).

--- a/skills/extension-to-functions-codebase/references/destructuring-shim.md
+++ b/skills/extension-to-functions-codebase/references/destructuring-shim.md
@@ -1,0 +1,119 @@
+# Architectural Deep Dive: Destructuring Compatibility Shim
+
+The Destructuring Compatibility Shim is a **Zero-Touch Logic Migration** pattern. It allows you to upgrade a function's infrastructure to V2 (and take advantage of GCF 2nd Gen runtimes) without rewriting any of your internal business logic.
+
+---
+
+## 🛠️ How it Works
+
+When you migrate a V1 function to V2, the signature changes from two parameters `(data, context)` to a single `CloudEvent` object.
+
+Instead of manually rewriting all usages of `context.params` or `message.json` inside the function, you use JavaScript's **Object Destructuring** in the signature.
+
+### Example Transformation
+
+#### Step 1: Legacy V1
+
+```typescript
+export const processOrder = functions.pubsub.topic("orders").onPublish((message, context) => {
+  const orderId = message.json.id;
+  console.log(`Processing order ${orderId} at ${context.timestamp}`);
+});
+```
+
+#### Step 2: Modern V2 + Shim
+
+We change the trigger to `onMessagePublished`, and instead of accepting `event`, we destructure `{ message, context }` directly:
+
+```typescript
+export const processOrder = onMessagePublished("orders", ({ message, context }) => {
+  const orderId = message.json.id; // Legacy logic remains untouched!
+  console.log(`Processing order ${orderId} at ${context.timestamp}`);
+});
+```
+
+### 🧠 Why This Works
+
+The Firebase Functions SDK uses a utility called `addV1Compat` to attach these properties via **Lazy Getters** on the `CloudEvent` object for standard event triggers. When you attempt to destructure `{ message, context }` from the event, the SDK transparently maps the V2 event properties back into V1-compatible objects on the fly! This feature is available in modern V2 environments supported by the SDK.
+
+---
+
+## 📖 Provider Mapping Examples
+
+Here are the exact destructuring patterns for every supported V2 provider:
+
+### 1. Cloud Firestore
+
+*   **Created / Deleted** triggers:
+    ```typescript
+    // V2: onDocumentCreated, onDocumentDeleted
+    export const processDoc = onDocumentCreated("users/{id}", ({ snapshot, context }) => { ... });
+    ```
+*   **Updated / Written** triggers:
+    ```typescript
+    // V2: onDocumentUpdated, onDocumentWritten
+    export const processDoc = onDocumentUpdated("users/{id}", ({ change, context }) => { ... });
+    ```
+
+### 2. Cloud Storage
+
+*   **All** triggers (`onObjectFinalized`, `onObjectDeleted`, `onObjectArchived`, `onObjectMetadataUpdated`):
+    ```typescript
+    export const processFile = onObjectFinalized(({ object, context }) => { ... });
+    ```
+
+### 3. Realtime Database
+
+*   **Created / Deleted** triggers:
+    ```typescript
+    export const processData = onValueCreated("/users/{id}", ({ snapshot, context }) => { ... });
+    ```
+*   **Updated / Written** triggers:
+    ```typescript
+    export const processData = onValueWritten("/users/{id}", ({ change, context }) => { ... });
+    ```
+
+### 4. Remote Config
+
+*   **Updated** triggers:
+    ```typescript
+    export const processConfig = onConfigUpdated(({ version, context }) => { ... });
+    ```
+
+---
+
+## 🛡️ Best Practices for AI Agents
+
+1.  **Do NOT attempt to rewrite variable access inside the body.** It is error-prone and time-consuming.
+2.  **Rely on the shim by default.** Only attempt a pure V2 rewrite if the user explicitly asks for "clean-room" modernization.
+3.  **Always type-check (`tsc`) after the rewrite.** If the types are wrong, the shim might not be fully supported for that specific provider yet!
+4.  **HTTPS Callables (Flattened Context)**: Unlike event triggers, Callables do **not** use `V1Compat` or a `context` object. Instead, all context properties are flattened onto the request object. 
+    *   **V1 Priority**: `(data, context) => { ... }`
+    *   **V2 Equivalent**: `({ data, auth, app }) => { ... }`
+
+---
+
+## 🔗 Related Migrations
+
+Migrating event signatures is only one part of moving from V1 to V2. Another critical area is configuration management.
+
+### Parameterized Configuration
+If your functions use `functions.config()`, you should migrate to the new **Parameterized Configuration** system in V2. The destructuring shim handles event signatures, but it does not shim `functions.config()`.
+
+#### How to Migrate:
+1.  **Identify Usages**: Search for `functions.config().path.to.value`.
+2.  **Define Parameters**: At the top of your file, define the parameter using the appropriate primitive from `firebase-functions/params` (available types include `defineString`, `defineSecret`, `defineInt`, `defineBoolean`, `defineList`, and `defineJSON`):
+    ```typescript
+    import { defineString, defineSecret } from "firebase-functions/params";
+    
+    const stripeKey = defineSecret("STRIPE_KEY");
+    const apiDomain = defineString("API_DOMAIN");
+    ```
+3.  **Access Values**: Replace the V1 call with the `.value()` method of the defined parameter:
+    *   **V1**: `const key = functions.config().stripe.key;`
+    *   **V2**: `const key = stripeKey.value();`
+
+> [!NOTE]
+> When you migrate a function to V2 (even with the destructuring shim), `functions.config()` will return `undefined` unless you have explicitly set up environment variables or are running in a specific emulation mode. Parameterized configuration is the standard and recommended way to handle this in V2.
+
+For a complete guide and deterministic rules on how to migrate configurations, refer to [configuration-migration.md](configuration-migration.md).

--- a/skills/extension-to-functions-codebase/references/destructuring-shim.md
+++ b/skills/extension-to-functions-codebase/references/destructuring-shim.md
@@ -1,6 +1,9 @@
 # Architectural Deep Dive: Destructuring Compatibility Shim
 
-The Destructuring Compatibility Shim is a **Zero-Touch Logic Migration** pattern. It allows you to upgrade a function's infrastructure to V2 (and take advantage of GCF 2nd Gen runtimes) without rewriting any of your internal business logic.
+The Destructuring Compatibility Shim is a **Zero-Touch Logic Migration**
+pattern. It allows you to upgrade a function's infrastructure to V2 (and take
+advantage of GCF 2nd Gen runtimes) without rewriting any of your internal
+business logic.
 
 ---
 
@@ -57,7 +60,8 @@ Here are the exact destructuring patterns for every supported V2 provider:
 
 ### 2. Cloud Storage
 
-- **All** triggers (`onObjectFinalized`, `onObjectDeleted`, `onObjectArchived`, `onObjectMetadataUpdated`):
+- **All** triggers (`onObjectFinalized`, `onObjectDeleted`, `onObjectArchived`,
+  `onObjectMetadataUpdated`):
   ```typescript
   export const processFile = onObjectFinalized(({ object, context }) => { ... });
   ```
@@ -84,10 +88,15 @@ Here are the exact destructuring patterns for every supported V2 provider:
 
 ## 🛡️ Best Practices for AI Agents
 
-1. **Do NOT attempt to rewrite variable access inside the body.** It is error-prone and time-consuming.
-2. **Rely on the shim by default.** Only attempt a pure V2 rewrite if the user explicitly asks for "clean-room" modernization.
-3. **Always type-check (`tsc`) after the rewrite.** If the types are wrong, the shim might not be fully supported for that specific provider yet!
-4. **HTTPS Callables (Flattened Context)**: Unlike event triggers, Callables do **not** use `V1Compat` or a `context` object. Instead, all context properties are flattened onto the request object.
+1. **Do NOT attempt to rewrite variable access inside the body.** It is
+  error-prone and time-consuming.
+2. **Rely on the shim by default.** Only attempt a pure V2 rewrite if the user
+  explicitly asks for "clean-room" modernization.
+3. **Always type-check (`tsc`) after the rewrite.** If the types are wrong, the
+  shim might not be fully supported for that specific provider yet!
+4. **HTTPS Callables (Flattened Context)**: Unlike event triggers, Callables do
+  **not** use `V1Compat` or a `context` object. Instead, all context properties
+  are flattened onto the request object.
    - **V1 Priority**: `(data, context) => { ... }`
    - **V2 Equivalent**: `({ data, auth, app }) => { ... }`
 
@@ -95,27 +104,39 @@ Here are the exact destructuring patterns for every supported V2 provider:
 
 ## 🔗 Related Migrations
 
-Migrating event signatures is only one part of moving from V1 to V2. Another critical area is configuration management.
+Migrating event signatures is only one part of moving from V1 to V2. Another
+critical area is configuration management.
 
 ### Parameterized Configuration
 
-If your functions use `functions.config()`, you should migrate to the new **Parameterized Configuration** system in V2. The destructuring shim handles event signatures, but it does not shim `functions.config()`.
+If your functions use `functions.config()`, you should migrate to the new
+**Parameterized Configuration** system in V2. The destructuring shim handles
+event signatures, but it does not shim `functions.config()`.
 
 #### How to Migrate:
 
 1. **Identify Usages**: Search for `functions.config().path.to.value`.
-2. **Define Parameters**: At the top of your file, define the parameter using the appropriate primitive from `firebase-functions/params` (available types include `defineString`, `defineSecret`, `defineInt`, `defineBoolean`, `defineList`, and `defineJSON`):
+2. **Define Parameters**: At the top of your file, define the parameter using
+  the appropriate primitive from `firebase-functions/params` (available types
+  include `defineString`, `defineSecret`, `defineInt`, `defineBoolean`,
+  `defineList`, and `defineJSON`):
    ```typescript
    import { defineString, defineSecret } from "firebase-functions/params";
 
    const stripeKey = defineSecret("STRIPE_KEY");
    const apiDomain = defineString("API_DOMAIN");
    ```
-3. **Access Values**: Replace the V1 call with the `.value()` method of the defined parameter:
+3. **Access Values**: Replace the V1 call with the `.value()` method of the
+  defined parameter:
    - **V1**: `const key = functions.config().stripe.key;`
    - **V2**: `const key = stripeKey.value();`
 
 > [!NOTE]
-> When you migrate a function to V2 (even with the destructuring shim), `functions.config()` will return `undefined` unless you have explicitly set up environment variables or are running in a specific emulation mode. Parameterized configuration is the standard and recommended way to handle this in V2.
+> When you migrate a function to V2 (even with the destructuring shim),
+> `functions.config()` will return `undefined` unless you have explicitly set up
+> environment variables or are running in a specific emulation mode.
+> Parameterized configuration is the standard and recommended way to handle this
+> in V2.
 
-For a complete guide and deterministic rules on how to migrate configurations, refer to [configuration-migration.md](configuration-migration.md).
+For a complete guide and deterministic rules on how to migrate configurations,
+refer to [configuration-migration.md](configuration-migration.md).

--- a/skills/extension-to-functions-codebase/references/destructuring-shim.md
+++ b/skills/extension-to-functions-codebase/references/destructuring-shim.md
@@ -5,13 +5,16 @@ pattern. It allows you to upgrade a function's infrastructure to V2 (and take
 advantage of GCF 2nd Gen runtimes) without rewriting any of your internal
 business logic.
 
----
+______________________________________________________________________
 
 ## 🛠️ How it Works
 
-When you migrate a V1 function to V2, the signature changes from two parameters `(data, context)` to a single `CloudEvent` object.
+When you migrate a V1 function to V2, the signature changes from two parameters
+`(data, context)` to a single `CloudEvent` object.
 
-Instead of manually rewriting all usages of `context.params` or `message.json` inside the function, you use JavaScript's **Object Destructuring** in the signature.
+Instead of manually rewriting all usages of `context.params` or `message.json`
+inside the function, you use JavaScript's **Object Destructuring** in the
+signature.
 
 ### Example Transformation
 
@@ -26,7 +29,8 @@ export const processOrder = functions.pubsub.topic("orders").onPublish((message,
 
 #### Step 2: Modern V2 + Shim
 
-We change the trigger to `onMessagePublished`, and instead of accepting `event`, we destructure `{ message, context }` directly:
+We change the trigger to `onMessagePublished`, and instead of accepting `event`,
+we destructure `{ message, context }` directly:
 
 ```typescript
 export const processOrder = onMessagePublished("orders", ({ message, context }) => {
@@ -37,9 +41,14 @@ export const processOrder = onMessagePublished("orders", ({ message, context }) 
 
 ### 🧠 Why This Works
 
-The Firebase Functions SDK uses a utility called `addV1Compat` to attach these properties via **Lazy Getters** on the `CloudEvent` object for standard event triggers. When you attempt to destructure `{ message, context }` from the event, the SDK transparently maps the V2 event properties back into V1-compatible objects on the fly! This feature is available in modern V2 environments supported by the SDK.
+The Firebase Functions SDK uses a utility called `addV1Compat` to attach these
+properties via **Lazy Getters** on the `CloudEvent` object for standard event
+triggers. When you attempt to destructure `{ message, context }` from the event,
+the SDK transparently maps the V2 event properties back into V1-compatible
+objects on the fly! This feature is available in modern V2 environments
+supported by the SDK.
 
----
+______________________________________________________________________
 
 ## 📖 Provider Mapping Examples
 
@@ -84,23 +93,23 @@ Here are the exact destructuring patterns for every supported V2 provider:
   export const processConfig = onConfigUpdated(({ version, context }) => { ... });
   ```
 
----
+______________________________________________________________________
 
 ## 🛡️ Best Practices for AI Agents
 
 1. **Do NOT attempt to rewrite variable access inside the body.** It is
-  error-prone and time-consuming.
-2. **Rely on the shim by default.** Only attempt a pure V2 rewrite if the user
-  explicitly asks for "clean-room" modernization.
-3. **Always type-check (`tsc`) after the rewrite.** If the types are wrong, the
-  shim might not be fully supported for that specific provider yet!
-4. **HTTPS Callables (Flattened Context)**: Unlike event triggers, Callables do
-  **not** use `V1Compat` or a `context` object. Instead, all context properties
-  are flattened onto the request object.
+   error-prone and time-consuming.
+1. **Rely on the shim by default.** Only attempt a pure V2 rewrite if the user
+   explicitly asks for "clean-room" modernization.
+1. **Always type-check (`tsc`) after the rewrite.** If the types are wrong, the
+   shim might not be fully supported for that specific provider yet!
+1. **HTTPS Callables (Flattened Context)**: Unlike event triggers, Callables do
+   **not** use `V1Compat` or a `context` object. Instead, all context properties
+   are flattened onto the request object.
    - **V1 Priority**: `(data, context) => { ... }`
    - **V2 Equivalent**: `({ data, auth, app }) => { ... }`
 
----
+______________________________________________________________________
 
 ## 🔗 Related Migrations
 
@@ -116,23 +125,22 @@ event signatures, but it does not shim `functions.config()`.
 #### How to Migrate:
 
 1. **Identify Usages**: Search for `functions.config().path.to.value`.
-2. **Define Parameters**: At the top of your file, define the parameter using
-  the appropriate primitive from `firebase-functions/params` (available types
-  include `defineString`, `defineSecret`, `defineInt`, `defineBoolean`,
-  `defineList`, and `defineJSON`):
+1. **Define Parameters**: At the top of your file, define the parameter using
+   the appropriate primitive from `firebase-functions/params` (available types
+   include `defineString`, `defineSecret`, `defineInt`, `defineBoolean`,
+   `defineList`, and `defineJSON`):
    ```typescript
    import { defineString, defineSecret } from "firebase-functions/params";
 
    const stripeKey = defineSecret("STRIPE_KEY");
    const apiDomain = defineString("API_DOMAIN");
    ```
-3. **Access Values**: Replace the V1 call with the `.value()` method of the
-  defined parameter:
+1. **Access Values**: Replace the V1 call with the `.value()` method of the
+   defined parameter:
    - **V1**: `const key = functions.config().stripe.key;`
    - **V2**: `const key = stripeKey.value();`
 
-> [!NOTE]
-> When you migrate a function to V2 (even with the destructuring shim),
+> [!NOTE] When you migrate a function to V2 (even with the destructuring shim),
 > `functions.config()` will return `undefined` unless you have explicitly set up
 > environment variables or are running in a specific emulation mode.
 > Parameterized configuration is the standard and recommended way to handle this

--- a/skills/extension-to-functions-codebase/references/destructuring-shim.md
+++ b/skills/extension-to-functions-codebase/references/destructuring-shim.md
@@ -1,6 +1,9 @@
 # Architectural Deep Dive: Destructuring Compatibility Shim
 
-The Destructuring Compatibility Shim is a **Zero-Touch Logic Migration** pattern. It allows you to upgrade a function's infrastructure to V2 (and take advantage of GCF 2nd Gen runtimes) without rewriting any of your internal business logic.
+The Destructuring Compatibility Shim is a **Zero-Touch Logic Migration**
+pattern. It allows you to upgrade a function's infrastructure to V2 (and take
+advantage of GCF 2nd Gen runtimes) without rewriting any of your internal
+business logic.
 
 ---
 
@@ -95,10 +98,13 @@ Here are the exact destructuring patterns for every supported V2 provider:
 
 ## 🔗 Related Migrations
 
-Migrating event signatures is only one part of moving from V1 to V2. Another critical area is configuration management.
+Migrating event signatures is only one part of moving from V1 to V2. Another
+critical area is configuration management.
 
 ### Parameterized Configuration
-If your functions use `functions.config()`, you should migrate to the new **Parameterized Configuration** system in V2. The destructuring shim handles event signatures, but it does not shim `functions.config()`.
+If your functions use `functions.config()`, you should migrate to the new
+**Parameterized Configuration** system in V2. The destructuring shim handles
+event signatures, but it does not shim `functions.config()`.
 
 #### How to Migrate:
 1.  **Identify Usages**: Search for `functions.config().path.to.value`.
@@ -116,4 +122,5 @@ If your functions use `functions.config()`, you should migrate to the new **Para
 > [!NOTE]
 > When you migrate a function to V2 (even with the destructuring shim), `functions.config()` will return `undefined` unless you have explicitly set up environment variables or are running in a specific emulation mode. Parameterized configuration is the standard and recommended way to handle this in V2.
 
-For a complete guide and deterministic rules on how to migrate configurations, refer to [configuration-migration.md](configuration-migration.md).
+For a complete guide and deterministic rules on how to migrate configurations,
+refer to [configuration-migration.md](configuration-migration.md).

--- a/skills/extension-to-functions-codebase/references/destructuring-shim.md
+++ b/skills/extension-to-functions-codebase/references/destructuring-shim.md
@@ -5,13 +5,16 @@ pattern. It allows you to upgrade a function's infrastructure to V2 (and take
 advantage of GCF 2nd Gen runtimes) without rewriting any of your internal
 business logic.
 
----
+______________________________________________________________________
 
 ## 🛠️ How it Works
 
-When you migrate a V1 function to V2, the signature changes from two parameters `(data, context)` to a single `CloudEvent` object.
+When you migrate a V1 function to V2, the signature changes from two parameters
+`(data, context)` to a single `CloudEvent` object.
 
-Instead of manually rewriting all usages of `context.params` or `message.json` inside the function, you use JavaScript's **Object Destructuring** in the signature.
+Instead of manually rewriting all usages of `context.params` or `message.json`
+inside the function, you use JavaScript's **Object Destructuring** in the
+signature.
 
 ### Example Transformation
 
@@ -26,7 +29,8 @@ export const processOrder = functions.pubsub.topic("orders").onPublish((message,
 
 #### Step 2: Modern V2 + Shim
 
-We change the trigger to `onMessagePublished`, and instead of accepting `event`, we destructure `{ message, context }` directly:
+We change the trigger to `onMessagePublished`, and instead of accepting `event`,
+we destructure `{ message, context }` directly:
 
 ```typescript
 export const processOrder = onMessagePublished("orders", ({ message, context }) => {
@@ -37,9 +41,14 @@ export const processOrder = onMessagePublished("orders", ({ message, context }) 
 
 ### 🧠 Why This Works
 
-The Firebase Functions SDK uses a utility called `addV1Compat` to attach these properties via **Lazy Getters** on the `CloudEvent` object for standard event triggers. When you attempt to destructure `{ message, context }` from the event, the SDK transparently maps the V2 event properties back into V1-compatible objects on the fly! This feature is available in modern V2 environments supported by the SDK.
+The Firebase Functions SDK uses a utility called `addV1Compat` to attach these
+properties via **Lazy Getters** on the `CloudEvent` object for standard event
+triggers. When you attempt to destructure `{ message, context }` from the event,
+the SDK transparently maps the V2 event properties back into V1-compatible
+objects on the fly! This feature is available in modern V2 environments
+supported by the SDK.
 
----
+______________________________________________________________________
 
 ## 📖 Provider Mapping Examples
 
@@ -47,54 +56,60 @@ Here are the exact destructuring patterns for every supported V2 provider:
 
 ### 1. Cloud Firestore
 
-*   **Created / Deleted** triggers:
-    ```typescript
-    // V2: onDocumentCreated, onDocumentDeleted
-    export const processDoc = onDocumentCreated("users/{id}", ({ snapshot, context }) => { ... });
-    ```
-*   **Updated / Written** triggers:
-    ```typescript
-    // V2: onDocumentUpdated, onDocumentWritten
-    export const processDoc = onDocumentUpdated("users/{id}", ({ change, context }) => { ... });
-    ```
+- **Created / Deleted** triggers:
+  ```typescript
+  // V2: onDocumentCreated, onDocumentDeleted
+  export const processDoc = onDocumentCreated("users/{id}", ({ snapshot, context }) => { ... });
+  ```
+- **Updated / Written** triggers:
+  ```typescript
+  // V2: onDocumentUpdated, onDocumentWritten
+  export const processDoc = onDocumentUpdated("users/{id}", ({ change, context }) => { ... });
+  ```
 
 ### 2. Cloud Storage
 
-*   **All** triggers (`onObjectFinalized`, `onObjectDeleted`, `onObjectArchived`, `onObjectMetadataUpdated`):
-    ```typescript
-    export const processFile = onObjectFinalized(({ object, context }) => { ... });
-    ```
+- **All** triggers (`onObjectFinalized`, `onObjectDeleted`, `onObjectArchived`,
+  `onObjectMetadataUpdated`):
+  ```typescript
+  export const processFile = onObjectFinalized(({ object, context }) => { ... });
+  ```
 
 ### 3. Realtime Database
 
-*   **Created / Deleted** triggers:
-    ```typescript
-    export const processData = onValueCreated("/users/{id}", ({ snapshot, context }) => { ... });
-    ```
-*   **Updated / Written** triggers:
-    ```typescript
-    export const processData = onValueWritten("/users/{id}", ({ change, context }) => { ... });
-    ```
+- **Created / Deleted** triggers:
+  ```typescript
+  export const processData = onValueCreated("/users/{id}", ({ snapshot, context }) => { ... });
+  ```
+- **Updated / Written** triggers:
+  ```typescript
+  export const processData = onValueWritten("/users/{id}", ({ change, context }) => { ... });
+  ```
 
 ### 4. Remote Config
 
-*   **Updated** triggers:
-    ```typescript
-    export const processConfig = onConfigUpdated(({ version, context }) => { ... });
-    ```
+- **Updated** triggers:
+  ```typescript
+  export const processConfig = onConfigUpdated(({ version, context }) => { ... });
+  ```
 
----
+______________________________________________________________________
 
 ## 🛡️ Best Practices for AI Agents
 
-1.  **Do NOT attempt to rewrite variable access inside the body.** It is error-prone and time-consuming.
-2.  **Rely on the shim by default.** Only attempt a pure V2 rewrite if the user explicitly asks for "clean-room" modernization.
-3.  **Always type-check (`tsc`) after the rewrite.** If the types are wrong, the shim might not be fully supported for that specific provider yet!
-4.  **HTTPS Callables (Flattened Context)**: Unlike event triggers, Callables do **not** use `V1Compat` or a `context` object. Instead, all context properties are flattened onto the request object. 
-    *   **V1 Priority**: `(data, context) => { ... }`
-    *   **V2 Equivalent**: `({ data, auth, app }) => { ... }`
+1. **Do NOT attempt to rewrite variable access inside the body.** It is
+   error-prone and time-consuming.
+1. **Rely on the shim by default.** Only attempt a pure V2 rewrite if the user
+   explicitly asks for "clean-room" modernization.
+1. **Always type-check (`tsc`) after the rewrite.** If the types are wrong, the
+   shim might not be fully supported for that specific provider yet!
+1. **HTTPS Callables (Flattened Context)**: Unlike event triggers, Callables do
+   **not** use `V1Compat` or a `context` object. Instead, all context properties
+   are flattened onto the request object.
+   - **V1 Priority**: `(data, context) => { ... }`
+   - **V2 Equivalent**: `({ data, auth, app }) => { ... }`
 
----
+______________________________________________________________________
 
 ## 🔗 Related Migrations
 
@@ -102,25 +117,34 @@ Migrating event signatures is only one part of moving from V1 to V2. Another
 critical area is configuration management.
 
 ### Parameterized Configuration
+
 If your functions use `functions.config()`, you should migrate to the new
 **Parameterized Configuration** system in V2. The destructuring shim handles
 event signatures, but it does not shim `functions.config()`.
 
 #### How to Migrate:
-1.  **Identify Usages**: Search for `functions.config().path.to.value`.
-2.  **Define Parameters**: At the top of your file, define the parameter using the appropriate primitive from `firebase-functions/params` (available types include `defineString`, `defineSecret`, `defineInt`, `defineBoolean`, `defineList`, and `defineJSON`):
-    ```typescript
-    import { defineString, defineSecret } from "firebase-functions/params";
-    
-    const stripeKey = defineSecret("STRIPE_KEY");
-    const apiDomain = defineString("API_DOMAIN");
-    ```
-3.  **Access Values**: Replace the V1 call with the `.value()` method of the defined parameter:
-    *   **V1**: `const key = functions.config().stripe.key;`
-    *   **V2**: `const key = stripeKey.value();`
 
-> [!NOTE]
-> When you migrate a function to V2 (even with the destructuring shim), `functions.config()` will return `undefined` unless you have explicitly set up environment variables or are running in a specific emulation mode. Parameterized configuration is the standard and recommended way to handle this in V2.
+1. **Identify Usages**: Search for `functions.config().path.to.value`.
+1. **Define Parameters**: At the top of your file, define the parameter using
+   the appropriate primitive from `firebase-functions/params` (available types
+   include `defineString`, `defineSecret`, `defineInt`, `defineBoolean`,
+   `defineList`, and `defineJSON`):
+   ```typescript
+   import { defineString, defineSecret } from "firebase-functions/params";
+
+   const stripeKey = defineSecret("STRIPE_KEY");
+   const apiDomain = defineString("API_DOMAIN");
+   ```
+1. **Access Values**: Replace the V1 call with the `.value()` method of the
+   defined parameter:
+   - **V1**: `const key = functions.config().stripe.key;`
+   - **V2**: `const key = stripeKey.value();`
+
+> [!NOTE] When you migrate a function to V2 (even with the destructuring shim),
+> `functions.config()` will return `undefined` unless you have explicitly set up
+> environment variables or are running in a specific emulation mode.
+> Parameterized configuration is the standard and recommended way to handle this
+> in V2.
 
 For a complete guide and deterministic rules on how to migrate configurations,
 refer to [configuration-migration.md](configuration-migration.md).

--- a/skills/extension-to-functions-codebase/references/destructuring-shim.md
+++ b/skills/extension-to-functions-codebase/references/destructuring-shim.md
@@ -1,20 +1,14 @@
 # Architectural Deep Dive: Destructuring Compatibility Shim
 
-The Destructuring Compatibility Shim is a **Zero-Touch Logic Migration**
-pattern. It allows you to upgrade a function's infrastructure to V2 (and take
-advantage of GCF 2nd Gen runtimes) without rewriting any of your internal
-business logic.
+The Destructuring Compatibility Shim is a **Zero-Touch Logic Migration** pattern. It allows you to upgrade a function's infrastructure to V2 (and take advantage of GCF 2nd Gen runtimes) without rewriting any of your internal business logic.
 
-______________________________________________________________________
+---
 
 ## 🛠️ How it Works
 
-When you migrate a V1 function to V2, the signature changes from two parameters
-`(data, context)` to a single `CloudEvent` object.
+When you migrate a V1 function to V2, the signature changes from two parameters `(data, context)` to a single `CloudEvent` object.
 
-Instead of manually rewriting all usages of `context.params` or `message.json`
-inside the function, you use JavaScript's **Object Destructuring** in the
-signature.
+Instead of manually rewriting all usages of `context.params` or `message.json` inside the function, you use JavaScript's **Object Destructuring** in the signature.
 
 ### Example Transformation
 
@@ -29,8 +23,7 @@ export const processOrder = functions.pubsub.topic("orders").onPublish((message,
 
 #### Step 2: Modern V2 + Shim
 
-We change the trigger to `onMessagePublished`, and instead of accepting `event`,
-we destructure `{ message, context }` directly:
+We change the trigger to `onMessagePublished`, and instead of accepting `event`, we destructure `{ message, context }` directly:
 
 ```typescript
 export const processOrder = onMessagePublished("orders", ({ message, context }) => {
@@ -41,14 +34,9 @@ export const processOrder = onMessagePublished("orders", ({ message, context }) 
 
 ### 🧠 Why This Works
 
-The Firebase Functions SDK uses a utility called `addV1Compat` to attach these
-properties via **Lazy Getters** on the `CloudEvent` object for standard event
-triggers. When you attempt to destructure `{ message, context }` from the event,
-the SDK transparently maps the V2 event properties back into V1-compatible
-objects on the fly! This feature is available in modern V2 environments
-supported by the SDK.
+The Firebase Functions SDK uses a utility called `addV1Compat` to attach these properties via **Lazy Getters** on the `CloudEvent` object for standard event triggers. When you attempt to destructure `{ message, context }` from the event, the SDK transparently maps the V2 event properties back into V1-compatible objects on the fly! This feature is available in modern V2 environments supported by the SDK.
 
-______________________________________________________________________
+---
 
 ## 📖 Provider Mapping Examples
 
@@ -69,8 +57,7 @@ Here are the exact destructuring patterns for every supported V2 provider:
 
 ### 2. Cloud Storage
 
-- **All** triggers (`onObjectFinalized`, `onObjectDeleted`, `onObjectArchived`,
-  `onObjectMetadataUpdated`):
+- **All** triggers (`onObjectFinalized`, `onObjectDeleted`, `onObjectArchived`, `onObjectMetadataUpdated`):
   ```typescript
   export const processFile = onObjectFinalized(({ object, context }) => { ... });
   ```
@@ -93,58 +80,42 @@ Here are the exact destructuring patterns for every supported V2 provider:
   export const processConfig = onConfigUpdated(({ version, context }) => { ... });
   ```
 
-______________________________________________________________________
+---
 
 ## 🛡️ Best Practices for AI Agents
 
-1. **Do NOT attempt to rewrite variable access inside the body.** It is
-   error-prone and time-consuming.
-1. **Rely on the shim by default.** Only attempt a pure V2 rewrite if the user
-   explicitly asks for "clean-room" modernization.
-1. **Always type-check (`tsc`) after the rewrite.** If the types are wrong, the
-   shim might not be fully supported for that specific provider yet!
-1. **HTTPS Callables (Flattened Context)**: Unlike event triggers, Callables do
-   **not** use `V1Compat` or a `context` object. Instead, all context properties
-   are flattened onto the request object.
+1. **Do NOT attempt to rewrite variable access inside the body.** It is error-prone and time-consuming.
+2. **Rely on the shim by default.** Only attempt a pure V2 rewrite if the user explicitly asks for "clean-room" modernization.
+3. **Always type-check (`tsc`) after the rewrite.** If the types are wrong, the shim might not be fully supported for that specific provider yet!
+4. **HTTPS Callables (Flattened Context)**: Unlike event triggers, Callables do **not** use `V1Compat` or a `context` object. Instead, all context properties are flattened onto the request object.
    - **V1 Priority**: `(data, context) => { ... }`
    - **V2 Equivalent**: `({ data, auth, app }) => { ... }`
 
-______________________________________________________________________
+---
 
 ## 🔗 Related Migrations
 
-Migrating event signatures is only one part of moving from V1 to V2. Another
-critical area is configuration management.
+Migrating event signatures is only one part of moving from V1 to V2. Another critical area is configuration management.
 
 ### Parameterized Configuration
 
-If your functions use `functions.config()`, you should migrate to the new
-**Parameterized Configuration** system in V2. The destructuring shim handles
-event signatures, but it does not shim `functions.config()`.
+If your functions use `functions.config()`, you should migrate to the new **Parameterized Configuration** system in V2. The destructuring shim handles event signatures, but it does not shim `functions.config()`.
 
 #### How to Migrate:
 
 1. **Identify Usages**: Search for `functions.config().path.to.value`.
-1. **Define Parameters**: At the top of your file, define the parameter using
-   the appropriate primitive from `firebase-functions/params` (available types
-   include `defineString`, `defineSecret`, `defineInt`, `defineBoolean`,
-   `defineList`, and `defineJSON`):
+2. **Define Parameters**: At the top of your file, define the parameter using the appropriate primitive from `firebase-functions/params` (available types include `defineString`, `defineSecret`, `defineInt`, `defineBoolean`, `defineList`, and `defineJSON`):
    ```typescript
    import { defineString, defineSecret } from "firebase-functions/params";
 
    const stripeKey = defineSecret("STRIPE_KEY");
    const apiDomain = defineString("API_DOMAIN");
    ```
-1. **Access Values**: Replace the V1 call with the `.value()` method of the
-   defined parameter:
+3. **Access Values**: Replace the V1 call with the `.value()` method of the defined parameter:
    - **V1**: `const key = functions.config().stripe.key;`
    - **V2**: `const key = stripeKey.value();`
 
-> [!NOTE] When you migrate a function to V2 (even with the destructuring shim),
-> `functions.config()` will return `undefined` unless you have explicitly set up
-> environment variables or are running in a specific emulation mode.
-> Parameterized configuration is the standard and recommended way to handle this
-> in V2.
+> [!NOTE]
+> When you migrate a function to V2 (even with the destructuring shim), `functions.config()` will return `undefined` unless you have explicitly set up environment variables or are running in a specific emulation mode. Parameterized configuration is the standard and recommended way to handle this in V2.
 
-For a complete guide and deterministic rules on how to migrate configurations,
-refer to [configuration-migration.md](configuration-migration.md).
+For a complete guide and deterministic rules on how to migrate configurations, refer to [configuration-migration.md](configuration-migration.md).

--- a/skills/extension-to-functions-codebase/references/signature-mapping.md
+++ b/skills/extension-to-functions-codebase/references/signature-mapping.md
@@ -1,0 +1,81 @@
+# Firebase Functions V1 vs V2 Signature Mapping
+
+This reference maps legacy V1 functions to their modern V2 equivalents. It includes the **Shimmed Parameter Key** you should use when destructuring the V2 event object to preserve V1 business logic.
+
+---
+
+## 🔥 Cloud Firestore
+
+| V1 Trigger | V2 Equivalent | Shimmed Key | Destructuring Pattern |
+| :--- | :--- | :--- | :--- |
+| `firestore.document().onWrite()` | `onDocumentWritten()` | `change` | `({ change, context })` |
+| `firestore.document().onCreate()` | `onDocumentCreated()` | `snapshot` | `({ snapshot, context })` |
+| `firestore.document().onUpdate()` | `onDocumentUpdated()` | `change` | `({ change, context })` |
+| `firestore.document().onDelete()` | `onDocumentDeleted()` | `snapshot` | `({ snapshot, context })` |
+
+---
+
+## 📨 Cloud Pub/Sub
+
+| V1 Trigger | V2 Equivalent | Shimmed Key | Destructuring Pattern |
+| :--- | :--- | :--- | :--- |
+| `pubsub.topic().onPublish()` | `onMessagePublished()` | `message` | `({ message, context })` |
+| `pubsub.schedule().onRun()` | `scheduler.onSchedule()` | **N/A** | Access `event` directly |
+
+> [!NOTE]
+> Scheduled functions moved from the `pubsub` namespace to the `scheduler` namespace in V2.
+
+---
+
+## 💾 Realtime Database
+
+| V1 Trigger | V2 Equivalent | Shimmed Key | Destructuring Pattern |
+| :--- | :--- | :--- | :--- |
+| `database.ref().onWrite()` | `onValueWritten()` | `change` | `({ change, context })` |
+| `database.ref().onCreate()` | `onValueCreated()` | `snapshot` | `({ snapshot, context })` |
+| `database.ref().onUpdate()` | `onValueUpdated()` | `change` | `({ change, context })` |
+| `database.ref().onDelete()` | `onValueDeleted()` | `snapshot` | `({ snapshot, context })` |
+
+---
+
+## 🗄️ Cloud Storage
+
+| V1 Trigger | V2 Equivalent | Shimmed Key | Destructuring Pattern |
+| :--- | :--- | :--- | :--- |
+| `storage.object().onArchive()` | `onObjectArchived()` | `object` | `({ object, context })` |
+| `storage.object().onDelete()` | `onObjectDeleted()` | `object` | `({ object, context })` |
+| `storage.object().onFinalize()` | `onObjectFinalized()` | `object` | `({ object, context })` |
+| `storage.object().onMetadataUpdate()` | `onObjectMetadataUpdated()` | `object` | `({ object, context })` |
+
+---
+
+## 🌐 HTTP / Callables
+
+| V1 Trigger | V2 Equivalent | Shimmed Key | Destructuring Pattern |
+| :--- | :--- | :--- | :--- |
+| `https.onRequest()` | `https.onRequest()` | **N/A** | Standard Express `(req, res)` |
+| `https.onCall()` | `https.onCall()` | **N/A** | Destructure `({ data, auth })` |
+
+> [!IMPORTANT]
+> **HTTP Callables do NOT use the Destructuring Shim.** 
+> In V2, the handler receives a single `CallableRequest` object (not a `CloudEvent`). You should destructure properties like `data`, `auth`, and `app` directly from it. The traditional `context` object is **unavailable**.
+
+---
+
+## 🔑 Auth (Blocking)
+
+| V1 Trigger | V2 Equivalent | Shimmed Key | Destructuring Pattern |
+| :--- | :--- | :--- | :--- |
+| `auth.user().beforeSignIn()` | `identity.beforeUserSignedIn()` | **N/A** | Access `event` directly |
+| `auth.user().beforeCreate()` | `identity.beforeUserCreated()` | **N/A** | Access `event` directly |
+
+> [!NOTE]
+> Auth Blocking triggers moved to the `identity` namespace in V2.
+
+---
+
+## ⏰ Cloud Tasks
+
+| V1 Trigger | V2 Equivalent | Shimmed Key | Destructuring Pattern |
+| :--- | :--- | :--- | :--- |
+| `tasks.taskQueue().onDispatch()` | `tasks.onTaskDispatched()` | **N/A** | Access `event` directly |

--- a/skills/extension-to-functions-codebase/references/signature-mapping.md
+++ b/skills/extension-to-functions-codebase/references/signature-mapping.md
@@ -1,6 +1,8 @@
 # Firebase Functions V1 vs V2 Signature Mapping
 
-This reference maps legacy V1 functions to their modern V2 equivalents. It includes the **Shimmed Parameter Key** you should use when destructuring the V2 event object to preserve V1 business logic.
+This reference maps legacy V1 functions to their modern V2 equivalents. It
+includes the **Shimmed Parameter Key** you should use when destructuring the V2
+event object to preserve V1 business logic.
 
 ---
 

--- a/skills/extension-to-functions-codebase/references/signature-mapping.md
+++ b/skills/extension-to-functions-codebase/references/signature-mapping.md
@@ -1,8 +1,6 @@
 # Firebase Functions V1 vs V2 Signature Mapping
 
-This reference maps legacy V1 functions to their modern V2 equivalents. It
-includes the **Shimmed Parameter Key** you should use when destructuring the V2
-event object to preserve V1 business logic.
+This reference maps legacy V1 functions to their modern V2 equivalents. It includes the **Shimmed Parameter Key** you should use when destructuring the V2 event object to preserve V1 business logic.
 
 ---
 

--- a/skills/extension-to-functions-codebase/references/signature-mapping.md
+++ b/skills/extension-to-functions-codebase/references/signature-mapping.md
@@ -1,62 +1,63 @@
 # Firebase Functions V1 vs V2 Signature Mapping
 
-This reference maps legacy V1 functions to their modern V2 equivalents. It
-includes the **Shimmed Parameter Key** you should use when destructuring the V2
-event object to preserve V1 business logic.
+This reference maps legacy V1 functions to their modern V2 equivalents. When
+using the compatibility shim, you can destructure the V2 event object using the
+exact parameter names from the legacy V1 trigger signature (`change`,
+`snapshot`, `message`, `object`) alongside `context`.
 
 ______________________________________________________________________
 
-## 🔥 Cloud Firestore
+## Cloud Firestore
 
-| V1 Trigger                        | V2 Equivalent         | Shimmed Key | Destructuring Pattern     |
-| :-------------------------------- | :-------------------- | :---------- | :------------------------ |
-| `firestore.document().onWrite()`  | `onDocumentWritten()` | `change`    | `({ change, context })`   |
-| `firestore.document().onCreate()` | `onDocumentCreated()` | `snapshot`  | `({ snapshot, context })` |
-| `firestore.document().onUpdate()` | `onDocumentUpdated()` | `change`    | `({ change, context })`   |
-| `firestore.document().onDelete()` | `onDocumentDeleted()` | `snapshot`  | `({ snapshot, context })` |
+| V1 Trigger                        | V2 Equivalent         | Destructuring Pattern     |
+| :-------------------------------- | :-------------------- | :------------------------ |
+| `firestore.document().onWrite()`  | `onDocumentWritten()` | `({ change, context })`   |
+| `firestore.document().onCreate()` | `onDocumentCreated()` | `({ snapshot, context })` |
+| `firestore.document().onUpdate()` | `onDocumentUpdated()` | `({ change, context })`   |
+| `firestore.document().onDelete()` | `onDocumentDeleted()` | `({ snapshot, context })` |
 
 ______________________________________________________________________
 
-## 📨 Cloud Pub/Sub
+## Cloud Pub/Sub
 
-| V1 Trigger                   | V2 Equivalent          | Shimmed Key | Destructuring Pattern    |
-| :--------------------------- | :--------------------- | :---------- | :----------------------- |
-| `pubsub.topic().onPublish()` | `onMessagePublished()` | `message`   | `({ message, context })` |
-| `pubsub.schedule().onRun()`  | `onSchedule()`         | **N/A**     | Access `event` directly  |
+| V1 Trigger                   | V2 Equivalent          | Destructuring Pattern    |
+| :--------------------------- | :--------------------- | :----------------------- |
+| `pubsub.topic().onPublish()` | `onMessagePublished()` | `({ message, context })` |
+| `pubsub.schedule().onRun()`  | `onSchedule()`         | Access `event` directly  |
 
 > [!NOTE] Scheduled functions moved from the `pubsub` namespace to the
 > `scheduler` namespace in V2.
 
 ______________________________________________________________________
 
-## 💾 Realtime Database
+## Realtime Database
 
-| V1 Trigger                  | V2 Equivalent      | Shimmed Key | Destructuring Pattern     |
-| :-------------------------- | :----------------- | :---------- | :------------------------ |
-| `database.ref().onWrite()`  | `onValueWritten()` | `change`    | `({ change, context })`   |
-| `database.ref().onCreate()` | `onValueCreated()` | `snapshot`  | `({ snapshot, context })` |
-| `database.ref().onUpdate()` | `onValueUpdated()` | `change`    | `({ change, context })`   |
-| `database.ref().onDelete()` | `onValueDeleted()` | `snapshot`  | `({ snapshot, context })` |
-
-______________________________________________________________________
-
-## 🗄️ Cloud Storage
-
-| V1 Trigger                            | V2 Equivalent               | Shimmed Key | Destructuring Pattern   |
-| :------------------------------------ | :-------------------------- | :---------- | :---------------------- |
-| `storage.object().onArchive()`        | `onObjectArchived()`        | `object`    | `({ object, context })` |
-| `storage.object().onDelete()`         | `onObjectDeleted()`         | `object`    | `({ object, context })` |
-| `storage.object().onFinalize()`       | `onObjectFinalized()`       | `object`    | `({ object, context })` |
-| `storage.object().onMetadataUpdate()` | `onObjectMetadataUpdated()` | `object`    | `({ object, context })` |
+| V1 Trigger                  | V2 Equivalent      | Destructuring Pattern     |
+| :-------------------------- | :----------------- | :------------------------ |
+| `database.ref().onWrite()`  | `onValueWritten()` | `({ change, context })`   |
+| `database.ref().onCreate()` | `onValueCreated()` | `({ snapshot, context })` |
+| `database.ref().onUpdate()` | `onValueUpdated()` | `({ change, context })`   |
+| `database.ref().onDelete()` | `onValueDeleted()` | `({ snapshot, context })` |
 
 ______________________________________________________________________
 
-## 🌐 HTTP / Callables
+## Cloud Storage
 
-| V1 Trigger          | V2 Equivalent       | Shimmed Key | Destructuring Pattern          |
-| :------------------ | :------------------ | :---------- | :----------------------------- |
-| `https.onRequest()` | `https.onRequest()` | **N/A**     | Standard Express `(req, res)`  |
-| `https.onCall()`    | `https.onCall()`    | **N/A**     | Destructure `({ data, auth })` |
+| V1 Trigger                            | V2 Equivalent               | Destructuring Pattern   |
+| :------------------------------------ | :-------------------------- | :---------------------- |
+| `storage.object().onArchive()`        | `onObjectArchived()`        | `({ object, context })` |
+| `storage.object().onDelete()`         | `onObjectDeleted()`         | `({ object, context })` |
+| `storage.object().onFinalize()`       | `onObjectFinalized()`       | `({ object, context })` |
+| `storage.object().onMetadataUpdate()` | `onObjectMetadataUpdated()` | `({ object, context })` |
+
+______________________________________________________________________
+
+## HTTP / Callables
+
+| V1 Trigger          | V2 Equivalent       | Destructuring Pattern          |
+| :------------------ | :------------------ | :----------------------------- |
+| `https.onRequest()` | `https.onRequest()` | Standard Express `(req, res)`  |
+| `https.onCall()`    | `https.onCall()`    | Destructure `({ data, auth })` |
 
 > [!IMPORTANT] **HTTP Callables do NOT use the Destructuring Shim.** In V2, the
 > handler receives a single `CallableRequest` object (not a `CloudEvent`). You
@@ -65,19 +66,19 @@ ______________________________________________________________________
 
 ______________________________________________________________________
 
-## 🔑 Auth (Blocking)
+## Auth (Blocking)
 
-| V1 Trigger                   | V2 Equivalent                   | Shimmed Key | Destructuring Pattern   |
-| :--------------------------- | :------------------------------ | :---------- | :---------------------- |
-| `auth.user().beforeSignIn()` | `identity.beforeUserSignedIn()` | **N/A**     | Access `event` directly |
-| `auth.user().beforeCreate()` | `identity.beforeUserCreated()`  | **N/A**     | Access `event` directly |
+| V1 Trigger                   | V2 Equivalent                   | Destructuring Pattern   |
+| :--------------------------- | :------------------------------ | :---------------------- |
+| `auth.user().beforeSignIn()` | `identity.beforeUserSignedIn()` | Access `event` directly |
+| `auth.user().beforeCreate()` | `identity.beforeUserCreated()`  | Access `event` directly |
 
 > [!NOTE] Auth Blocking triggers moved to the `identity` namespace in V2.
 
 ______________________________________________________________________
 
-## ⏰ Cloud Tasks
+## Cloud Tasks
 
-| V1 Trigger                       | V2 Equivalent        | Shimmed Key | Destructuring Pattern   |
-| :------------------------------- | :------------------- | :---------- | :---------------------- |
-| `tasks.taskQueue().onDispatch()` | `onTaskDispatched()` | **N/A**     | Access `event` directly |
+| V1 Trigger                       | V2 Equivalent        | Destructuring Pattern   |
+| :------------------------------- | :------------------- | :---------------------- |
+| `tasks.taskQueue().onDispatch()` | `onTaskDispatched()` | Access `event` directly |

--- a/skills/extension-to-functions-codebase/references/signature-mapping.md
+++ b/skills/extension-to-functions-codebase/references/signature-mapping.md
@@ -4,83 +4,80 @@ This reference maps legacy V1 functions to their modern V2 equivalents. It
 includes the **Shimmed Parameter Key** you should use when destructuring the V2
 event object to preserve V1 business logic.
 
----
+______________________________________________________________________
 
 ## 🔥 Cloud Firestore
 
-| V1 Trigger | V2 Equivalent | Shimmed Key | Destructuring Pattern |
-| :--- | :--- | :--- | :--- |
-| `firestore.document().onWrite()` | `onDocumentWritten()` | `change` | `({ change, context })` |
-| `firestore.document().onCreate()` | `onDocumentCreated()` | `snapshot` | `({ snapshot, context })` |
-| `firestore.document().onUpdate()` | `onDocumentUpdated()` | `change` | `({ change, context })` |
-| `firestore.document().onDelete()` | `onDocumentDeleted()` | `snapshot` | `({ snapshot, context })` |
+| V1 Trigger                        | V2 Equivalent         | Shimmed Key | Destructuring Pattern     |
+| :-------------------------------- | :-------------------- | :---------- | :------------------------ |
+| `firestore.document().onWrite()`  | `onDocumentWritten()` | `change`    | `({ change, context })`   |
+| `firestore.document().onCreate()` | `onDocumentCreated()` | `snapshot`  | `({ snapshot, context })` |
+| `firestore.document().onUpdate()` | `onDocumentUpdated()` | `change`    | `({ change, context })`   |
+| `firestore.document().onDelete()` | `onDocumentDeleted()` | `snapshot`  | `({ snapshot, context })` |
 
----
+______________________________________________________________________
 
 ## 📨 Cloud Pub/Sub
 
-| V1 Trigger | V2 Equivalent | Shimmed Key | Destructuring Pattern |
-| :--- | :--- | :--- | :--- |
-| `pubsub.topic().onPublish()` | `onMessagePublished()` | `message` | `({ message, context })` |
-| `pubsub.schedule().onRun()` | `onSchedule()` | **N/A** | Access `event` directly |
+| V1 Trigger                   | V2 Equivalent          | Shimmed Key | Destructuring Pattern    |
+| :--------------------------- | :--------------------- | :---------- | :----------------------- |
+| `pubsub.topic().onPublish()` | `onMessagePublished()` | `message`   | `({ message, context })` |
+| `pubsub.schedule().onRun()`  | `onSchedule()`         | **N/A**     | Access `event` directly  |
 
-> [!NOTE]
-> Scheduled functions moved from the `pubsub` namespace to the `scheduler`
-> namespace in V2.
+> [!NOTE] Scheduled functions moved from the `pubsub` namespace to the
+> `scheduler` namespace in V2.
 
----
+______________________________________________________________________
 
 ## 💾 Realtime Database
 
-| V1 Trigger | V2 Equivalent | Shimmed Key | Destructuring Pattern |
-| :--- | :--- | :--- | :--- |
-| `database.ref().onWrite()` | `onValueWritten()` | `change` | `({ change, context })` |
-| `database.ref().onCreate()` | `onValueCreated()` | `snapshot` | `({ snapshot, context })` |
-| `database.ref().onUpdate()` | `onValueUpdated()` | `change` | `({ change, context })` |
-| `database.ref().onDelete()` | `onValueDeleted()` | `snapshot` | `({ snapshot, context })` |
+| V1 Trigger                  | V2 Equivalent      | Shimmed Key | Destructuring Pattern     |
+| :-------------------------- | :----------------- | :---------- | :------------------------ |
+| `database.ref().onWrite()`  | `onValueWritten()` | `change`    | `({ change, context })`   |
+| `database.ref().onCreate()` | `onValueCreated()` | `snapshot`  | `({ snapshot, context })` |
+| `database.ref().onUpdate()` | `onValueUpdated()` | `change`    | `({ change, context })`   |
+| `database.ref().onDelete()` | `onValueDeleted()` | `snapshot`  | `({ snapshot, context })` |
 
----
+______________________________________________________________________
 
 ## 🗄️ Cloud Storage
 
-| V1 Trigger | V2 Equivalent | Shimmed Key | Destructuring Pattern |
-| :--- | :--- | :--- | :--- |
-| `storage.object().onArchive()` | `onObjectArchived()` | `object` | `({ object, context })` |
-| `storage.object().onDelete()` | `onObjectDeleted()` | `object` | `({ object, context })` |
-| `storage.object().onFinalize()` | `onObjectFinalized()` | `object` | `({ object, context })` |
-| `storage.object().onMetadataUpdate()` | `onObjectMetadataUpdated()` | `object` | `({ object, context })` |
+| V1 Trigger                            | V2 Equivalent               | Shimmed Key | Destructuring Pattern   |
+| :------------------------------------ | :-------------------------- | :---------- | :---------------------- |
+| `storage.object().onArchive()`        | `onObjectArchived()`        | `object`    | `({ object, context })` |
+| `storage.object().onDelete()`         | `onObjectDeleted()`         | `object`    | `({ object, context })` |
+| `storage.object().onFinalize()`       | `onObjectFinalized()`       | `object`    | `({ object, context })` |
+| `storage.object().onMetadataUpdate()` | `onObjectMetadataUpdated()` | `object`    | `({ object, context })` |
 
----
+______________________________________________________________________
 
 ## 🌐 HTTP / Callables
 
-| V1 Trigger | V2 Equivalent | Shimmed Key | Destructuring Pattern |
-| :--- | :--- | :--- | :--- |
-| `https.onRequest()` | `https.onRequest()` | **N/A** | Standard Express `(req, res)` |
-| `https.onCall()` | `https.onCall()` | **N/A** | Destructure `({ data, auth })` |
+| V1 Trigger          | V2 Equivalent       | Shimmed Key | Destructuring Pattern          |
+| :------------------ | :------------------ | :---------- | :----------------------------- |
+| `https.onRequest()` | `https.onRequest()` | **N/A**     | Standard Express `(req, res)`  |
+| `https.onCall()`    | `https.onCall()`    | **N/A**     | Destructure `({ data, auth })` |
 
-> [!IMPORTANT]
-> **HTTP Callables do NOT use the Destructuring Shim.** 
-> In V2, the handler receives a single `CallableRequest` object (not a
-> `CloudEvent`). You should destructure properties like `data`, `auth`, and
-> `app` directly from it. The traditional `context` object is **unavailable**.
+> [!IMPORTANT] **HTTP Callables do NOT use the Destructuring Shim.** In V2, the
+> handler receives a single `CallableRequest` object (not a `CloudEvent`). You
+> should destructure properties like `data`, `auth`, and `app` directly from it.
+> The traditional `context` object is **unavailable**.
 
----
+______________________________________________________________________
 
 ## 🔑 Auth (Blocking)
 
-| V1 Trigger | V2 Equivalent | Shimmed Key | Destructuring Pattern |
-| :--- | :--- | :--- | :--- |
-| `auth.user().beforeSignIn()` | `identity.beforeUserSignedIn()` | **N/A** | Access `event` directly |
-| `auth.user().beforeCreate()` | `identity.beforeUserCreated()` | **N/A** | Access `event` directly |
+| V1 Trigger                   | V2 Equivalent                   | Shimmed Key | Destructuring Pattern   |
+| :--------------------------- | :------------------------------ | :---------- | :---------------------- |
+| `auth.user().beforeSignIn()` | `identity.beforeUserSignedIn()` | **N/A**     | Access `event` directly |
+| `auth.user().beforeCreate()` | `identity.beforeUserCreated()`  | **N/A**     | Access `event` directly |
 
-> [!NOTE]
-> Auth Blocking triggers moved to the `identity` namespace in V2.
+> [!NOTE] Auth Blocking triggers moved to the `identity` namespace in V2.
 
----
+______________________________________________________________________
 
 ## ⏰ Cloud Tasks
 
-| V1 Trigger | V2 Equivalent | Shimmed Key | Destructuring Pattern |
-| :--- | :--- | :--- | :--- |
-| `tasks.taskQueue().onDispatch()` | `onTaskDispatched()` | **N/A** | Access `event` directly |
+| V1 Trigger                       | V2 Equivalent        | Shimmed Key | Destructuring Pattern   |
+| :------------------------------- | :------------------- | :---------- | :---------------------- |
+| `tasks.taskQueue().onDispatch()` | `onTaskDispatched()` | **N/A**     | Access `event` directly |

--- a/skills/extension-to-functions-codebase/references/signature-mapping.md
+++ b/skills/extension-to-functions-codebase/references/signature-mapping.md
@@ -20,7 +20,7 @@ This reference maps legacy V1 functions to their modern V2 equivalents. It inclu
 | V1 Trigger | V2 Equivalent | Shimmed Key | Destructuring Pattern |
 | :--- | :--- | :--- | :--- |
 | `pubsub.topic().onPublish()` | `onMessagePublished()` | `message` | `({ message, context })` |
-| `pubsub.schedule().onRun()` | `scheduler.onSchedule()` | **N/A** | Access `event` directly |
+| `pubsub.schedule().onRun()` | `onSchedule()` | **N/A** | Access `event` directly |
 
 > [!NOTE]
 > Scheduled functions moved from the `pubsub` namespace to the `scheduler` namespace in V2.
@@ -78,4 +78,4 @@ This reference maps legacy V1 functions to their modern V2 equivalents. It inclu
 
 | V1 Trigger | V2 Equivalent | Shimmed Key | Destructuring Pattern |
 | :--- | :--- | :--- | :--- |
-| `tasks.taskQueue().onDispatch()` | `tasks.onTaskDispatched()` | **N/A** | Access `event` directly |
+| `tasks.taskQueue().onDispatch()` | `onTaskDispatched()` | **N/A** | Access `event` directly |

--- a/skills/extension-to-functions-codebase/references/signature-mapping.md
+++ b/skills/extension-to-functions-codebase/references/signature-mapping.md
@@ -1,6 +1,8 @@
 # Firebase Functions V1 vs V2 Signature Mapping
 
-This reference maps legacy V1 functions to their modern V2 equivalents. It includes the **Shimmed Parameter Key** you should use when destructuring the V2 event object to preserve V1 business logic.
+This reference maps legacy V1 functions to their modern V2 equivalents. It
+includes the **Shimmed Parameter Key** you should use when destructuring the V2
+event object to preserve V1 business logic.
 
 ---
 
@@ -23,7 +25,8 @@ This reference maps legacy V1 functions to their modern V2 equivalents. It inclu
 | `pubsub.schedule().onRun()` | `onSchedule()` | **N/A** | Access `event` directly |
 
 > [!NOTE]
-> Scheduled functions moved from the `pubsub` namespace to the `scheduler` namespace in V2.
+> Scheduled functions moved from the `pubsub` namespace to the `scheduler`
+> namespace in V2.
 
 ---
 
@@ -58,7 +61,9 @@ This reference maps legacy V1 functions to their modern V2 equivalents. It inclu
 
 > [!IMPORTANT]
 > **HTTP Callables do NOT use the Destructuring Shim.** 
-> In V2, the handler receives a single `CallableRequest` object (not a `CloudEvent`). You should destructure properties like `data`, `auth`, and `app` directly from it. The traditional `context` object is **unavailable**.
+> In V2, the handler receives a single `CallableRequest` object (not a
+> `CloudEvent`). You should destructure properties like `data`, `auth`, and
+> `app` directly from it. The traditional `context` object is **unavailable**.
 
 ---
 


### PR DESCRIPTION
This pull request introduces the extension-to-functions-codebase agent skill, designed to guide AI coding assistants through migrating installed Firebase Extensions to standalone Cloud Functions (CF3). It enables fully automated deployments by parsing permission and API requirements from extension.yaml and declaring them directly in code via the new requiresRole() and requiresAPI() SDK methods, completely removing the need for manual service account setup. It also automates the transition of lifecycle events using native SDK hooks (afterInstall/afterUpdate).

To ensure long-term compatibility, the skill instructs the agent to modernize any legacy Functions V1 triggers to V2 using the SDK's destructuring compatibility shim. This shim preserves the existing function bodies, so internal business logic requires no rewriting. The skill also incorporates best practices such as safe git copy sequences, parameterization mappings, and using onInit() for global variable initializations to prevent runtime crashes. Technical reference tables mapping triggers, options, and parameters have been included in a dedicated references/ directory.

