### PR TITLE
Add Kimi Code plugin manifest and update documentation

### DIFF
--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -1,0 +1,50 @@
+{
+  "name": "firebase",
+  "version": "1.1.0",
+  "description": "Official Firebase plugin for Kimi Code. Manage projects, add backend services, develop AI features, deploy and host apps, and more.",
+  "author": {
+    "name": "Firebase",
+    "email": "firebase-support@google.com",
+    "url": "https://firebase.google.com"
+  },
+  "homepage": "https://github.com/firebase/agent-skills",
+  "repository": "https://github.com/firebase/agent-skills",
+  "license": "Apache-2.0",
+  "keywords": [
+    "firebase",
+    "kimi",
+    "skills",
+    "mcp",
+    "firestore",
+    "hosting",
+    "auth",
+    "storage",
+    "ailogic",
+    "backend",
+    "cloud-services"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "Firebase",
+    "shortDescription": "Build and manage Firebase apps from Kimi Code.",
+    "longDescription": "Use official Firebase skills and the Firebase MCP server to set up projects, configure backend services, query Firestore, manage authentication, deploy hosting, work with AI Logic, and audit security rules from Kimi Code.",
+    "developerName": "Firebase",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Skills",
+      "MCP"
+    ],
+    "websiteURL": "https://firebase.google.com",
+    "privacyPolicyURL": "https://policies.google.com/privacy",
+    "termsOfServiceURL": "https://policies.google.com/terms",
+    "defaultPrompt": [
+      "Set up Firebase in this app.",
+      "Audit my Firestore security rules.",
+      "Deploy this app with Firebase Hosting."
+    ],
+    "brandColor": "#FFCA28",
+    "composerIcon": "./assets/firebase_logo.svg",
+    "logo": "./assets/firebase-agent-skills_logo.svg"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -63,7 +63,21 @@ Install the Firebase plugin:
 codex plugin add firebase@firebase
 ```
 
-### Option 5: Manual Set Up
+### Option 5: Kimi Plugin
+
+Install the Firebase plugin in Kimi Code CLI:
+
+```bash
+/plugins install https://github.com/firebase/skills
+```
+
+Verify the installation:
+
+```bash
+/plugins list
+```
+
+### Option 6: Manual Set Up
 
 1. Clone this repository:
 
@@ -78,7 +92,7 @@ git clone https://github.com/firebase/skills.git
    - **GitHub Copilot**: `.github/copilot-instructions.md` (or project-specific
      instruction files)
 
-### Option 6: Local Path via Agent Skills CLI
+### Option 7: Local Path via Agent Skills CLI
 
 The `skills` CLI also supports installing skills from a local directory. If you
 have cloned this repository, you can add skills by pointing the CLI to your
@@ -95,7 +109,7 @@ project with the new changes, you can update them by running:
 npx skills experimental_install
 ```
 
-### Option 7: Local Development (Live Symlinking)
+### Option 8: Local Development (Live Symlinking)
 
 If you are actively contributing to or developing these skills, using
 `npx skills add` or copying files means you have to manually update them every

--- a/scripts/format.py
+++ b/scripts/format.py
@@ -11,6 +11,7 @@ EXCLUDE_DIRS = {
     '.claude-plugin',
     '.codex-plugin',
     '.cursor-plugin',
+    '.kimi-plugin',
     '.jetskicli',
 }
 


### PR DESCRIPTION
This PR adds the Kimi Code plugin manifest at `.kimi-plugin/plugin.json`, updates formatting exclusions in `scripts/format.py`, and documents Kimi Plugin installation in `README.md`.