### PR TITLE
update logo to use the official logo

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "Firebase",
     "email": "firebase-support@google.com",
-    "url": "https://firebase.google.com"
+    "url": "https://github.com/firebase/agent-skills"
   },
   "homepage": "https://github.com/firebase/agent-skills",
   "repository": "https://github.com/firebase/agent-skills",
@@ -45,6 +45,6 @@
     ],
     "brandColor": "#FFCA28",
     "composerIcon": "./assets/firebase_logo.svg",
-    "logo": "./assets/firebase-agent-skills_logo.svg"
+    "logo": "./assets/firebase_logo.svg"
   }
 }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "Firebase",
     "email": "firebase-support@google.com",
-    "url": "https://github.com/firebase/agent-skills"
+    "url": "https://firebase.google.com"
   },
   "homepage": "https://github.com/firebase/agent-skills",
   "repository": "https://github.com/firebase/agent-skills",


### PR DESCRIPTION
The current codex plugin shows a firebase logo that's not our official firebase brand logo. It might confuse users that this is not official plugin.