### PR TITLE
update the example to reflect the correct authorized domain

### DIFF
--- a/skills/firebase-auth-basics/SKILL.md
+++ b/skills/firebase-auth-basics/SKILL.md
@@ -64,13 +64,13 @@ Configure Firebase Authentication in `firebase.json` by adding an 'auth' block:
 ```
 {
   "auth": {
+  "authorizedDomains": ["localhost"],
     "providers": {
       "anonymous": true,
       "emailPassword": true,
       "googleSignIn": {
         "oAuthBrandDisplayName": "Your Brand Name",
         "supportEmail": "support@example.com",
-        "authorizedRedirectUris": ["https://example.com", "http://localhost"]
       }
     }
   }

--- a/skills/firebase-auth-basics/SKILL.md
+++ b/skills/firebase-auth-basics/SKILL.md
@@ -70,7 +70,7 @@ Configure Firebase Authentication in `firebase.json` by adding an 'auth' block:
       "emailPassword": true,
       "googleSignIn": {
         "oAuthBrandDisplayName": "Your Brand Name",
-        "supportEmail": "support@example.com",
+        "supportEmail": "support@example.com"
       }
     }
   }


### PR DESCRIPTION
The example in auth skills confused coding agent how to set authorized domain. The localhost should not be set in the Authorized Redirect.