### PR TITLE
Fix: add --non-interactive flag to apps:create references for iOS to unblock agent

### DIFF
--- a/skills/firebase-basics/SKILL.md
+++ b/skills/firebase-basics/SKILL.md
@@ -85,6 +85,7 @@ Adhere to these principles:
    instead of just `firebase`. For example, use
    `npx -y firebase-tools@latest --version`. NEVER suggest the naked `firebase`
    command as an alternative.
+1. **Always use `--non-interactive` for iOS app registration:** When registering iOS apps via the CLI (specifically `apps:create IOS`), you MUST append the `--non-interactive` flag. This prevents the CLI from prompting for the optional App Store ID, which blocks coding agents in non-interactive environments.
 1. **Prioritize official knowledge:** For any Firebase-related knowledge,
    consult the `developerknowledge_search_documents` MCP tool before falling
    back to Google Search or your internal knowledge base. Including "Firebase"

--- a/skills/firebase-basics/references/ios_setup.md
+++ b/skills/firebase-basics/references/ios_setup.md
@@ -39,7 +39,7 @@ Do not use the Firebase Console. Use the CLI to automate setup:
 1. Action: Read the Xcode project (`.pbxproj` or `Info.plist`) to determine the
    iOS bundle ID.
 1. Register the iOS app:
-   `npx -y firebase-tools@latest apps:create IOS <bundle-id>`
+   `npx -y firebase-tools@latest apps:create IOS <bundle-id> --non-interactive`
 1. Fetch the config: `npx -y firebase-tools@latest apps:sdkconfig IOS <App-ID>`
 1. Save the output as `GoogleService-Info.plist` in your Xcode project folder.
    Ensure you remove any non-XML CLI output headers, and ensure the file is

--- a/skills/firebase-crashlytics/references/ios_setup.md
+++ b/skills/firebase-crashlytics/references/ios_setup.md
@@ -16,7 +16,7 @@ Use the `firebase-tools` CLI to set up the project if necessary.
 1. **Create Firebase Project:** If no project exists, create one:
    `npx -y firebase-tools@latest projects:create <project-id> --display-name="My Awesome App"`
 1. **Create Firebase App:** Register the iOS app with the discovered bundle ID:
-   `npx -y firebase-tools@latest apps:create IOS <bundle-id>`
+   `npx -y firebase-tools@latest apps:create IOS <bundle-id> --non-interactive`
 1. **Link the GoogleService-Info.plist file:** Use the script in the
    `xcode-project-setup` skill to obtain the config and link.
 

--- a/skills/firebase-remote-config-basics/references/ios_setup.md
+++ b/skills/firebase-remote-config-basics/references/ios_setup.md
@@ -16,7 +16,7 @@ Use the `firebase-tools` CLI to set up the project if necessary.
 1. **Create Firebase Project:** If no project exists, create one:
    `npx -y firebase-tools@latest projects:create <project-id> --display-name="My Awesome App"`
 1. **Create Firebase App:** Register the iOS app with the discovered bundle ID:
-   `npx -y firebase-tools@latest apps:create IOS <bundle-id>`
+   `npx -y firebase-tools@latest apps:create IOS <bundle-id> --non-interactive`
 1. **Link the GoogleService-Info.plist file:** Use the script in the
    `xcode-project-setup` skill to obtain the config and link.
 


### PR DESCRIPTION
Addresses #146

This PR adds the `--non-interactive` flag to the `apps:create IOS` CLI command in all iOS setup reference guides. This prevents the Firebase CLI from prompting for the optional App Store ID, which blocks coding agents running in non-interactive environments.
