### PR TITLE
Add category frontmatter to all skills

### DIFF
--- a/skills/extension-to-functions-codebase/SKILL.md
+++ b/skills/extension-to-functions-codebase/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: extension-to-functions-codebase
 description: Skill for converting an installed Firebase Extension (or extension source) into a standalone Cloud Functions for Firebase codebase or publishable npm package, including V1 to V2 trigger upgrades, lifecycle hooks, and declarative security
+metadata:
+  category: Serverless
 ---
 
 # Extension to Functions Codebase & npm Package Migration

--- a/skills/firebase-ai-logic-basics/SKILL.md
+++ b/skills/firebase-ai-logic-basics/SKILL.md
@@ -2,6 +2,8 @@
 name: firebase-ai-logic-basics
 description: Official skill for integrating Firebase AI Logic (Gemini API) into web applications. Covers setup, multimodal inference, structured output, and security.
 version: 1.0.1
+metadata:
+  category: AiAndMachineLearning
 ---
 
 # Firebase AI Logic Basics

--- a/skills/firebase-app-hosting-basics/SKILL.md
+++ b/skills/firebase-app-hosting-basics/SKILL.md
@@ -2,6 +2,8 @@
 name: firebase-app-hosting-basics
 description: >-
   Deploys and manages full-stack web applications (Next.js, Angular) with Server-Side Rendering (SSR) using Firebase App Hosting. Use when deploying Next.js/Angular apps, configuring apphosting.yaml or firebase.json apphosting blocks, managing secrets, setting up GitHub CI/CD, or configuring Blaze billing requirements. Don't use for classic static web hosting, Auth, Firestore, Crashlytics, or Xcode.
+metadata:
+  category: Serverless
 ---
 
 # App Hosting Basics

--- a/skills/firebase-auth-basics/SKILL.md
+++ b/skills/firebase-auth-basics/SKILL.md
@@ -2,6 +2,8 @@
 name: firebase-auth-basics
 description: Guide for setting up and using Firebase Authentication. Use this skill when the user's app requires user sign-in, user management, or secure data access using auth rules.
 compatibility: This skill is best used with the Firebase CLI, but does not require it. Firebase CLI can be accessed through `npx -y firebase-tools@latest`.
+metadata:
+  category: Identity
 ---
 
 ## Prerequisites

--- a/skills/firebase-basics/SKILL.md
+++ b/skills/firebase-basics/SKILL.md
@@ -2,6 +2,8 @@
 name: firebase-basics
 description: >-
   Provides foundational Firebase CLI setup, CLI installation, version checks (`firebase-tools@latest --version`), CLI login (including --no-localhost), project creation, project selection (`firebase use`), and app config file downloads (`google-services.json`, `GoogleService-Info.plist`). Use ONLY for CLI login, project creation/switching, or downloading app config files. Don't use for Firebase Hosting deploy, Firestore, Auth, App Hosting, Data Connect, Crashlytics, or Remote Config.
+metadata:
+  category: CloudInfrastructureAndServices
 ---
 
 # Prerequisites

--- a/skills/firebase-crashlytics/SKILL.md
+++ b/skills/firebase-crashlytics/SKILL.md
@@ -2,6 +2,8 @@
 name: firebase-crashlytics
 description: Comprehensive guide for Firebase Crashlytics, including provisioning and SDK usage. Use this skill when the user needs help setting up Crashlytics, adding crash reporting, or using the Crashlytics SDK in their application.
 compatibility: This skill is best used with the Firebase CLI, but does not require it. Firebase CLI can be accessed through `npx -y firebase-tools@latest`.
+metadata:
+  category: CloudObservabilityAndMonitoring
 ---
 
 # Crashlytics

--- a/skills/firebase-data-connect-basics/SKILL.md
+++ b/skills/firebase-data-connect-basics/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: firebase-data-connect
 description: Builds and deploys Firebase SQL Connect (aka Firebase Data Connect) backends with PostgreSQL securely. Use when designing schemas with tables and relations, writing authorized queries and mutations, configuring real-time data updates, or generating type-safe SDKs. Use when you need a relational database with Firebase, or when the user mentions SQL Connect or Data Connect.
+metadata:
+  category: Databases
 ---
 
 # Firebase SQL Connect

--- a/skills/firebase-firestore/SKILL.md
+++ b/skills/firebase-firestore/SKILL.md
@@ -3,6 +3,8 @@ name: firebase-firestore
 description: >-
   Sets up, manages, queries, and configures Cloud Firestore databases (Standard/Enterprise edition), including data modeling, security rules, indexes, and SDK integrations (Web, Python, iOS, Android, Flutter). Use when creating/listing Firestore databases, defining data models/indexes, writing SDK queries, or integrating Firestore SDKs. Don't use for Firebase Hosting, Data Connect, Auth, Storage/GCS, Crashlytics, Functions, or BigQuery.
 compatibility: This skill is best used with the Firebase CLI, but does not require it. Firebase CLI can be accessed through `npx -y firebase-tools@latest`.
+metadata:
+  category: Databases
 ---
 
 # Cloud Firestore Database and Operations

--- a/skills/firebase-hosting-basics/SKILL.md
+++ b/skills/firebase-hosting-basics/SKILL.md
@@ -2,6 +2,8 @@
 name: firebase-hosting-basics
 description: >-
   Deploys and configures classic Firebase Hosting for static websites, single-page apps (SPAs), and microservices. Use when deploying static sites/SPAs, setting up custom domains, configuring firebase.json hosting settings (redirects, rewrites, headers, multi-site), or managing preview channels. Don't use for Firebase App Hosting (Next.js/SSR), Auth, Firestore queries/rules, Data Connect, or Crashlytics.
+metadata:
+  category: Serverless
 ---
 
 # hosting-basics

--- a/skills/firebase-remote-config-basics/SKILL.md
+++ b/skills/firebase-remote-config-basics/SKILL.md
@@ -3,6 +3,8 @@ name: firebase-remote-config-basics
 description: >-
   Manages Firebase Remote Config templates, feature flags, loading strategies, and SDKs (Android, iOS). Use when downloading/deploying remoteconfig JSON templates, managing version history/feature flags, setting in-app defaults, fetchAndActivate(), real-time listeners, or SDK setup. Don't use for Firebase Hosting, Auth, Firestore, Data Connect, Crashlytics, or App Hosting.
 compatibility: This skill is best used with the Firebase CLI, but does not require it. Firebase CLI can be accessed through `npx -y firebase-tools@latest`.
+metadata:
+  category: ApplicationDevelopment
 ---
 
 # Remote Config

--- a/skills/firebase-security-rules-auditor/SKILL.md
+++ b/skills/firebase-security-rules-auditor/SKILL.md
@@ -2,6 +2,8 @@
 name: firebase-security-rules-auditor
 description: >-
   Audits Firebase (Firestore, Cloud Storage) security rules for vulnerabilities, privilege escalation, role bypasses, create vs update inconsistencies, resource exhaustion, type safety, size limits, and hasOnly ownership checks. Use when auditing/reviewing rules, running red-team rule assessments, or scoring against auditor checklists. Don't use for Firebase CLI (login, deploy), Auth, Crashlytics, Remote Config, or database queries.
+metadata:
+  category: CloudSecurity
 ---
 
 # Overview

--- a/skills/xcode-project-setup/SKILL.md
+++ b/skills/xcode-project-setup/SKILL.md
@@ -2,6 +2,8 @@
 name: xcode-project-setup
 description: Safely modifies Xcode projects (.pbxproj) to add Swift Packages and link files. Use this skill whenever an iOS project needs dependencies installed (e.g. Firebase, Alamofire).
 compatibility: Requires Swift to be installed locally and macOS environment.
+metadata:
+  category: ApplicationDevelopment
 ---
 
 # Xcode Project Setup


### PR DESCRIPTION
This PR adds the metadata.category field to the frontmatter of all SKILL.md files in the repository. The categories are based on the standard list defined in readme_utils.py.