### PR TITLE
docs: add limited-use App Check tokens documentation for iOS

### DIFF
--- a/skills/firebase-ai-logic-basics/references/ios_setup.md
+++ b/skills/firebase-ai-logic-basics/references/ios_setup.md
@@ -14,6 +14,32 @@ let ai = FirebaseAI.firebaseAI()
 let model = ai.generativeModel(modelName: "<latest_supported_model>")
 ```
 
+### Using Limited-Use App Check Tokens
+
+For enhanced security and cost control, you can enable limited-use tokens during instantiation. This restricts each token to a single API call, reducing risk if a token is compromised:
+
+```swift
+import FirebaseAILogic
+
+// Initialize with limited-use tokens enabled
+let ai = FirebaseAI.firebaseAI(
+  backend: .googleAI(),
+  useLimitedUseAppCheckTokens: true
+)
+
+// [AGENT] Replace "<latest_supported_model>" with the latest model from https://firebase.google.com/docs/ai-logic/models.md.txt
+let model = ai.generativeModel(modelName: "<latest_supported_model>")
+```
+
+**Benefits:**
+- Each App Check token is valid for only one API request
+- Reduces attack surface if a token is intercepted
+- Ideal for production applications with strict security requirements
+
+**Prerequisites:**
+- App Check must be configured in your Firebase project
+- Ensure your app's attestation provider is set up (DeviceCheck for iOS)
+
 ## 2. SwiftUI Integration (Best Practices)
 
 Use the `@Observable` pattern to manage AI state and provide a smooth UX with
@@ -77,6 +103,42 @@ struct AIView: View {
             }
         }
         .padding()
+    }
+}
+```
+
+### With Limited-Use Tokens
+
+For enhanced security in production, use limited-use App Check tokens:
+
+```swift
+import SwiftUI
+import FirebaseAILogic
+
+@MainActor
+@Observable
+final class SecureAIViewModel {
+    // Initialize with limited-use tokens for enhanced security
+    private lazy var model = FirebaseAI.firebaseAI(
+        backend: .googleAI(),
+        useLimitedUseAppCheckTokens: true
+    ).generativeModel(modelName: "<latest_supported_model>")
+    
+    var responseText: String = ""
+    var isFetching: Bool = false
+    var errorMessage: String?
+    
+    func generate(prompt: String) async {
+        isFetching = true
+        errorMessage = nil
+        defer { isFetching = false }
+        
+        do {
+            let response = try await model.generateContent(prompt)
+            self.responseText = response.text ?? "No response"
+        } catch {
+            self.errorMessage = error.localizedDescription
+        }
     }
 }
 ```

--- a/skills/firebase-ai-logic-basics/references/ios_setup.md
+++ b/skills/firebase-ai-logic-basics/references/ios_setup.md
@@ -119,8 +119,9 @@ import FirebaseAILogic
 @Observable
 final class SecureAIViewModel {
     // Initialize with limited-use tokens for enhanced security
+    // [AGENT] Replace "<latest_supported_model>" with the latest model from https://firebase.google.com/docs/ai-logic/models.md.txt
     private lazy var model = FirebaseAI.firebaseAI(
-        backend: .googleAI(),
+        backend: .geminiDeveloperAPI(),
         useLimitedUseAppCheckTokens: true
     ).generativeModel(modelName: "<latest_supported_model>")
     

--- a/skills/firebase-ai-logic-basics/references/ios_setup.md
+++ b/skills/firebase-ai-logic-basics/references/ios_setup.md
@@ -23,7 +23,7 @@ import FirebaseAILogic
 
 // Initialize with limited-use tokens enabled
 let ai = FirebaseAI.firebaseAI(
-  backend: .googleAI(),
+  backend: .geminiDeveloperAPI(),
   useLimitedUseAppCheckTokens: true
 )
 


### PR DESCRIPTION
## Summary

Add comprehensive documentation for using limited-use App Check tokens with Firebase AI Logic on iOS. This feature enhances security by restricting each App Check token to a single API request, reducing risk if a token is intercepted.

## Changes

- Added "Using Limited-Use App Check Tokens" subsection in the initialization section with working code example
- Included benefits: single-use tokens, reduced attack surface, ideal for production applications
- Added prerequisites for App Check configuration
- Created `SecureAIViewModel` example showing production-ready implementation with limited-use tokens in SwiftUI

## Why This Matters

Limited-use tokens are a best practice for production iOS applications. This documentation makes the feature discoverable and provides developers with clear, runnable examples of how to implement this security enhancement.