### PR TITLE
Add FirebaseUI Auth references to firebase-auth-basics

### DIFF
--- a/skills/firebase-auth-basics/SKILL.md
+++ b/skills/firebase-auth-basics/SKILL.md
@@ -113,7 +113,23 @@ Enable other providers in the Firebase Console.
 **Android (Kotlin)** See
 [references/client_sdk_android.md](references/client_sdk_android.md).
 
-### 3. Security Rules
+### 3. Drop-in Auth UI with FirebaseUI
+
+FirebaseUI provides pre-built sign-in screens on top of Firebase Auth, covering
+sign-in, sign-up, password reset, and account linking. Prefer it when the app
+needs a working auth flow quickly, and drop to the client SDKs above when the UI
+must be fully custom.
+
+**iOS (SwiftUI)** See
+[references/firebaseui_ios.md](references/firebaseui_ios.md).
+
+**Android (Compose)** See
+[references/firebaseui_android.md](references/firebaseui_android.md).
+
+**Web (React, Shadcn, Angular)** See
+[references/firebaseui_web.md](references/firebaseui_web.md).
+
+### 4. Security Rules
 
 Secure your data using `request.auth` in Firestore/Storage rules.
 

--- a/skills/firebase-auth-basics/SKILL.md
+++ b/skills/firebase-auth-basics/SKILL.md
@@ -105,11 +105,30 @@ Enable other providers in the Firebase Console.
 1. Select your project.
 1. Enable the desired Sign-in providers (e.g., Email/Password, Google).
 
-### 2. Client Setup & Usage
+### 2. Choose the Auth UI Approach
 
-Build auth UI yourself against the Auth SDK. Use these when the user asks for
-custom-designed screens, names their own UI framework or design system, or the
-app already has sign-in screens to wire up.
+> [!IMPORTANT] **For Agents:** For every request to add or build a sign-in,
+> sign-up, login, password-reset, or authentication flow, you MUST surface both
+> UI approaches and ask the user which they want before planning or changing
+> code:
+>
+> 1. **FirebaseUI** (recommended) — pre-built, maintained authentication screens
+>    and flows.
+> 1. **Direct Firebase Auth SDK integration** — for custom-designed screens, or
+>    to wire auth into screens the app already has.
+
+Briefly explain the tradeoffs when asking. Do not assume the user knows
+FirebaseUI exists. Do not pick direct SDK integration merely because the project
+uses Compose, SwiftUI, React, Angular, Flutter, or any other UI framework —
+FirebaseUI supports these.
+
+Skip the question only when the user has already chosen: they asked for
+FirebaseUI, asked for direct SDK integration or custom screens, or asked to wire
+Firebase Auth into existing screens.
+
+### 3. Direct Firebase Auth SDK Setup and Usage
+
+Build authentication UI directly against the Auth SDK.
 
 - **Web**: [references/client_sdk_web.md](references/client_sdk_web.md)
 - **iOS (Swift)**: [references/ios_setup.md](references/ios_setup.md)
@@ -117,11 +136,10 @@ app already has sign-in screens to wire up.
   [references/client_sdk_android.md](references/client_sdk_android.md)
 - **Flutter**: [references/flutter_setup.md](references/flutter_setup.md)
 
-### 3. Drop-in Auth UI with FirebaseUI
+### 4. Drop-in Auth UI with FirebaseUI
 
 FirebaseUI ships pre-built sign-in screens handling sign-in, sign-up, password
-reset, account linking, and MFA. Prefer it unless one of the section 2
-conditions applies.
+reset, account linking, and MFA.
 
 - **iOS (SwiftUI)**:
   [references/firebaseui_ios.md](references/firebaseui_ios.md)
@@ -133,10 +151,13 @@ conditions applies.
   [references/firebaseui_flutter.md](references/firebaseui_flutter.md)
 
 Each reference above is a pointer, not a guide: it routes to that library's own
-agent skill, or to its documentation where no skill exists. Load that source and
-follow it — do not implement from the reference or the library README.
+agent skill, or to its documentation where no skill exists.
 
-### 4. Security Rules
+Load and follow that source before planning or implementing the FirebaseUI flow.
+Do not implement from the pointer reference, from memory, or from a library
+README, which lags behind the library.
+
+### 5. Security Rules
 
 Secure your data using `request.auth` in Firestore/Storage rules.
 

--- a/skills/firebase-auth-basics/SKILL.md
+++ b/skills/firebase-auth-basics/SKILL.md
@@ -121,8 +121,7 @@ app already has sign-in screens to wire up.
 
 FirebaseUI ships pre-built sign-in screens handling sign-in, sign-up, password
 reset, account linking, and MFA. Prefer it unless one of the section 2
-conditions applies. There is no FirebaseUI for Flutter — Flutter apps use the
-client SDK above.
+conditions applies.
 
 - **iOS (SwiftUI)**:
   [references/firebaseui_ios.md](references/firebaseui_ios.md)
@@ -130,9 +129,11 @@ client SDK above.
   [references/firebaseui_android.md](references/firebaseui_android.md)
 - **Web (React, Shadcn, Angular)**:
   [references/firebaseui_web.md](references/firebaseui_web.md)
+- **Flutter**:
+  [references/firebaseui_flutter.md](references/firebaseui_flutter.md)
 
 Each reference above is a pointer, not a guide: it routes to that library's own
-agent skill, which is maintained alongside the library. Load that skill and
+agent skill, or to its documentation where no skill exists. Load that source and
 follow it — do not implement from the reference or the library README.
 
 ### 4. Security Rules

--- a/skills/firebase-auth-basics/SKILL.md
+++ b/skills/firebase-auth-basics/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: firebase-auth-basics
-description: Guide for setting up and using Firebase Authentication. Use this skill when the user's app requires user sign-in, user management, or secure data access using auth rules.
+description: Guide for setting up Firebase Authentication and FirebaseUI drop-in sign-in screens on Web, iOS, Android, and Flutter. Use when adding user sign-in, sign-up, password reset, social/OAuth providers, a login or auth UI, or user management to an app. Don't use for authoring Firestore or Storage security rules beyond `request.auth` checks.
 compatibility: This skill is best used with the Firebase CLI, but does not require it. Firebase CLI can be accessed through `npx -y firebase-tools@latest`.
 metadata:
   category: Identity
@@ -107,27 +107,33 @@ Enable other providers in the Firebase Console.
 
 ### 2. Client Setup & Usage
 
-**Web** See [references/client_sdk_web.md](references/client_sdk_web.md).
+Build auth UI yourself against the Auth SDK. Use these when the user asks for
+custom-designed screens, names their own UI framework or design system, or the
+app already has sign-in screens to wire up.
 
-**Flutter** See [references/flutter_setup.md](references/flutter_setup.md).
-**Android (Kotlin)** See
-[references/client_sdk_android.md](references/client_sdk_android.md).
+- **Web**: [references/client_sdk_web.md](references/client_sdk_web.md)
+- **iOS (Swift)**: [references/ios_setup.md](references/ios_setup.md)
+- **Android (Kotlin)**:
+  [references/client_sdk_android.md](references/client_sdk_android.md)
+- **Flutter**: [references/flutter_setup.md](references/flutter_setup.md)
 
 ### 3. Drop-in Auth UI with FirebaseUI
 
-FirebaseUI provides pre-built sign-in screens on top of Firebase Auth, covering
-sign-in, sign-up, password reset, and account linking. Prefer it when the app
-needs a working auth flow quickly, and drop to the client SDKs above when the UI
-must be fully custom.
+FirebaseUI ships pre-built sign-in screens handling sign-in, sign-up, password
+reset, account linking, and MFA. Prefer it unless one of the section 2
+conditions applies. There is no FirebaseUI for Flutter — Flutter apps use the
+client SDK above.
 
-**iOS (SwiftUI)** See
-[references/firebaseui_ios.md](references/firebaseui_ios.md).
+- **iOS (SwiftUI)**:
+  [references/firebaseui_ios.md](references/firebaseui_ios.md)
+- **Android (Compose)**:
+  [references/firebaseui_android.md](references/firebaseui_android.md)
+- **Web (React, Shadcn, Angular)**:
+  [references/firebaseui_web.md](references/firebaseui_web.md)
 
-**Android (Compose)** See
-[references/firebaseui_android.md](references/firebaseui_android.md).
-
-**Web (React, Shadcn, Angular)** See
-[references/firebaseui_web.md](references/firebaseui_web.md).
+Each reference above is a pointer, not a guide: it routes to that library's own
+agent skill, which is maintained alongside the library. Load that skill and
+follow it — do not implement from the reference or the library README.
 
 ### 4. Security Rules
 

--- a/skills/firebase-auth-basics/SKILL.md
+++ b/skills/firebase-auth-basics/SKILL.md
@@ -119,8 +119,8 @@ Enable other providers in the Firebase Console.
 
 Briefly explain the tradeoffs when asking. Do not assume the user knows
 FirebaseUI exists. Do not pick direct SDK integration merely because the project
-uses Compose, SwiftUI, React, Angular, Flutter, or any other UI framework —
-FirebaseUI supports these.
+uses Compose, SwiftUI, React, Angular, Flutter, or another framework supported
+by that platform's FirebaseUI library.
 
 Skip the question only when the user has already chosen: they asked for
 FirebaseUI, asked for direct SDK integration or custom screens, or asked to wire

--- a/skills/firebase-auth-basics/references/firebaseui_android.md
+++ b/skills/firebase-auth-basics/references/firebaseui_android.md
@@ -1,0 +1,100 @@
+# FirebaseUI Auth for Android (Compose)
+
+FirebaseUI Auth is a Compose-based library of drop-in authentication screens
+built on Firebase Auth and Material Design 3. Use it when the app needs a
+working sign-in flow quickly; use [client SDK setup](client_sdk_android.md)
+directly when the UI must be fully custom.
+
+Requires Android SDK 21+, Kotlin 1.9+, Compose compiler 1.5+, and Firebase Auth
+22.0.0+.
+
+Canonical docs:
+https://github.com/firebase/FirebaseUI-Android/blob/master/auth/README.md
+
+## 1. Add Dependencies
+
+In the module `build.gradle.kts`:
+
+```kotlin
+dependencies {
+    implementation("com.firebaseui:firebase-ui-auth:10.0.0-beta03")
+
+    implementation(platform("com.google.firebase:firebase-bom:32.7.0"))
+    implementation("com.google.firebase:firebase-auth")
+
+    implementation(platform("androidx.compose:compose-bom:2024.01.00"))
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.material3:material3")
+
+    // Only if you use AuthProvider.Facebook()
+    implementation("com.facebook.android:facebook-login:16.3.0")
+}
+```
+
+Check the README for the current FirebaseUI version before pinning it.
+
+## 2. Configure Providers
+
+Google Sign-In needs no Android-specific code — the `google-services` Gradle
+plugin supplies the configuration, so just enable Google in the Firebase
+Console. Twitter, GitHub, Microsoft, Yahoo, and Apple are also Console-only.
+
+Facebook Login additionally needs `facebook_application_id`,
+`facebook_login_protocol_scheme`, and `facebook_client_token` in
+`res/values/strings.xml`.
+
+## 3. Show the Auth UI
+
+Declare providers with `authUIConfiguration { }` and render
+`FirebaseAuthScreen`. It handles sign-in, sign-up, password reset, display name
+collection, Credential Manager, and error display.
+
+```kotlin
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            MyAppTheme {
+                val configuration = authUIConfiguration {
+                    providers {
+                        provider(AuthProvider.Email())
+                        provider(AuthProvider.Google())
+                    }
+                }
+
+                FirebaseAuthScreen(
+                    configuration = configuration,
+                    onSignInSuccess = { result -> /* navigate to your app */ },
+                    onSignInFailure = { exception -> /* show an error */ },
+                    onSignInCancelled = { finish() },
+                )
+            }
+        }
+    }
+}
+```
+
+## 4. Observe Auth State
+
+`FirebaseAuthUI.getInstance()` is the entry point for auth state and account
+operations. Prefer the flow so the UI reacts to sign-out and token changes:
+
+```kotlin
+@Composable
+fun AuthGate() {
+    val authUI = remember { FirebaseAuthUI.getInstance() }
+    val authState by authUI.authStateFlow().collectAsState(initial = AuthState.Idle)
+
+    if (authState is AuthState.Success) {
+        MainAppScreen()
+    } else {
+        FirebaseAuthScreen(/* ... */)
+    }
+}
+```
+
+`authUI.isSignedIn()` is available for a one-off check outside composition.
+
+For theming, multi-factor auth, anonymous user upgrade, custom slot-based UI,
+and the low-level `AuthFlowController` API, see the README linked above.

--- a/skills/firebase-auth-basics/references/firebaseui_android.md
+++ b/skills/firebase-auth-basics/references/firebaseui_android.md
@@ -1,100 +1,18 @@
 # FirebaseUI Auth for Android (Compose)
 
-FirebaseUI Auth is a Compose-based library of drop-in authentication screens
-built on Firebase Auth and Material Design 3. Use it when the app needs a
-working sign-in flow quickly; use [client SDK setup](client_sdk_android.md)
-directly when the UI must be fully custom.
+FirebaseUI Auth provides `FirebaseAuthScreen`, a pre-built Compose sign-in flow
+on Material Design 3, handling sign-in, sign-up, password reset, Credential
+Manager, MFA, and error states.
 
-Requires Android SDK 21+, Kotlin 1.9+, Compose compiler 1.5+, and Firebase Auth
-22.0.0+.
+**Follow the library's own agent skill — do not work from this file or the
+README:**
+https://github.com/firebase/FirebaseUI-Android/blob/master/.agents/skills/firebaseui-android-getting-started/SKILL.md
 
-Canonical docs:
-https://github.com/firebase/FirebaseUI-Android/blob/master/auth/README.md
+It is maintained alongside the library and carries the current dependency
+versions, provider constructor requirements, theming, content slots, and
+gotchas. The
+[README](https://github.com/firebase/FirebaseUI-Android/blob/master/auth/README.md)
+is background reading and lags the library.
 
-## 1. Add Dependencies
-
-In the module `build.gradle.kts`:
-
-```kotlin
-dependencies {
-    implementation("com.firebaseui:firebase-ui-auth:10.0.0-beta03")
-
-    implementation(platform("com.google.firebase:firebase-bom:32.7.0"))
-    implementation("com.google.firebase:firebase-auth")
-
-    implementation(platform("androidx.compose:compose-bom:2024.01.00"))
-    implementation("androidx.compose.ui:ui")
-    implementation("androidx.compose.material3:material3")
-
-    // Only if you use AuthProvider.Facebook()
-    implementation("com.facebook.android:facebook-login:16.3.0")
-}
-```
-
-Check the README for the current FirebaseUI version before pinning it.
-
-## 2. Configure Providers
-
-Google Sign-In needs no Android-specific code — the `google-services` Gradle
-plugin supplies the configuration, so just enable Google in the Firebase
-Console. Twitter, GitHub, Microsoft, Yahoo, and Apple are also Console-only.
-
-Facebook Login additionally needs `facebook_application_id`,
-`facebook_login_protocol_scheme`, and `facebook_client_token` in
-`res/values/strings.xml`.
-
-## 3. Show the Auth UI
-
-Declare providers with `authUIConfiguration { }` and render
-`FirebaseAuthScreen`. It handles sign-in, sign-up, password reset, display name
-collection, Credential Manager, and error display.
-
-```kotlin
-class MainActivity : ComponentActivity() {
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-
-        setContent {
-            MyAppTheme {
-                val configuration = authUIConfiguration {
-                    providers {
-                        provider(AuthProvider.Email())
-                        provider(AuthProvider.Google())
-                    }
-                }
-
-                FirebaseAuthScreen(
-                    configuration = configuration,
-                    onSignInSuccess = { result -> /* navigate to your app */ },
-                    onSignInFailure = { exception -> /* show an error */ },
-                    onSignInCancelled = { finish() },
-                )
-            }
-        }
-    }
-}
-```
-
-## 4. Observe Auth State
-
-`FirebaseAuthUI.getInstance()` is the entry point for auth state and account
-operations. Prefer the flow so the UI reacts to sign-out and token changes:
-
-```kotlin
-@Composable
-fun AuthGate() {
-    val authUI = remember { FirebaseAuthUI.getInstance() }
-    val authState by authUI.authStateFlow().collectAsState(initial = AuthState.Idle)
-
-    if (authState is AuthState.Success) {
-        MainAppScreen()
-    } else {
-        FirebaseAuthScreen(/* ... */)
-    }
-}
-```
-
-`authUI.isSignedIn()` is available for a one-off check outside composition.
-
-For theming, multi-factor auth, anonymous user upgrade, custom slot-based UI,
-and the low-level `AuthFlowController` API, see the README linked above.
+For hand-built auth UI on the Auth SDK instead, see
+[client_sdk_android.md](client_sdk_android.md).

--- a/skills/firebase-auth-basics/references/firebaseui_flutter.md
+++ b/skills/firebase-auth-basics/references/firebaseui_flutter.md
@@ -1,0 +1,17 @@
+# FirebaseUI Auth for Flutter
+
+FirebaseUI for Flutter provides pre-built auth screens and widgets via the
+`firebase_ui_auth` package, with per-provider packages for OAuth
+(`firebase_ui_oauth_google`, `firebase_ui_oauth_apple`,
+`firebase_ui_oauth_facebook`, `firebase_ui_oauth_twitter`).
+
+**Follow the library's own documentation — do not work from this file:**
+https://github.com/firebase/FirebaseUI-Flutter/tree/main/docs/firebase-ui-auth
+
+Unlike the iOS, Android, and Web libraries, this repo does not ship an agent
+skill, so those docs are the authoritative source. They cover setup, navigation,
+theming, migration, and per-provider guides for email, email link, email
+verification, phone, and OAuth.
+
+For hand-built auth UI on the Auth SDK instead, see
+[flutter_setup.md](flutter_setup.md).

--- a/skills/firebase-auth-basics/references/firebaseui_ios.md
+++ b/skills/firebase-auth-basics/references/firebaseui_ios.md
@@ -1,0 +1,92 @@
+# FirebaseUI Auth for iOS (SwiftUI)
+
+FirebaseUI provides drop-in SwiftUI views for the whole sign-in flow, so you
+don't hand-build sign-in screens on top of the `FirebaseAuth` SDK. Use it when
+the app needs a working auth UI quickly; use [client SDK setup](ios_setup.md)
+directly when the UI must be fully custom.
+
+Requires iOS 17+ and Swift 6.0+.
+
+Canonical docs:
+https://github.com/firebase/FirebaseUI-iOS/blob/main/FirebaseSwiftUI/README.md
+
+## 1. Add the Package
+
+In Xcode, **File > Add Package Dependencies...** and enter the package URL
+`https://github.com/firebase/FirebaseUI-iOS`, then pick the products you need:
+
+- `FirebaseAuthSwiftUI` (required, includes the email provider)
+- `FirebaseGoogleSwiftUI`, `FirebaseAppleSwiftUI`, `FirebaseFacebookSwiftUI`,
+  `FirebaseTwitterSwiftUI`, `FirebasePhoneAuthSwiftUI`
+- `FirebaseOAuthSwiftUI` for generic OAuth providers (GitHub, Microsoft, Yahoo)
+
+## 2. Configure Firebase
+
+`FirebaseApp.configure()` must run before any FirebaseUI view is created.
+
+```swift
+import FirebaseAuthSwiftUI
+import FirebaseCore
+import SwiftUI
+
+class AppDelegate: NSObject, UIApplicationDelegate {
+  func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+  ) -> Bool {
+    FirebaseApp.configure()
+    return true
+  }
+}
+
+@main
+struct YourApp: App {
+  @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+
+  var body: some Scene {
+    WindowGroup {
+      ContentView()
+    }
+  }
+}
+```
+
+## 3. Show the Auth UI
+
+Build an `AuthService`, register providers on it, and wrap your authenticated
+content in `AuthPickerView`. `AuthPickerView` renders the sign-in flow while the
+user is unauthenticated and your content once they are signed in.
+
+```swift
+import FirebaseAuthSwiftUI
+import FirebaseGoogleSwiftUI
+import SwiftUI
+
+struct ContentView: View {
+  let authService: AuthService
+
+  init() {
+    let configuration = AuthConfiguration()
+
+    authService = AuthService(configuration: configuration)
+      .withEmailSignIn()
+      .withGoogleSignIn()
+  }
+
+  var body: some View {
+    AuthPickerView {
+      Text("Welcome to your app!")
+    }
+    .environment(authService)
+  }
+}
+```
+
+Read `authService.authenticationState` to branch on auth state, and set
+`authService.isPresented = true` to present the flow manually.
+
+`AuthConfiguration` also accepts `shouldAutoUpgradeAnonymousUsers`, `tosUrl`,
+`privacyPolicyUrl`, `emailLinkSignInActionCodeSettings`, and `mfaEnabled`.
+
+For custom buttons, custom navigation, reauthentication, and the full
+`AuthService` API, see the README linked above.

--- a/skills/firebase-auth-basics/references/firebaseui_ios.md
+++ b/skills/firebase-auth-basics/references/firebaseui_ios.md
@@ -1,92 +1,18 @@
 # FirebaseUI Auth for iOS (SwiftUI)
 
-FirebaseUI provides drop-in SwiftUI views for the whole sign-in flow, so you
-don't hand-build sign-in screens on top of the `FirebaseAuth` SDK. Use it when
-the app needs a working auth UI quickly; use [client SDK setup](ios_setup.md)
-directly when the UI must be fully custom.
+FirebaseUI for SwiftUI provides `AuthPickerView`, a pre-built sign-in flow
+handling sign-in, sign-up, password reset, account linking, MFA, and
+reauthentication. Requires iOS 17+ and Swift 6.0+.
 
-Requires iOS 17+ and Swift 6.0+.
+**Follow the library's own agent skill — do not work from this file or the
+README:**
+https://github.com/firebase/FirebaseUI-iOS/blob/main/.agents/skills/firebaseui-ios-getting-started/SKILL.md
 
-Canonical docs:
-https://github.com/firebase/FirebaseUI-iOS/blob/main/FirebaseSwiftUI/README.md
+It is maintained alongside the library and carries the current SPM products,
+initialisation pattern, per-provider setup, gotchas, and validation checklist.
+The
+[README](https://github.com/firebase/FirebaseUI-iOS/blob/main/FirebaseSwiftUI/README.md)
+is background reading and lags the library.
 
-## 1. Add the Package
-
-In Xcode, **File > Add Package Dependencies...** and enter the package URL
-`https://github.com/firebase/FirebaseUI-iOS`, then pick the products you need:
-
-- `FirebaseAuthSwiftUI` (required, includes the email provider)
-- `FirebaseGoogleSwiftUI`, `FirebaseAppleSwiftUI`, `FirebaseFacebookSwiftUI`,
-  `FirebaseTwitterSwiftUI`, `FirebasePhoneAuthSwiftUI`
-- `FirebaseOAuthSwiftUI` for generic OAuth providers (GitHub, Microsoft, Yahoo)
-
-## 2. Configure Firebase
-
-`FirebaseApp.configure()` must run before any FirebaseUI view is created.
-
-```swift
-import FirebaseAuthSwiftUI
-import FirebaseCore
-import SwiftUI
-
-class AppDelegate: NSObject, UIApplicationDelegate {
-  func application(
-    _ application: UIApplication,
-    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
-  ) -> Bool {
-    FirebaseApp.configure()
-    return true
-  }
-}
-
-@main
-struct YourApp: App {
-  @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
-
-  var body: some Scene {
-    WindowGroup {
-      ContentView()
-    }
-  }
-}
-```
-
-## 3. Show the Auth UI
-
-Build an `AuthService`, register providers on it, and wrap your authenticated
-content in `AuthPickerView`. `AuthPickerView` renders the sign-in flow while the
-user is unauthenticated and your content once they are signed in.
-
-```swift
-import FirebaseAuthSwiftUI
-import FirebaseGoogleSwiftUI
-import SwiftUI
-
-struct ContentView: View {
-  let authService: AuthService
-
-  init() {
-    let configuration = AuthConfiguration()
-
-    authService = AuthService(configuration: configuration)
-      .withEmailSignIn()
-      .withGoogleSignIn()
-  }
-
-  var body: some View {
-    AuthPickerView {
-      Text("Welcome to your app!")
-    }
-    .environment(authService)
-  }
-}
-```
-
-Read `authService.authenticationState` to branch on auth state, and set
-`authService.isPresented = true` to present the flow manually.
-
-`AuthConfiguration` also accepts `shouldAutoUpgradeAnonymousUsers`, `tosUrl`,
-`privacyPolicyUrl`, `emailLinkSignInActionCodeSettings`, and `mfaEnabled`.
-
-For custom buttons, custom navigation, reauthentication, and the full
-`AuthService` API, see the README linked above.
+For hand-built auth UI on the Auth SDK instead, see
+[ios_setup.md](ios_setup.md).

--- a/skills/firebase-auth-basics/references/firebaseui_web.md
+++ b/skills/firebase-auth-basics/references/firebaseui_web.md
@@ -1,0 +1,91 @@
+# FirebaseUI Auth for Web
+
+FirebaseUI for Web (v7) provides composable authentication components for React,
+Shadcn, and Angular, plus a framework-agnostic core package if you want to bring
+your own UI. Use it when the app needs a working sign-in flow quickly; use
+[client SDK setup](client_sdk_web.md) directly when the UI must be fully custom.
+
+v7 is a complete rewrite. v6 lives on the `v6-archive` branch and has a separate
+migration guide.
+
+Canonical docs: https://github.com/firebase/firebaseui-web/blob/main/README.md
+
+## 1. Install and Initialize
+
+Install `firebase` plus the package for your framework, then pass a configured
+Firebase App instance to `initializeUI`:
+
+```bash
+npm install firebase @firebase-oss/ui-react
+```
+
+```ts
+import { initializeApp } from 'firebase/app';
+import { initializeUI } from '@firebase-oss/ui-core';
+
+const app = initializeApp({ /* your Firebase config */ });
+
+const ui = initializeUI({ app });
+```
+
+Angular installs
+`@angular/fire @firebase-oss/ui-angular @firebase-oss/ui-core @firebase-oss/ui-styles`
+instead and requires AngularFire to be set up first. Shadcn pulls components
+from a registry rather than a package — see the README.
+
+## 2. Provide the UI Instance
+
+**React / Shadcn**: wrap the app in `FirebaseUIProvider`.
+
+```tsx
+import { FirebaseUIProvider } from '@firebase-oss/ui-react';
+
+function App() {
+  return <FirebaseUIProvider ui={ui}>{/* your app */}</FirebaseUIProvider>;
+}
+```
+
+**Angular**: add `provideFirebaseUI` alongside `provideFirebaseApp`.
+
+```ts
+import { provideFirebaseApp, initializeApp } from '@angular/fire/app';
+import { initializeUI } from '@firebase-oss/ui-core';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideFirebaseApp(() => initializeApp({ /* your Firebase config */ })),
+    provideFirebaseUI((apps) => initializeUI({ app: apps[0] })),
+  ],
+};
+```
+
+## 3. Import the Styles
+
+Required for React and Angular. Skip this for Shadcn — those components inherit
+your Shadcn configuration.
+
+```css
+@import "@firebase-oss/ui-styles/dist.min.css";
+/* Or, for Tailwind users */
+@import "@firebase-oss/ui-styles/tailwind";
+```
+
+If your bundler cannot import CSS from `node_modules`, the README covers the CDN
+option.
+
+## 4. Render a Screen
+
+```tsx
+import { SignInAuthScreen } from '@firebase-oss/ui-react';
+
+export function MySignInPage() {
+  return <SignInAuthScreen onSignIn={() => { /* redirect */ }} />;
+}
+```
+
+The Angular equivalent is
+`<fui-sign-in-auth-screen (signIn)="onSignIn($event)" />` from
+`SignInAuthScreenComponent`.
+
+For the full component list, theming, behaviors, translations, and the
+`FirebaseUIStore` core API, see the README linked above.

--- a/skills/firebase-auth-basics/references/firebaseui_web.md
+++ b/skills/firebase-auth-basics/references/firebaseui_web.md
@@ -1,91 +1,17 @@
 # FirebaseUI Auth for Web
 
 FirebaseUI for Web (v7) provides composable authentication components for React,
-Shadcn, and Angular, plus a framework-agnostic core package if you want to bring
-your own UI. Use it when the app needs a working sign-in flow quickly; use
-[client SDK setup](client_sdk_web.md) directly when the UI must be fully custom.
+Shadcn, and Angular, plus a framework-agnostic core package for custom UI. Any
+other stack should use the client SDK directly.
 
-v7 is a complete rewrite. v6 lives on the `v6-archive` branch and has a separate
-migration guide.
+**Follow the library's own agent skill — do not work from this file or the
+README:**
+https://github.com/firebase/firebaseui-web/blob/main/.agents/skills/firebaseui-web-getting-started/SKILL.md
 
-Canonical docs: https://github.com/firebase/firebaseui-web/blob/main/README.md
+It is maintained alongside the library and carries the current packages,
+per-framework wiring, styling, available screens, and gotchas. The
+[README](https://github.com/firebase/firebaseui-web/blob/main/README.md) is
+background reading and lags the library.
 
-## 1. Install and Initialize
-
-Install `firebase` plus the package for your framework, then pass a configured
-Firebase App instance to `initializeUI`:
-
-```bash
-npm install firebase @firebase-oss/ui-react
-```
-
-```ts
-import { initializeApp } from 'firebase/app';
-import { initializeUI } from '@firebase-oss/ui-core';
-
-const app = initializeApp({ /* your Firebase config */ });
-
-const ui = initializeUI({ app });
-```
-
-Angular installs
-`@angular/fire @firebase-oss/ui-angular @firebase-oss/ui-core @firebase-oss/ui-styles`
-instead and requires AngularFire to be set up first. Shadcn pulls components
-from a registry rather than a package — see the README.
-
-## 2. Provide the UI Instance
-
-**React / Shadcn**: wrap the app in `FirebaseUIProvider`.
-
-```tsx
-import { FirebaseUIProvider } from '@firebase-oss/ui-react';
-
-function App() {
-  return <FirebaseUIProvider ui={ui}>{/* your app */}</FirebaseUIProvider>;
-}
-```
-
-**Angular**: add `provideFirebaseUI` alongside `provideFirebaseApp`.
-
-```ts
-import { provideFirebaseApp, initializeApp } from '@angular/fire/app';
-import { initializeUI } from '@firebase-oss/ui-core';
-
-export const appConfig: ApplicationConfig = {
-  providers: [
-    provideFirebaseApp(() => initializeApp({ /* your Firebase config */ })),
-    provideFirebaseUI((apps) => initializeUI({ app: apps[0] })),
-  ],
-};
-```
-
-## 3. Import the Styles
-
-Required for React and Angular. Skip this for Shadcn — those components inherit
-your Shadcn configuration.
-
-```css
-@import "@firebase-oss/ui-styles/dist.min.css";
-/* Or, for Tailwind users */
-@import "@firebase-oss/ui-styles/tailwind";
-```
-
-If your bundler cannot import CSS from `node_modules`, the README covers the CDN
-option.
-
-## 4. Render a Screen
-
-```tsx
-import { SignInAuthScreen } from '@firebase-oss/ui-react';
-
-export function MySignInPage() {
-  return <SignInAuthScreen onSignIn={() => { /* redirect */ }} />;
-}
-```
-
-The Angular equivalent is
-`<fui-sign-in-auth-screen (signIn)="onSignIn($event)" />` from
-`SignInAuthScreenComponent`.
-
-For the full component list, theming, behaviors, translations, and the
-`FirebaseUIStore` core API, see the README linked above.
+For hand-built auth UI on the Auth SDK instead, see
+[client_sdk_web.md](client_sdk_web.md).


### PR DESCRIPTION
Adds FirebaseUI Auth references for iOS, Android, Web, and Flutter under skills/firebase-auth-basics/references. Each file is a pointer rather than a guide: it states what FirebaseUI provides on that platform, when to prefer it over building directly on the Auth SDK, and routes to that library's own agent skill. No setup code, dependency versions, or API usage is duplicated here, so these references cannot drift as the libraries change.

FirebaseUI-Flutter is the exception: it ships no agent skill, so that reference points at docs/firebase-ui-auth in the repo, which is the authoritative source there.

SKILL.md gains a "Drop-in Auth UI with FirebaseUI" section linking the four, and section 2 is reworked into the same bullet form with a decision rule for choosing between the two paths. Section 2 previously had no iOS entry, which left references/ios_setup.md unreachable from SKILL.md; it is now linked.

The frontmatter description is updated to cover FirebaseUI and drop-in sign-in screens across all four platforms, and to exclude security-rules authoring, which firebase-security-rules-auditor owns.