### PR TITLE
feat: add HOL Guard Firebase agent safety skill

### DIFF
--- a/skills/firebase-hol-guard/SKILL.md
+++ b/skills/firebase-hol-guard/SKILL.md
@@ -63,14 +63,15 @@ If Guard blocks or queues work, inspect the request before proceeding:
 
 ```bash
 hol-guard approvals
-hol-guard approvals open
+hol-guard approvals open <request-id>
 hol-guard receipts
 hol-guard diff <harness>
 ```
 
-Only approve after reviewing the risk reason and requested scope. Never bypass
-Guard by launching an unprotected copy of the agent or editing around
-Guard-owned hooks.
+Pass the pending approval request ID to `hol-guard approvals open` so the CLI
+opens the specific queued request. Only approve after reviewing the risk reason
+and requested scope. Never bypass Guard by launching an unprotected copy of the
+agent or editing around Guard-owned hooks.
 
 ## Diagnose protection
 

--- a/skills/firebase-hol-guard/SKILL.md
+++ b/skills/firebase-hol-guard/SKILL.md
@@ -28,17 +28,20 @@ hol-guard status
 hol-guard detect --json
 ```
 
-For the harness that will perform Firebase work, install Guard, then verify a
-protected launch before making project changes:
+Initialize Guard-managed local state, then install Guard for the exact harness
+reported by `hol-guard detect` and verify a protected launch before making
+project changes:
 
 ```bash
+hol-guard bootstrap
 hol-guard install <harness>
 hol-guard run <harness> --dry-run
 hol-guard run <harness>
 hol-guard status
 ```
 
-Use the exact harness identifier reported by `hol-guard detect`; do not infer or
+`hol-guard bootstrap` is part of HOL Guard's maintained setup flow. Use the
+exact harness identifier reported by `hol-guard detect`; do not infer or
 substitute a product name. Do not claim a workspace is protected until Guard
 reports the harness setup successfully.
 

--- a/skills/firebase-hol-guard/SKILL.md
+++ b/skills/firebase-hol-guard/SKILL.md
@@ -28,20 +28,18 @@ hol-guard status
 hol-guard detect --json
 ```
 
-For the harness that will perform Firebase work, bootstrap and install Guard,
-then verify a protected launch before making project changes:
+For the harness that will perform Firebase work, install Guard, then verify a
+protected launch before making project changes:
 
 ```bash
-hol-guard bootstrap
 hol-guard install <harness>
 hol-guard run <harness> --dry-run
 hol-guard run <harness>
 hol-guard status
 ```
 
-Use the harness identifier reported by `hol-guard detect`. Supported harnesses
-include Codex, Claude Code, Copilot CLI, Cursor, Gemini, Hermes, OpenClaw,
-OpenCode, and Antigravity. Do not claim a workspace is protected until Guard
+Use the exact harness identifier reported by `hol-guard detect`; do not infer or
+substitute a product name. Do not claim a workspace is protected until Guard
 reports the harness setup successfully.
 
 ## Use with Firebase Agent Skills

--- a/skills/firebase-hol-guard/SKILL.md
+++ b/skills/firebase-hol-guard/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: firebase-hol-guard
+description: >-
+  Protect local AI coding-agent sessions before Firebase CLI, MCP, and Agent
+  Skills workflows with HOL Guard. Use when an agent can run commands or mutate
+  a Firebase project and you want Guard-owned harness protection and evidence.
+---
+
+# Protect Firebase agent workflows with HOL Guard
+
+Use HOL Guard at the local coding-agent boundary before starting Firebase work.
+It protects supported local agent harnesses before their tools run. It does not
+run inside Firebase services and does not replace Firebase Authentication,
+Security Rules, App Check, IAM, emulator validation, or normal change review.
+
+## Set up protection
+
+Install HOL Guard in an isolated Python application environment:
+
+```bash
+pipx install hol-guard
+```
+
+Check the machine and discover supported local harnesses:
+
+```bash
+hol-guard status
+hol-guard detect --json
+```
+
+For the harness that will perform Firebase work, bootstrap and install Guard,
+then verify a protected launch before making project changes:
+
+```bash
+hol-guard bootstrap
+hol-guard install <harness>
+hol-guard run <harness> --dry-run
+hol-guard run <harness>
+hol-guard status
+```
+
+Use the harness identifier reported by `hol-guard detect`. Supported harnesses
+include Codex, Claude Code, Copilot CLI, Cursor, Gemini, Hermes, OpenClaw,
+OpenCode, and Antigravity. Do not claim a workspace is protected until Guard
+reports the harness setup successfully.
+
+## Use with Firebase Agent Skills
+
+Start the coding agent through `hol-guard run <harness>` first. From that
+protected session, use the Firebase skills and their documented Firebase CLI or
+MCP workflows normally. Keep Firebase's own safety instructions in force,
+including project-selection checks, user confirmation where a skill requires
+it, Security Rules review, and emulator or preview steps.
+
+HOL Guard owns the local harness protection boundary. This skill does not claim
+that every Firebase CLI subcommand has a dedicated Guard classifier or that
+Guard intercepts hosted Firebase services directly.
+
+## Handle Guard decisions
+
+If Guard blocks or queues work, inspect the request before proceeding:
+
+```bash
+hol-guard approvals
+hol-guard approvals open
+hol-guard receipts
+hol-guard diff <harness>
+```
+
+Only approve after reviewing the risk reason and requested scope. Never bypass
+Guard by launching an unprotected copy of the agent or editing around
+Guard-owned hooks.
+
+## Diagnose protection
+
+If the harness does not appear protected, stop mutating Firebase resources and
+inspect the setup:
+
+```bash
+hol-guard doctor
+hol-guard doctor <harness> --json
+hol-guard detect --json
+hol-guard settings show
+```
+
+Resume Firebase mutations only after Guard output proves the local harness is
+protected, or continue without claiming HOL Guard protection.


### PR DESCRIPTION
## Summary

Adds a focused `firebase-hol-guard` Agent Skill to the official Firebase skills distribution.

The skill directly installs and invokes HOL Guard on a supported local coding-agent harness before the agent starts Firebase work:

- `pipx install hol-guard`
- `hol-guard detect --json`
- `hol-guard install <harness>`
- `hol-guard run <harness>`
- Guard approvals, receipts, diff, status, and doctor flows for blocked or uncertain work

The scope is deliberately narrow. HOL Guard protects the local coding-agent harness; this skill does not claim that HOL Guard runs inside Firebase services, replaces Firebase Authentication / Security Rules / App Check / IAM, or has dedicated classifiers for every Firebase CLI subcommand.

## Contribution shape

`CONTRIBUTING.md` currently directs new skills to the `next` branch, so this PR targets `next`. The accepted security-skill precedent in #63 was also a single `SKILL.md`; this follows that minimal shape and relies on the repository's existing plugin/skills distribution rather than adding duplicate manifests.

## Validation

- Exact upstream `HOL Guard` issue/PR/code dedupe was clean immediately before opening this PR.
- Harness commands were checked against the maintained HOL Guard Agent Skill, including supported harness names and the `install`, `run`, `doctor`, approvals, receipts, and status flows.
- I have not run Firebase's separate cross-repository agent-eval pipeline in this environment, so this PR does not claim that evaluation as passed.
